### PR TITLE
Fixed operator[] in ManagedArray to take generic index type.  

### DIFF
--- a/src/ManagedArray.hpp
+++ b/src/ManagedArray.hpp
@@ -162,7 +162,8 @@ class ManagedArray {
    *
    * \return Reference to i-th element.
    */
-  CHAI_HOST_DEVICE T& operator[](const int i) const;
+	template<typename Idx>
+  CHAI_HOST_DEVICE T& operator[](const Idx i) const;
 
   /*!
    * \brief Set val to the value of element i in the ManagedArray.

--- a/src/ManagedArray.inl
+++ b/src/ManagedArray.inl
@@ -168,8 +168,9 @@ CHAI_HOST void ManagedArray<T>::registerTouch(ExecutionSpace space) {
 }
 
 template<typename T>
+template<typename Idx>
 CHAI_INLINE
-CHAI_HOST_DEVICE T& ManagedArray<T>::operator[](const int i) const {
+CHAI_HOST_DEVICE T& ManagedArray<T>::operator[](const Idx i) const {
   return m_active_pointer[i];
 }
 


### PR DESCRIPTION
This avoids unnecessary type conversion, and possible performance loss