### PR TITLE
Feature/dayton8/managed ptr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+*.swp

--- a/src/chai/CMakeLists.txt
+++ b/src/chai/CMakeLists.txt
@@ -58,6 +58,7 @@ set (chai_headers
   ExecutionSpaces.hpp
   ManagedArray.hpp
   ManagedArray.inl
+  managed_ptr.hpp
   PointerRecord.hpp
   Types.hpp)
 

--- a/src/chai/managed_ptr.hpp
+++ b/src/chai/managed_ptr.hpp
@@ -1,0 +1,258 @@
+#ifndef MANAGED_PTR_H_
+#define MANAGED_PTR_H_
+
+#include "chai/ChaiMacros.hpp"
+#include "chai/ManagedArray.hpp"
+
+#include "../util/forall.hpp"
+
+namespace chai {
+   ///
+   /// @class managed_ptr<T>
+   /// @author Alan Dayton
+   /// This wrapper calls new on both the GPU and CPU so that polymorphism can
+   ///    be used on the GPU. It is modeled after std::shared_ptr, so it does
+   ///    reference counting and automatically cleans up when the last reference
+   ///    is destroyed. If we ever do multi-threading on the CPU, locking will
+   ///    need to be added to the reference counter.
+   /// Requirements:
+   ///    The actual type created (D in the first constructor) must be copy
+   ///       constructible and the copy constructor must call the base class
+   ///       copy constructors to avoid slicing. The default constructor has
+   ///       the correct behavior, but only if the whole inheritance chain uses
+   ///       the default copy constructor. Otherwise, at whatever point the
+   ///       default is no longer used, the the base class copy constructors
+   ///       must be called to avoid copy slicing. If the copy constructors are
+   ///       private, this class must be declared as a friend.
+   ///    The actual type created (D in the first constructor) must be convertible
+   ///       to T (e.g. T is a base class of D).
+   ///    This wrapper does NOT automatically sync the GPU copy if the CPU copy is
+   ///       updated and vice versa. The one exception to this is that if the class
+   ///       has chai::ManagedArray members or members that inherit chai::ManagedArray,
+   ///       these will be kept in sync (hence the need for D to be copy constructible).
+   ///       HOWEVER, the chai::ManagedArray members must be initialized upon object
+   ///       construction. Otherwise, if you wish to keep the CPU and GPU copies in sync,
+   ///       you must explicitly call the same modifying function in the CPU context and
+   ///       in the GPU context.
+   ///    Do NOT pass the base pointer type to the constructor. Always pass the derived
+   ///       type.
+   ///    Pointer types members of T must be chai::ManagedArrays or managed_ptrs to be
+   ///       accessible on the GPU. The same requirements apply to inner managed_ptrs.
+   ///       Requirements for using chai::ManagedArrays in the proper context still apply.
+   ///    Methods that can be called on the CPU and GPU must be declared with the
+   ///       __host__ __device__ specifiers. This includes the constructors (including
+   ///       copy constructors) and destructors.
+   ///    Raw pointer members still can be used, but they will only be valid on the host.
+   ///       To prevent accidentally using them in a device context, any methods that
+   ///       access raw pointers should be host only.
+   ///    Be especially careful of passing raw pointers to member functions.
+   template <typename T>
+   class managed_ptr {
+      public:
+         using element_type = T;
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Constructs a managed_ptr from the given pointer.
+         /// Takes the given host pointer and creates a copy of the object on the GPU.
+         ///
+         /// @param[in] cpuPtr The host pointer to take ownership of
+         ///
+         template <typename D>
+         explicit managed_ptr(D* ptr) : m_cpu(ptr), m_numReferences(new std::size_t{1}) {
+#ifdef __CUDACC__
+            createDevicePtr(*ptr);
+#endif
+
+            // Need to be able to access the copy constructor if T is a base pointer type
+            m_copyConstructor = [] (void* basePtr) {
+               D derivedCopy = *(static_cast<D*>(basePtr));
+               (void) derivedCopy;
+            };
+         }
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Copy constructor.
+         /// Constructs a copy of the given managed_ptr and increases the reference count.
+         ///    D must be convertible to T.
+         ///
+         /// @param[in] other The managed_ptr to copy.
+         ///
+         template <typename D>
+         managed_ptr(managed_ptr<D> const & other) :
+            m_cpu(other.m_cpu),
+#ifdef __CUDACC__
+            m_gpu(other.m_gpu),
+#endif
+            m_numReferences(other.m_numReferences),
+            m_copyConstructor(other.m_copyConstructor),
+            m_destructor(other.m_destructor) {
+#ifndef __CUDA_ARCH__
+               // Increment the number of references.
+               (*m_numReferences)++;
+
+               // Trigger copy constructor so that any ManagedArrays in the object
+               // are copied to the right data space.
+               m_copyConstructor(m_cpu);
+#endif
+         }
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Copy constructor.
+         /// Constructs a copy of the given managed_ptr and increases the reference count.
+         ///
+         /// @param[in] other The managed_ptr to copy.
+         ///
+         CHAI_HOST_DEVICE managed_ptr(const managed_ptr<T>& other) :
+            m_cpu(other.m_cpu),
+#ifdef __CUDACC__
+            m_gpu(other.m_gpu),
+#endif
+            m_numReferences(other.m_numReferences),
+            m_copyConstructor(other.m_copyConstructor),
+            m_destructor(other.m_destructor) {
+
+#ifndef __CUDA_ARCH__
+               // Increment the number of references.
+               (*m_numReferences)++;
+
+               // Trigger copy constructor so that any ManagedArrays in the object
+               // are copied to the right data space.
+               m_copyConstructor(m_cpu);
+#endif
+         }
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Destructor. Decreases the reference count and if this is the last reference,
+         ///    clean up.
+         ///
+         CHAI_HOST_DEVICE ~managed_ptr() {
+#ifndef __CUDA_ARCH__
+            (*m_numReferences)--;
+
+            if (m_numReferences && *m_numReferences == 0) {
+               delete m_numReferences;
+
+               m_destructor(m_cpu);
+
+#ifdef __CUDACC__
+               destroyDevicePtr();
+#endif
+            }
+#endif
+         }
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Returns the CPU or GPU pointer depending on the calling context.
+         ///
+         CHAI_HOST_DEVICE inline T* operator->() const {
+#ifndef __CUDA_ARCH__
+            return m_cpu;
+#else
+            return m_gpu;
+#endif
+         }
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Returns the CPU or GPU reference depending on the calling context.
+         ///
+         CHAI_HOST_DEVICE inline T& operator*() const {
+#ifndef __CUDA_ARCH__
+            return *m_cpu;
+#else
+            return *m_gpu;
+#endif
+         }
+
+#ifdef __CUDACC__
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Creates the device pointer.
+         /// Should be called only by the constructor, but extended __host__ __device__
+         ///    lambdas can only be in public methods.
+         ///
+         template <typename D>
+         void createDevicePtr(const D& obj) {
+            chai::ManagedArray<D*> temp(1, chai::GPU);
+
+            forall(cuda(), 0, 1, [=] __device__ (int i) {
+               temp[i] = new D(obj);
+            });
+
+            temp.move(chai::CPU);
+            m_gpu = temp[0];
+            temp.free();
+
+            // __host__ __device__ functions can't be created in constructor
+            // Need to be able to delete the original type if T is a base pointer type
+            m_destructor = [] CHAI_HOST_DEVICE (void* basePtr) {
+               delete static_cast<D*>(basePtr);
+            };
+         }
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Cleans up the device pointer.
+         /// Should be called only by the destructor, but extended __host__ __device__
+         ///    lambdas can only be in public methods.
+         ///
+         void destroyDevicePtr() {
+            chai::ManagedArray<T*> temp(1, chai::CPU);
+            temp[0] = m_gpu;
+
+            // Does not capture "this"
+            void (*destructor)(void*) = m_destructor;
+
+            forall(cuda(), 0, 1, [=] __device__ (int i) {
+               destructor(temp[i]);
+            });
+
+            temp.free();
+         }
+#endif
+
+      private:
+         T* m_cpu = nullptr; /// The host pointer
+
+#ifdef __CUDACC__
+         T* m_gpu = nullptr; /// The device pointer
+#endif
+
+         size_t* m_numReferences = nullptr; /// The reference counter
+
+         void (*m_copyConstructor)(void*); /// A function that casts to the derived type and calls the copy constructor so that chai::ManagedArrays are moved to the correct execution space.
+
+         void (*m_destructor)(void*); /// A function that casts to the derived type and calls delete on it.
+
+         template <class D> friend class managed_ptr; /// Needed for the converting constructor
+   };
+
+   ///
+   /// @author Alan Dayton
+   ///
+   /// Makes a managed_ptr<T>.
+   /// Factory function to create managed_ptrs.
+   ///
+   /// @params[in] args The arguments to T's constructor
+   ///
+   template <typename T, typename... Args>
+   managed_ptr<T> make_managed(Args&&... args) {
+      return managed_ptr<T>(new T(std::forward<Args>(args)...));
+   }
+} // namespace chai
+
+#endif // MANAGED_PTR
+

