### PR TITLE
Add support for shared BLT outside of the repository

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,15 +75,25 @@ set(BLT_CXX_STD c++11 CACHE STRING "")
 ################################
 # BLT
 ################################
-if (NOT EXISTS ${PROJECT_SOURCE_DIR}/blt/SetupBLT.cmake)
-  message(FATAL_ERROR "\
-  The BLT submodule is not present. \
-  If in git repository run the following two commands:\n \
-  git submodule init\n \
-  git submodule update")
+if (DEFINED BLT_SOURCE_DIR)
+  # Support having a shared BLT outside of the repository if given a BLT_SOURCE_DIR
+
+  if (NOT EXISTS ${BLT_SOURCE_DIR}/SetupBLT.cmake)
+    message(FATAL_ERROR "Given BLT_SOURCE_DIR does not contain SetupBLT.cmake")
+  endif()
+else()
+  # Use internal BLT if no BLT_SOURCE_DIR is given
+  set(BLT_SOURCE_DIR "${PROJECT_SOURCE_DIR}/blt" CACHE PATH "")
+  if (NOT EXISTS ${BLT_SOURCE_DIR}/SetupBLT.cmake)
+    message(FATAL_ERROR "\
+    The BLT submodule is not present. \
+    If in git repository run the following two commands:\n \
+    git submodule init\n \
+    git submodule update")
+  endif()
 endif()
 
-include(blt/SetupBLT.cmake)
+include(${BLT_SOURCE_DIR}/SetupBLT.cmake)
 
 include(cmake/ChaiBasics.cmake)
 


### PR DESCRIPTION
Add support for shared BLT directory outside of the repository.
If BLT_SOURCE_DIR is set, then that directory will be used for BLT, otherwise, the internal one will be used.