### PR TITLE
Feature/settgast/install all headers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,9 +97,7 @@ install(
   FILES ${PROJECT_BINARY_DIR}/share/chai/cmake/chai-config.cmake
   DESTINATION share/chai/cmake/)
 
-install(
-  FILES ${PROJECT_BINARY_DIR}/include/chai/config.hpp
-  DESTINATION include/chai)
+install(DIRECTORY ${PROJECT_BINARY_DIR}/include DESTINATION . OPTIONAL)
 
 install(
   TARGETS chai
@@ -109,6 +107,7 @@ install(
   ARCHIVE DESTINATION lib)
 
 install(EXPORT chai-targets DESTINATION share/chai/cmake/)
+
 
 add_subdirectory(tests)
 if (ENABLE_BENCHMARKS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,7 +97,7 @@ install(
   FILES ${PROJECT_BINARY_DIR}/share/chai/cmake/chai-config.cmake
   DESTINATION share/chai/cmake/)
 
-install(DIRECTORY ${PROJECT_BINARY_DIR}/include DESTINATION . OPTIONAL)
+install(DIRECTORY ${PROJECT_BINARY_DIR}/include DESTINATION .)
 
 install(
   TARGETS chai
@@ -107,7 +107,6 @@ install(
   ARCHIVE DESTINATION lib)
 
 install(EXPORT chai-targets DESTINATION share/chai/cmake/)
-
 
 add_subdirectory(tests)
 if (ENABLE_BENCHMARKS)


### PR DESCRIPTION
The CHAI installation did not contain the CHAI headers. 

`install(DIRECTORY ${PROJECT_BINARY_DIR}/include DESTINATION . OPTIONAL)`

was added to copy the entire include directory from the build directory to the install directory
