### PR TITLE
Added install command to install CHAI headers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,6 +91,8 @@ blt_add_library(
   HEADERS_OUTPUT_SUBDIR chai
   DEPENDS_ON ${chai_depends})
 
+install(FILES ${chai_headers} DESTINATION include/chai/)
+
 install(FILES util/forall.hpp DESTINATION include/chai/util/)
 
 target_include_directories(


### PR DESCRIPTION
The CHAI headers were'nt being installed to the install path.  This isn't noticed if you are using CHAI as a submodule, but is a problem as an installed library.