--- a/src/chai/managed_ptr.hpp
+++ b/src/chai/managed_ptr.hpp
@@ -130,7 +130,7 @@ namespace chai {
          /// @param[in] other The managed_ptr to copy.
          ///
          template <typename D>
-         CHAI_HOST_DEVICE managed_ptr(managed_ptr<D> const & other) :
+         CHAI_HOST_DEVICE managed_ptr(managed_ptr<D> const & other) noexcept :
             m_cpu(other.m_cpu),
 #ifdef __CUDACC__
             m_gpu(other.m_gpu),
@@ -170,6 +170,68 @@ namespace chai {
                }
             }
 #endif
+         }
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Copy assignment operator.
+         /// Copies the given managed_ptr and increases the reference count.
+         ///
+         /// @param[in] other The managed_ptr to copy.
+         ///
+         CHAI_HOST_DEVICE managed_ptr& operator=(const managed_ptr& other) noexcept {
+            if (this != &other) {
+               m_cpu = other.m_cpu;
+#ifdef __CUDACC__
+               m_gpu = other.m_gpu;
+#endif
+               m_numReferences = other.m_numReferences;
+               m_copyConstructor = other.m_copyConstructor;
+               m_destructor = other.m_destructor;
+
+#ifndef __CUDA_ARCH__
+               (*m_numReferences)++;
+
+               // Trigger copy constructor so that any ManagedArrays in the object
+               // are copied to the right data space.
+               m_copyConstructor(m_cpu);
+#endif
+            }
+
+            return *this;
+         }
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Conversion copy assignment operator.
+         /// Copies the given managed_ptr and increases the reference count.
+         ///    D must be convertible to T.
+         ///
+         /// @param[in] other The managed_ptr to copy.
+         ///
+         template<class D>
+         CHAI_HOST_DEVICE managed_ptr& operator=(const managed_ptr<D>& other) noexcept {
+            if (this != &other) {
+               m_cpu = other.m_cpu;
+#ifdef __CUDACC__
+               m_gpu = other.m_gpu;
+#endif
+               m_numReferences = other.m_numReferences;
+               m_copyConstructor = other.m_copyConstructor;
+               m_destructor = other.m_destructor;
+
+#ifndef __CUDA_ARCH__
+               (*m_numReferences)++;
+
+               // Trigger copy constructor so that any ManagedArrays in the object
+               // are copied to the right data space.
+               m_copyConstructor(m_cpu);
+#endif
+            }
+
+            return *this;
          }
 
          ///

--- a/src/chai/managed_ptr.hpp
+++ b/src/chai/managed_ptr.hpp
@@ -81,7 +81,14 @@ namespace chai {
          template <typename D>
          CHAI_HOST explicit managed_ptr(D* ptr) :
             m_cpu(ptr),
-            m_numReferences(new std::size_t{1}) {
+            m_numReferences(new std::size_t{1})
+         {
+            static_assert(std::is_base_of<T, D>::value ||
+                          std::is_convertible<D, T>::value,
+                          "Type D must a descendent of or be convertible to type T.");
+            static_assert(std::is_copy_constructible<D>::value,
+                          "Type D must be copy constructible.");
+
 #ifdef __CUDACC__
             createDevicePtr(*ptr);
 #endif
@@ -131,7 +138,14 @@ namespace chai {
 #endif
             m_numReferences(other.m_numReferences),
             m_copyConstructor(other.m_copyConstructor),
-            m_destructor(other.m_destructor) {
+            m_destructor(other.m_destructor)
+         {
+            static_assert(std::is_base_of<T, D>::value ||
+                          std::is_convertible<D, T>::value,
+                          "Type D must a descendent of or be convertible to type T.");
+            static_assert(std::is_copy_constructible<D>::value,
+                          "Type D must be copy constructible.");
+
 #ifndef __CUDA_ARCH__
                incrementReferenceCount();
 #endif
@@ -190,6 +204,12 @@ namespace chai {
          ///
          template<class D>
          CHAI_HOST_DEVICE managed_ptr& operator=(const managed_ptr<D>& other) noexcept {
+            static_assert(std::is_base_of<T, D>::value ||
+                          std::is_convertible<D, T>::value,
+                          "Type D must a descendent of or be convertible to type T.");
+            static_assert(std::is_copy_constructible<D>::value,
+                          "Type D must be copy constructible.");
+
 #ifndef __CUDA_ARCH__
             decrementReferenceCount();
 #endif
@@ -337,7 +357,8 @@ namespace chai {
 
          void (*m_destructor)(void*); /// A function that casts to the derived type and calls delete on it.
 
-         template <class D> friend class managed_ptr; /// Needed for the converting constructor
+         template <typename D>
+         friend class managed_ptr; /// Needed for the converting constructor
 
          ///
          /// @author Alan Dayton

--- a/src/chai/managed_ptr.hpp
+++ b/src/chai/managed_ptr.hpp
@@ -111,12 +111,14 @@ namespace chai {
             m_destructor(other.m_destructor) {
 
 #ifndef __CUDA_ARCH__
+            if (m_numReferences) {
                // Increment the number of references.
                (*m_numReferences)++;
 
                // Trigger copy constructor so that any ManagedArrays in the object
                // are copied to the right data space.
                m_copyConstructor(m_cpu);
+            }
 #endif
          }
 
@@ -139,12 +141,14 @@ namespace chai {
             m_copyConstructor(other.m_copyConstructor),
             m_destructor(other.m_destructor) {
 #ifndef __CUDA_ARCH__
-               // Increment the number of references.
-               (*m_numReferences)++;
+               if (m_numReferences) {
+                  // Increment the number of references.
+                  (*m_numReferences)++;
 
-               // Trigger copy constructor so that any ManagedArrays in the object
-               // are copied to the right data space.
-               m_copyConstructor(m_cpu);
+                  // Trigger copy constructor so that any ManagedArrays in the object
+                  // are copied to the right data space.
+                  m_copyConstructor(m_cpu);
+               }
 #endif
          }
 
@@ -191,11 +195,13 @@ namespace chai {
                m_destructor = other.m_destructor;
 
 #ifndef __CUDA_ARCH__
-               (*m_numReferences)++;
+               if (m_numReferences) {
+                  (*m_numReferences)++;
 
-               // Trigger copy constructor so that any ManagedArrays in the object
-               // are copied to the right data space.
-               m_copyConstructor(m_cpu);
+                  // Trigger copy constructor so that any ManagedArrays in the object
+                  // are copied to the right data space.
+                  m_copyConstructor(m_cpu);
+               }
 #endif
             }
 
@@ -213,23 +219,23 @@ namespace chai {
          ///
          template<class D>
          CHAI_HOST_DEVICE managed_ptr& operator=(const managed_ptr<D>& other) noexcept {
-            if (this != &other) {
-               m_cpu = other.m_cpu;
+            m_cpu = other.m_cpu;
 #ifdef __CUDACC__
-               m_gpu = other.m_gpu;
+            m_gpu = other.m_gpu;
 #endif
-               m_numReferences = other.m_numReferences;
-               m_copyConstructor = other.m_copyConstructor;
-               m_destructor = other.m_destructor;
+            m_numReferences = other.m_numReferences;
+            m_copyConstructor = other.m_copyConstructor;
+            m_destructor = other.m_destructor;
 
 #ifndef __CUDA_ARCH__
+            if (m_numReferences) {
                (*m_numReferences)++;
 
                // Trigger copy constructor so that any ManagedArrays in the object
                // are copied to the right data space.
                m_copyConstructor(m_cpu);
-#endif
             }
+#endif
 
             return *this;
          }

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,12 +1,19 @@
 set (managed_array_test_depends
   chai umpire gtest)
 
+set (managed_ptr_test_depends
+  chai umpire gtest)
+
 if (ENABLE_CUDA)
   set (managed_array_test_depends
     ${managed_array_test_depends}
     cuda)
+  set (managed_ptr_test_depends
+    ${managed_ptr_test_depends}
+    cuda)
 endif ()
 
+# ManagedArray tests
 blt_add_executable(
   NAME managed_array_tests
   SOURCES managed_array_tests.cpp
@@ -19,3 +26,17 @@ target_include_directories(
 blt_add_test(
   NAME managed_array_test
   COMMAND managed_array_tests)
+
+# managed_ptr tests
+blt_add_executable(
+  NAME managed_ptr_tests
+  SOURCES managed_ptr_tests.cpp
+  DEPENDS_ON ${managed_ptr_test_depends})
+
+target_include_directories(
+  managed_ptr_tests
+  PUBLIC ${PROJECT_BINARY_DIR}/include)
+
+blt_add_test(
+  NAME managed_ptr_test
+  COMMAND managed_ptr_tests)

--- a/tests/integration/managed_array_tests.cpp
+++ b/tests/integration/managed_array_tests.cpp
@@ -1291,3 +1291,23 @@ CUDA_TEST(ManagedArray, DeviceDeepCopy)
 }
 #endif
 #endif  // defined(CHAI_ENABLE_CUDA)
+
+CUDA_TEST(ManagedArray, CopyConstruct)
+{
+  const int expectedValue = rand();
+
+  chai::ManagedArray<int> array(1, chai::CPU);
+  array[0] = expectedValue;
+
+  chai::ManagedArray<int> array2 = array;
+
+  chai::ManagedArray<int> results(1, chai::GPU);
+
+  forall(cuda(), 0, 1, [=] __device__ (int i) {
+    results[i] = array2[i];
+  });
+
+  results.move(chai::CPU);
+  ASSERT_EQ(results[0], expectedValue);
+}
+

--- a/tests/integration/managed_ptr_tests.cpp
+++ b/tests/integration/managed_ptr_tests.cpp
@@ -1,0 +1,105 @@
+// ---------------------------------------------------------------------
+// Copyright (c) 2016-2018, Lawrence Livermore National Security, LLC. All
+// rights reserved.
+//
+// Produced at the Lawrence Livermore National Laboratory.
+//
+// This file is part of CHAI.
+//
+// LLNL-CODE-705877
+//
+// For details, see https:://github.com/LLNL/CHAI
+// Please also see the NOTICE and LICENSE files.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// - Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+//
+// - Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the
+//   distribution.
+//
+// - Neither the name of the LLNS/LLNL nor the names of its contributors
+//   may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+// WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// ---------------------------------------------------------------------
+#include "gtest/gtest.h"
+
+#define CUDA_TEST(X, Y)              \
+  static void cuda_test_##X##Y();    \
+  TEST(X, Y) { cuda_test_##X##Y(); } \
+  static void cuda_test_##X##Y()
+
+#include "chai/config.hpp"
+
+#include "../src/util/forall.hpp"
+
+#include "chai/managed_ptr.hpp"
+
+// Standard library headers
+#include <cstdlib>
+
+class TestBase {
+   public:
+      TestBase() {}
+
+      CHAI_HOST_DEVICE virtual int getValue(const int i) const = 0;
+};
+
+class TestDerived : public TestBase {
+   public:
+      TestDerived() : TestBase(), m_values(nullptr) {}
+      TestDerived(chai::ManagedArray<int> values) : TestBase(), m_values(values) {}
+
+      CHAI_HOST_DEVICE virtual int getValue(const int i) const { return m_values[i]; }
+
+   private:
+      chai::ManagedArray<int> m_values;
+};
+
+TEST(managed_ptr, inner_ManagedArray)
+{
+  const int expectedValue = rand();
+
+  chai::ManagedArray<int> array(1, chai::CPU);
+  array[0] = expectedValue;
+
+  chai::managed_ptr<TestDerived> derived(new TestDerived(array));
+  ASSERT_EQ(derived->getValue(0), expectedValue);
+}
+
+CUDA_TEST(managed_ptr, cuda_inner_ManagedArray)
+{
+  const int expectedValue = rand();
+
+  chai::ManagedArray<int> array(1, chai::CPU);
+  array[0] = expectedValue;
+
+  chai::managed_ptr<TestBase> derived(new TestDerived(array));
+  chai::ManagedArray<int> results(1, chai::GPU);
+  
+  forall(cuda(), 0, 1, [=] __device__ (int i) {
+    results[i] = derived->getValue(i);
+  });
+
+  results.move(chai::CPU);
+  ASSERT_EQ(results[0], expectedValue);
+}
+

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -47,6 +47,9 @@ set (managed_array_test_depends
 set (array_manager_test_depends
   chai umpire gtest)
 
+set (managed_ptr_test_depends
+  chai umpire gtest)
+
 if (ENABLE_CUDA)
   set (managed_array_test_depends
     ${managed_array_test_depends}
@@ -54,8 +57,12 @@ if (ENABLE_CUDA)
   set (array_manager_test_depends
     ${array_manager_test_depends}
     cuda)
+  set (managed_ptr_test_depends
+    ${managed_ptr_test_depends}
+    cuda)
 endif ()
 
+# ManagedArray tests
 blt_add_executable(
   NAME managed_array_unit_tests
   SOURCES managed_array_unit_tests.cpp
@@ -82,4 +89,18 @@ target_include_directories(
 blt_add_test(
   NAME array_manager_unit_test
   COMMAND array_manager_unit_tests)
+
+# managed_ptr tests
+blt_add_executable(
+  NAME managed_ptr_unit_tests
+  SOURCES managed_ptr_unit_tests.cpp
+  DEPENDS_ON ${managed_ptr_test_depends})
+
+target_include_directories(
+  managed_ptr_unit_tests
+  PUBLIC ${PROJECT_BINARY_DIR}/include)
+
+blt_add_test(
+  NAME managed_ptr_unit_test
+  COMMAND managed_ptr_unit_tests)
 

--- a/tests/unit/managed_ptr_unit_tests.cpp
+++ b/tests/unit/managed_ptr_unit_tests.cpp
@@ -315,3 +315,63 @@ TEST(managed_ptr, conversion_copy_assignment_operator_from_default_constructed)
   ASSERT_EQ(nullptr, otherDerived);
 }
 
+TEST(managed_ptr, copy_assignment_operator_from_host_ptr_constructed)
+{
+  const int expectedValue1 = rand();
+  const int expectedValue2 = rand();
+
+  chai::managed_ptr<TestDerived> derived(new TestDerived(expectedValue1));
+  chai::managed_ptr<TestDerived> otherDerived(new TestDerived(expectedValue2));
+  chai::managed_ptr<TestDerived> thirdDerived(otherDerived);
+
+  thirdDerived = derived;
+
+  ASSERT_NE(derived.get(), nullptr);
+  ASSERT_EQ(derived.use_count(), 2);
+  ASSERT_EQ(bool(derived), true);
+  ASSERT_NE(derived, nullptr);
+  ASSERT_NE(nullptr, derived);
+
+  ASSERT_NE(otherDerived.get(), nullptr);
+  ASSERT_EQ(otherDerived.use_count(), 1);
+  ASSERT_EQ(bool(otherDerived), true);
+  ASSERT_NE(otherDerived, nullptr);
+  ASSERT_NE(nullptr, otherDerived);
+
+  ASSERT_NE(thirdDerived.get(), nullptr);
+  ASSERT_EQ(thirdDerived.use_count(), 2);
+  ASSERT_EQ(bool(thirdDerived), true);
+  ASSERT_NE(thirdDerived, nullptr);
+  ASSERT_NE(nullptr, thirdDerived);
+}
+
+TEST(managed_ptr, conversion_copy_assignment_operator_from_host_ptr_constructed)
+{
+  const int expectedValue1 = rand();
+  const int expectedValue2 = rand();
+
+  chai::managed_ptr<TestDerived> derived(new TestDerived(expectedValue1));
+  chai::managed_ptr<TestDerived> otherDerived(new TestDerived(expectedValue2));
+  chai::managed_ptr<TestBase> thirdDerived(otherDerived);
+
+  thirdDerived = derived;
+
+  ASSERT_NE(derived.get(), nullptr);
+  ASSERT_EQ(derived.use_count(), 2);
+  ASSERT_EQ(bool(derived), true);
+  ASSERT_NE(derived, nullptr);
+  ASSERT_NE(nullptr, derived);
+
+  ASSERT_NE(otherDerived.get(), nullptr);
+  ASSERT_EQ(otherDerived.use_count(), 1);
+  ASSERT_EQ(bool(otherDerived), true);
+  ASSERT_NE(otherDerived, nullptr);
+  ASSERT_NE(nullptr, otherDerived);
+
+  ASSERT_NE(thirdDerived.get(), nullptr);
+  ASSERT_EQ(thirdDerived.use_count(), 2);
+  ASSERT_EQ(bool(thirdDerived), true);
+  ASSERT_NE(thirdDerived, nullptr);
+  ASSERT_NE(nullptr, thirdDerived);
+}
+

--- a/tests/unit/managed_ptr_unit_tests.cpp
+++ b/tests/unit/managed_ptr_unit_tests.cpp
@@ -202,3 +202,116 @@ CUDA_TEST(managed_ptr, cuda_converting_make_managed)
   ASSERT_EQ(array[0], expectedValue);
 }
 
+TEST(managed_ptr, copy_constructor)
+{
+  const int expectedValue = rand();
+  chai::managed_ptr<TestDerived> derived(new TestDerived(expectedValue));
+  chai::managed_ptr<TestDerived> otherDerived(derived);
+
+  ASSERT_NE(derived.get(), nullptr);
+  ASSERT_EQ(derived.use_count(), 2);
+  ASSERT_EQ(bool(derived), true);
+  ASSERT_NE(derived, nullptr);
+  ASSERT_NE(nullptr, derived);
+
+  ASSERT_NE(otherDerived.get(), nullptr);
+  ASSERT_EQ(otherDerived.use_count(), 2);
+  ASSERT_EQ(bool(otherDerived), true);
+  ASSERT_NE(otherDerived, nullptr);
+  ASSERT_NE(nullptr, otherDerived);
+}
+
+TEST(managed_ptr, copy_assignment_operator)
+{
+  const int expectedValue = rand();
+  chai::managed_ptr<TestDerived> derived(new TestDerived(expectedValue));
+  chai::managed_ptr<TestDerived> otherDerived;
+  otherDerived = derived;
+
+  ASSERT_NE(derived.get(), nullptr);
+  ASSERT_EQ(derived.use_count(), 2);
+  ASSERT_EQ(bool(derived), true);
+  ASSERT_NE(derived, nullptr);
+  ASSERT_NE(nullptr, derived);
+
+  ASSERT_NE(otherDerived.get(), nullptr);
+  ASSERT_EQ(otherDerived.use_count(), 2);
+  ASSERT_EQ(bool(otherDerived), true);
+  ASSERT_NE(otherDerived, nullptr);
+  ASSERT_NE(nullptr, otherDerived);
+}
+
+TEST(managed_ptr, copy_constructor_from_default_constructed)
+{
+  chai::managed_ptr<TestDerived> derived;
+  chai::managed_ptr<TestDerived> otherDerived(derived);
+
+  ASSERT_EQ(derived.get(), nullptr);
+  ASSERT_EQ(derived.use_count(), 0);
+  ASSERT_EQ(bool(derived), false);
+  ASSERT_EQ(derived, nullptr);
+  ASSERT_EQ(nullptr, derived);
+
+  ASSERT_EQ(otherDerived.get(), nullptr);
+  ASSERT_EQ(otherDerived.use_count(), 0);
+  ASSERT_EQ(bool(otherDerived), false);
+  ASSERT_EQ(otherDerived, nullptr);
+  ASSERT_EQ(nullptr, otherDerived);
+}
+
+TEST(managed_ptr, copy_assignment_operator_from_default_constructed)
+{
+  chai::managed_ptr<TestDerived> derived;
+  chai::managed_ptr<TestDerived> otherDerived;
+  otherDerived = derived;
+
+  ASSERT_EQ(derived.get(), nullptr);
+  ASSERT_EQ(derived.use_count(), 0);
+  ASSERT_EQ(bool(derived), false);
+  ASSERT_EQ(derived, nullptr);
+  ASSERT_EQ(nullptr, derived);
+
+  ASSERT_EQ(otherDerived.get(), nullptr);
+  ASSERT_EQ(otherDerived.use_count(), 0);
+  ASSERT_EQ(bool(otherDerived), false);
+  ASSERT_EQ(otherDerived, nullptr);
+  ASSERT_EQ(nullptr, otherDerived);
+}
+
+TEST(managed_ptr, conversion_copy_constructor_from_default_constructed)
+{
+  chai::managed_ptr<TestDerived> derived;
+  chai::managed_ptr<TestBase> otherDerived(derived);
+
+  ASSERT_EQ(derived.get(), nullptr);
+  ASSERT_EQ(derived.use_count(), 0);
+  ASSERT_EQ(bool(derived), false);
+  ASSERT_EQ(derived, nullptr);
+  ASSERT_EQ(nullptr, derived);
+
+  ASSERT_EQ(otherDerived.get(), nullptr);
+  ASSERT_EQ(otherDerived.use_count(), 0);
+  ASSERT_EQ(bool(otherDerived), false);
+  ASSERT_EQ(otherDerived, nullptr);
+  ASSERT_EQ(nullptr, otherDerived);
+}
+
+TEST(managed_ptr, conversion_copy_assignment_operator_from_default_constructed)
+{
+  chai::managed_ptr<TestDerived> derived;
+  chai::managed_ptr<TestBase> otherDerived;
+  otherDerived = derived;
+
+  ASSERT_EQ(derived.get(), nullptr);
+  ASSERT_EQ(derived.use_count(), 0);
+  ASSERT_EQ(bool(derived), false);
+  ASSERT_EQ(derived, nullptr);
+  ASSERT_EQ(nullptr, derived);
+
+  ASSERT_EQ(otherDerived.get(), nullptr);
+  ASSERT_EQ(otherDerived.use_count(), 0);
+  ASSERT_EQ(bool(otherDerived), false);
+  ASSERT_EQ(otherDerived, nullptr);
+  ASSERT_EQ(nullptr, otherDerived);
+}
+

--- a/tests/unit/managed_ptr_unit_tests.cpp
+++ b/tests/unit/managed_ptr_unit_tests.cpp
@@ -58,23 +58,33 @@
 
 class TestBase {
    public:
-      TestBase() : m_value(0) {}
-      TestBase(const int value) : m_value(value) {}
+      TestBase() {}
 
-      CHAI_HOST_DEVICE virtual int getValue() const { return m_value; }
-
-   protected:
-      int m_value;
-
+      CHAI_HOST_DEVICE virtual int getValue() const = 0;
 };
 
 class TestDerived : public TestBase {
    public:
-      TestDerived() : TestBase(1) {}
-      TestDerived(const int value) : TestBase(value) {}
+      TestDerived() : TestBase(), m_value(0) {}
+      TestDerived(const int value) : TestBase(), m_value(value) {}
 
       CHAI_HOST_DEVICE virtual int getValue() const { return m_value; }
+
+   private:
+      int m_value;
 };
+
+TEST(managed_ptr, DefaultConstructor)
+{
+  chai::managed_ptr<TestDerived> derived;
+  ASSERT_EQ(derived.get(), nullptr);
+}
+
+TEST(managed_ptr, nullptrConstructor)
+{
+  chai::managed_ptr<TestDerived> derived = nullptr;
+  ASSERT_EQ(derived.get(), nullptr);
+}
 
 TEST(managed_ptr, HostPtrConstructor)
 {

--- a/tests/unit/managed_ptr_unit_tests.cpp
+++ b/tests/unit/managed_ptr_unit_tests.cpp
@@ -1,0 +1,111 @@
+// ---------------------------------------------------------------------
+// Copyright (c) 2016-2018, Lawrence Livermore National Security, LLC. All
+// rights reserved.
+//
+// Produced at the Lawrence Livermore National Laboratory.
+//
+// This file is part of CHAI.
+//
+// LLNL-CODE-705877
+//
+// For details, see https:://github.com/LLNL/CHAI
+// Please also see the NOTICE and LICENSE files.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// - Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+//
+// - Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the
+//   distribution.
+//
+// - Neither the name of the LLNS/LLNL nor the names of its contributors
+//   may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+// WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// ---------------------------------------------------------------------
+#include "gtest/gtest.h"
+
+#define CUDA_TEST(X, Y)              \
+  static void cuda_test_##X##Y();    \
+  TEST(X, Y) { cuda_test_##X##Y(); } \
+  static void cuda_test_##X##Y()
+
+#include "chai/config.hpp"
+
+#include "../src/util/forall.hpp"
+
+#include "chai/managed_ptr.hpp"
+
+// Standard library headers
+#include <cstdlib>
+
+class TestDerived {
+   public:
+      TestDerived() : m_value(0) {}
+      TestDerived(const int value) : m_value(value) {}
+
+      int getValue() const { return m_value; }
+
+   private:
+      int m_value;
+};
+
+TEST(managed_ptr, HostPtrConstructor)
+{
+  const int expectedValue = rand();
+  chai::managed_ptr<TestDerived> derived(new TestDerived(expectedValue));
+  ASSERT_EQ(derived->getValue(), expectedValue);
+}
+
+CUDA_TEST(managed_ptr, cuda_HostPtrConstructor)
+{
+  const int expectedValue = rand();
+  chai::managed_ptr<TestDerived> derived(new TestDerived(expectedValue));
+  chai::ManagedArray<int> array(1, chai::GPU);
+  
+  forall(cuda(), 0, 1, [=] __device__ (int i) {
+    array[i] = derived->getValue();
+  });
+
+  array.move(chai::CPU);
+  ASSERT_EQ(array[0], expectedValue);
+}
+
+TEST(managed_ptr, make_managed)
+{
+  const int expectedValue = rand();
+  auto derived = chai::make_managed<TestDerived>(expectedValue);
+  ASSERT_EQ((*derived).getValue(), expectedValue);
+}
+
+CUDA_TEST(managed_ptr, cuda_make_managed)
+{
+  const int expectedValue = rand();
+  auto derived = chai::make_managed<TestDerived>(expectedValue);
+  chai::ManagedArray<int> array(1, chai::GPU);
+  
+  forall(cuda(), 0, 1, [=] __device__ (int i) {
+    array[i] = (*derived).getValue();
+  });
+
+  array.move(chai::CPU);
+  ASSERT_EQ(array[0], expectedValue);
+}
+


### PR DESCRIPTION
The purpose of managed_ptr is to allow us to use inheritance on the GPU in a way that requires minimal modification of the inheritance hierarchy. Many codes use extensive inheritance and it would be quite the undertaking to change that.