### PR TITLE
Feature/dayton8/managed_ptr_2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+*.swp

--- a/src/chai/CMakeLists.txt
+++ b/src/chai/CMakeLists.txt
@@ -58,6 +58,7 @@ set (chai_headers
   ExecutionSpaces.hpp
   ManagedArray.hpp
   ManagedArray.inl
+  managed_ptr.hpp
   PointerRecord.hpp
   Types.hpp)
 

--- a/src/chai/managed_ptr.hpp
+++ b/src/chai/managed_ptr.hpp
@@ -1,0 +1,258 @@
+#ifndef MANAGED_PTR_H_
+#define MANAGED_PTR_H_
+
+#include "chai/ChaiMacros.hpp"
+#include "chai/ManagedArray.hpp"
+
+#include "../util/forall.hpp"
+
+namespace chai {
+   ///
+   /// @class managed_ptr<T>
+   /// @author Alan Dayton
+   /// This wrapper calls new on both the GPU and CPU so that polymorphism can
+   ///    be used on the GPU. It is modeled after std::shared_ptr, so it does
+   ///    reference counting and automatically cleans up when the last reference
+   ///    is destroyed. If we ever do multi-threading on the CPU, locking will
+   ///    need to be added to the reference counter.
+   /// Requirements:
+   ///    The actual type created (D in the first constructor) must be copy
+   ///       constructible and the copy constructor must call the base class
+   ///       copy constructors to avoid slicing. The default constructor has
+   ///       the correct behavior, but only if the whole inheritance chain uses
+   ///       the default copy constructor. Otherwise, at whatever point the
+   ///       default is no longer used, the the base class copy constructors
+   ///       must be called to avoid copy slicing. If the copy constructors are
+   ///       private, this class must be declared as a friend.
+   ///    The actual type created (D in the first constructor) must be convertible
+   ///       to T (e.g. T is a base class of D).
+   ///    This wrapper does NOT automatically sync the GPU copy if the CPU copy is
+   ///       updated and vice versa. The one exception to this is that if the class
+   ///       has chai::ManagedArray members or members that inherit chai::ManagedArray,
+   ///       these will be kept in sync (hence the need for D to be copy constructible).
+   ///       HOWEVER, the chai::ManagedArray members must be initialized upon object
+   ///       construction. Otherwise, if you wish to keep the CPU and GPU copies in sync,
+   ///       you must explicitly call the same modifying function in the CPU context and
+   ///       in the GPU context.
+   ///    Do NOT pass the base pointer type to the constructor. Always pass the derived
+   ///       type.
+   ///    Pointer types members of T must be chai::ManagedArrays or managed_ptrs to be
+   ///       accessible on the GPU. The same requirements apply to inner managed_ptrs.
+   ///       Requirements for using chai::ManagedArrays in the proper context still apply.
+   ///    Methods that can be called on the CPU and GPU must be declared with the
+   ///       __host__ __device__ specifiers. This includes the constructors (including
+   ///       copy constructors) and destructors.
+   ///    Raw pointer members still can be used, but they will only be valid on the host.
+   ///       To prevent accidentally using them in a device context, any methods that
+   ///       access raw pointers should be host only.
+   ///    Be especially careful of passing raw pointers to member functions.
+   template <typename T>
+   class managed_ptr {
+      public:
+         using element_type = T;
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Constructs a managed_ptr from the given pointer.
+         /// Takes the given host pointer and creates a copy of the object on the GPU.
+         ///
+         /// @param[in] cpuPtr The host pointer to take ownership of
+         ///
+         template <typename D>
+         explicit managed_ptr(D* ptr) : m_cpu(ptr), m_numReferences(new std::size_t{1}) {
+#ifdef __CUDACC__
+            createDevicePtr(*ptr);
+#endif
+
+            // Need to be able to access the copy constructor if T is a base pointer type
+            m_copyConstructor = [] (void* basePtr) {
+               D derivedCopy = *(static_cast<D*>(basePtr));
+               (void) derivedCopy;
+            };
+         }
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Copy constructor.
+         /// Constructs a copy of the given managed_ptr and increases the reference count.
+         ///    D must be convertible to T.
+         ///
+         /// @param[in] other The managed_ptr to copy.
+         ///
+         template <typename D>
+         managed_ptr(managed_ptr<D> const & other) :
+            m_cpu(other.m_cpu),
+#ifdef __CUDACC__
+            m_gpu(other.m_gpu),
+#endif
+            m_numReferences(other.m_numReferences),
+            m_copyConstructor(other.m_copyConstructor),
+            m_destructor(other.m_destructor) {
+#ifndef __CUDA_ARCH__
+               // Increment the number of references.
+               (*m_numReferences)++;
+
+               // Trigger copy constructor so that any ManagedArrays in the object
+               // are copied to the right data space.
+               m_copyConstructor(m_cpu);
+#endif
+         }
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Copy constructor.
+         /// Constructs a copy of the given managed_ptr and increases the reference count.
+         ///
+         /// @param[in] other The managed_ptr to copy.
+         ///
+         CHAI_HOST_DEVICE managed_ptr(const managed_ptr<T>& other) :
+            m_cpu(other.m_cpu),
+#ifdef __CUDACC__
+            m_gpu(other.m_gpu),
+#endif
+            m_numReferences(other.m_numReferences),
+            m_copyConstructor(other.m_copyConstructor),
+            m_destructor(other.m_destructor) {
+
+#ifndef __CUDA_ARCH__
+               // Increment the number of references.
+               (*m_numReferences)++;
+
+               // Trigger copy constructor so that any ManagedArrays in the object
+               // are copied to the right data space.
+               m_copyConstructor(m_cpu);
+#endif
+         }
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Destructor. Decreases the reference count and if this is the last reference,
+         ///    clean up.
+         ///
+         CHAI_HOST_DEVICE ~managed_ptr() {
+#ifndef __CUDA_ARCH__
+            (*m_numReferences)--;
+
+            if (m_numReferences && *m_numReferences == 0) {
+               delete m_numReferences;
+
+               m_destructor(m_cpu);
+
+#ifdef __CUDACC__
+               destroyDevicePtr();
+#endif
+            }
+#endif
+         }
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Returns the CPU or GPU pointer depending on the calling context.
+         ///
+         CHAI_HOST_DEVICE inline T* operator->() const {
+#ifndef __CUDA_ARCH__
+            return m_cpu;
+#else
+            return m_gpu;
+#endif
+         }
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Returns the CPU or GPU reference depending on the calling context.
+         ///
+         CHAI_HOST_DEVICE inline T& operator*() const {
+#ifndef __CUDA_ARCH__
+            return *m_cpu;
+#else
+            return *m_gpu;
+#endif
+         }
+
+#ifdef __CUDACC__
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Creates the device pointer.
+         /// Should be called only by the constructor, but extended __host__ __device__
+         ///    lambdas can only be in public methods.
+         ///
+         template <typename D>
+         void createDevicePtr(const D& obj) {
+            chai::ManagedArray<D*> temp(1, chai::GPU);
+
+            forall(cuda(), 0, 1, [=] __device__ (int i) {
+               temp[i] = new D(obj);
+            });
+
+            temp.move(chai::CPU);
+            m_gpu = temp[0];
+            temp.free();
+
+            // __host__ __device__ functions can't be created in constructor
+            // Need to be able to delete the original type if T is a base pointer type
+            m_destructor = [] CHAI_HOST_DEVICE (void* basePtr) {
+               delete static_cast<D*>(basePtr);
+            };
+         }
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Cleans up the device pointer.
+         /// Should be called only by the destructor, but extended __host__ __device__
+         ///    lambdas can only be in public methods.
+         ///
+         void destroyDevicePtr() {
+            chai::ManagedArray<T*> temp(1, chai::CPU);
+            temp[0] = m_gpu;
+
+            // Does not capture "this"
+            void (*destructor)(void*) = m_destructor;
+
+            forall(cuda(), 0, 1, [=] __device__ (int i) {
+               destructor(temp[i]);
+            });
+
+            temp.free();
+         }
+#endif
+
+      private:
+         T* m_cpu = nullptr; /// The host pointer
+
+#ifdef __CUDACC__
+         T* m_gpu = nullptr; /// The device pointer
+#endif
+
+         size_t* m_numReferences = nullptr; /// The reference counter
+
+         void (*m_copyConstructor)(void*); /// A function that casts to the derived type and calls the copy constructor so that chai::ManagedArrays are moved to the correct execution space.
+
+         void (*m_destructor)(void*); /// A function that casts to the derived type and calls delete on it.
+
+         template <class D> friend class managed_ptr; /// Needed for the converting constructor
+   };
+
+   ///
+   /// @author Alan Dayton
+   ///
+   /// Makes a managed_ptr<T>.
+   /// Factory function to create managed_ptrs.
+   ///
+   /// @params[in] args The arguments to T's constructor
+   ///
+   template <typename T, typename... Args>
+   managed_ptr<T> make_managed(Args&&... args) {
+      return managed_ptr<T>(new T(std::forward<Args>(args)...));
+   }
+} // namespace chai
+
+#endif // MANAGED_PTR
+

--- a/src/chai/managed_ptr.hpp
+++ b/src/chai/managed_ptr.hpp
@@ -394,14 +394,13 @@ namespace chai {
          friend class managed_ptr; /// Needed for the converting constructor
 
          template <typename U,
-                   typename std::enable_if<std::is_class<U>::value, int>::type,
                    typename... Args>
          friend managed_ptr<U> make_managed(Args&&... args);
 
-         template <typename F,
-                   typename std::enable_if<!std::is_class<F>::value, int>::type,
+         template <typename U,
+                   typename F,
                    typename... Args>
-         managed_ptr<typename std::remove_pointer<typename std::result_of<F(Args...)>::type>::type> make_managed(F f, Args&&... args);
+         friend managed_ptr<U> make_managed_from_factory(F&& f, Args&&... args);
 
          ///
          /// @author Alan Dayton
@@ -598,7 +597,7 @@ namespace chai {
    template <typename T,
              typename F,
              typename... Args>
-   managed_ptr<T> make_managed_from_factory(F f, Args&&... args) {
+   managed_ptr<T> make_managed_from_factory(F&& f, Args&&... args) {
       static_assert(std::is_pointer<typename std::result_of<F(Args...)>::type>::value,
                     "Factory function must return a pointer");
 

--- a/src/chai/managed_ptr.hpp
+++ b/src/chai/managed_ptr.hpp
@@ -130,7 +130,7 @@ namespace chai {
          /// @param[in] other The managed_ptr to copy.
          ///
          template <typename D>
-         CHAI_HOST_DEVICE managed_ptr(managed_ptr<D> const & other) :
+         CHAI_HOST_DEVICE managed_ptr(managed_ptr<D> const & other) noexcept :
             m_cpu(other.m_cpu),
 #ifdef __CUDACC__
             m_gpu(other.m_gpu),
@@ -170,6 +170,68 @@ namespace chai {
                }
             }
 #endif
+         }
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Copy assignment operator.
+         /// Copies the given managed_ptr and increases the reference count.
+         ///
+         /// @param[in] other The managed_ptr to copy.
+         ///
+         CHAI_HOST_DEVICE managed_ptr& operator=(const managed_ptr& other) noexcept {
+            if (this != &other) {
+               m_cpu = other.m_cpu;
+#ifdef __CUDACC__
+               m_gpu = other.m_gpu;
+#endif
+               m_numReferences = other.m_numReferences;
+               m_copyConstructor = other.m_copyConstructor;
+               m_destructor = other.m_destructor;
+
+#ifndef __CUDA_ARCH__
+               (*m_numReferences)++;
+
+               // Trigger copy constructor so that any ManagedArrays in the object
+               // are copied to the right data space.
+               m_copyConstructor(m_cpu);
+#endif
+            }
+
+            return *this;
+         }
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Conversion copy assignment operator.
+         /// Copies the given managed_ptr and increases the reference count.
+         ///    D must be convertible to T.
+         ///
+         /// @param[in] other The managed_ptr to copy.
+         ///
+         template<class D>
+         CHAI_HOST_DEVICE managed_ptr& operator=(const managed_ptr<D>& other) noexcept {
+            if (this != &other) {
+               m_cpu = other.m_cpu;
+#ifdef __CUDACC__
+               m_gpu = other.m_gpu;
+#endif
+               m_numReferences = other.m_numReferences;
+               m_copyConstructor = other.m_copyConstructor;
+               m_destructor = other.m_destructor;
+
+#ifndef __CUDA_ARCH__
+               (*m_numReferences)++;
+
+               // Trigger copy constructor so that any ManagedArrays in the object
+               // are copied to the right data space.
+               m_copyConstructor(m_cpu);
+#endif
+            }
+
+            return *this;
          }
 
          ///

--- a/src/chai/managed_ptr.hpp
+++ b/src/chai/managed_ptr.hpp
@@ -319,6 +319,8 @@ namespace chai {
 #endif
          }
 
+         CHAI_HOST_DEVICE inline operator T*() const { return get(); }
+
          ///
          /// @author Alan Dayton
          ///

--- a/src/chai/managed_ptr.hpp
+++ b/src/chai/managed_ptr.hpp
@@ -2,9 +2,6 @@
 #define MANAGED_PTR_H_
 
 #include "chai/ChaiMacros.hpp"
-#include "chai/ManagedArray.hpp"
-
-#include "../util/forall.hpp"
 
 // Standard libary headers
 #include <cstddef>

--- a/src/chai/managed_ptr.hpp
+++ b/src/chai/managed_ptr.hpp
@@ -81,7 +81,14 @@ namespace chai {
          template <typename D>
          CHAI_HOST explicit managed_ptr(D* ptr) :
             m_cpu(ptr),
-            m_numReferences(new std::size_t{1}) {
+            m_numReferences(new std::size_t{1})
+         {
+            static_assert(std::is_base_of<T, D>::value ||
+                          std::is_convertible<D, T>::value,
+                          "Type D must a descendent of or be convertible to type T.");
+            static_assert(std::is_copy_constructible<D>::value,
+                          "Type D must be copy constructible.");
+
 #ifdef __CUDACC__
             createDevicePtr(*ptr);
 #endif
@@ -131,7 +138,14 @@ namespace chai {
 #endif
             m_numReferences(other.m_numReferences),
             m_copyConstructor(other.m_copyConstructor),
-            m_destructor(other.m_destructor) {
+            m_destructor(other.m_destructor)
+         {
+            static_assert(std::is_base_of<T, D>::value ||
+                          std::is_convertible<D, T>::value,
+                          "Type D must a descendent of or be convertible to type T.");
+            static_assert(std::is_copy_constructible<D>::value,
+                          "Type D must be copy constructible.");
+
 #ifndef __CUDA_ARCH__
                incrementReferenceCount();
 #endif
@@ -190,6 +204,12 @@ namespace chai {
          ///
          template<class D>
          CHAI_HOST_DEVICE managed_ptr& operator=(const managed_ptr<D>& other) noexcept {
+            static_assert(std::is_base_of<T, D>::value ||
+                          std::is_convertible<D, T>::value,
+                          "Type D must a descendent of or be convertible to type T.");
+            static_assert(std::is_copy_constructible<D>::value,
+                          "Type D must be copy constructible.");
+
 #ifndef __CUDA_ARCH__
             decrementReferenceCount();
 #endif
@@ -337,7 +357,8 @@ namespace chai {
 
          void (*m_destructor)(void*); /// A function that casts to the derived type and calls delete on it.
 
-         template <class D> friend class managed_ptr; /// Needed for the converting constructor
+         template <typename D>
+         friend class managed_ptr; /// Needed for the converting constructor
 
          ///
          /// @author Alan Dayton

--- a/src/chai/managed_ptr.hpp
+++ b/src/chai/managed_ptr.hpp
@@ -113,33 +113,31 @@ namespace chai {
    ///    is destroyed. If we ever do multi-threading on the CPU, locking will
    ///    need to be added to the reference counter.
    /// Requirements:
-   ///    The actual type created (U in the first constructor) must be convertible
+   ///    The underlying type created (U in the first constructor) must be convertible
    ///       to T (e.g. T is a base class of U or there is a user defined conversion).
    ///    This wrapper does NOT automatically sync the GPU copy if the CPU copy is
    ///       updated and vice versa. The one exception to this is nested ManagedArrays
    ///       and managed_ptrs, but only if they are registered via the registerArguments
-   ///       method. The factory method make_managed will register arguments passed
-   ///       to it automatically. Otherwise, if you wish to keep the CPU and GPU copies
-   ///       in sync, you must explicitly modify the object in both the CPU context
-   ///       and the GPU context.
+   ///       method. The factory methods make_managed and make_managed_from_factory
+   ///       will register arguments passed to them automatically. Otherwise, if you
+   ///       wish to keep the CPU and GPU instances in sync, you must explicitly modify
+   ///       the object in both the CPU context and the GPU context.
    ///    Members of T that are raw pointers need to be initialized correctly with a
    ///       host or device pointer. If it is desired that these be kept in sync,
-   ///       pass a ManagedArray to the make_managed function in place of a raw array.
-   ///       Or, if this is after the managed_ptr has been constructed, use the same
-   ///       ManagedArray in both the CPU and GPU contexts to initialize the raw pointer
-   ///       member and then register the ManagedArray with the registerArguments
-   ///       method on the managed_ptr. If only a raw array is passed to make_managed,
-   ///       accessing that member will be valid in the correct context. To prevent the
-   ///       accidental use of them in the wrong context, any methods that access raw
-   ///       pointers not initialized in both contexts should be __host__ only or
-   ///       __device__ only. Special care should be taken when passing raw pointers
-   ///       as arguments to member functions.
+   ///       pass a ManagedArray to the make_managed or make_managed_from_factory
+   ///       functions in place of a raw array. Or, if this is after the managed_ptr
+   ///       has been constructed, use the same ManagedArray in both the CPU and GPU
+   ///       contexts to initialize the raw pointer member and then register the
+   ///       ManagedArray with the registerArguments method on the managed_ptr.
+   ///       If only a raw array is passed to make_managed, accessing that member
+   ///       will be valid only in the correct context. To prevent the accidental
+   ///       use of that member in the wrong context, any methods that access raw
+   ///       pointers not initialized in both contexts as previously described
+   ///       should be __host__ only or __device__ only. Special care should be
+   ///       taken when passing raw pointers as arguments to member functions.
    ///    Methods that can be called on the CPU and GPU must be declared with the
    ///       __host__ __device__ specifiers. This includes the constructors being
    ///       used and destructors.
-   ///    Raw pointer members still can be used, but they will only be valid on the host.
-   ///       To prevent accidentally using them in a device context, any methods that
-   ///       access raw pointers should be host only.
    ///
    template <typename T>
    class managed_ptr {

--- a/src/chai/managed_ptr.hpp
+++ b/src/chai/managed_ptr.hpp
@@ -111,12 +111,14 @@ namespace chai {
             m_destructor(other.m_destructor) {
 
 #ifndef __CUDA_ARCH__
+            if (m_numReferences) {
                // Increment the number of references.
                (*m_numReferences)++;
 
                // Trigger copy constructor so that any ManagedArrays in the object
                // are copied to the right data space.
                m_copyConstructor(m_cpu);
+            }
 #endif
          }
 
@@ -139,12 +141,14 @@ namespace chai {
             m_copyConstructor(other.m_copyConstructor),
             m_destructor(other.m_destructor) {
 #ifndef __CUDA_ARCH__
-               // Increment the number of references.
-               (*m_numReferences)++;
+               if (m_numReferences) {
+                  // Increment the number of references.
+                  (*m_numReferences)++;
 
-               // Trigger copy constructor so that any ManagedArrays in the object
-               // are copied to the right data space.
-               m_copyConstructor(m_cpu);
+                  // Trigger copy constructor so that any ManagedArrays in the object
+                  // are copied to the right data space.
+                  m_copyConstructor(m_cpu);
+               }
 #endif
          }
 
@@ -191,11 +195,13 @@ namespace chai {
                m_destructor = other.m_destructor;
 
 #ifndef __CUDA_ARCH__
-               (*m_numReferences)++;
+               if (m_numReferences) {
+                  (*m_numReferences)++;
 
-               // Trigger copy constructor so that any ManagedArrays in the object
-               // are copied to the right data space.
-               m_copyConstructor(m_cpu);
+                  // Trigger copy constructor so that any ManagedArrays in the object
+                  // are copied to the right data space.
+                  m_copyConstructor(m_cpu);
+               }
 #endif
             }
 
@@ -213,23 +219,23 @@ namespace chai {
          ///
          template<class D>
          CHAI_HOST_DEVICE managed_ptr& operator=(const managed_ptr<D>& other) noexcept {
-            if (this != &other) {
-               m_cpu = other.m_cpu;
+            m_cpu = other.m_cpu;
 #ifdef __CUDACC__
-               m_gpu = other.m_gpu;
+            m_gpu = other.m_gpu;
 #endif
-               m_numReferences = other.m_numReferences;
-               m_copyConstructor = other.m_copyConstructor;
-               m_destructor = other.m_destructor;
+            m_numReferences = other.m_numReferences;
+            m_copyConstructor = other.m_copyConstructor;
+            m_destructor = other.m_destructor;
 
 #ifndef __CUDA_ARCH__
+            if (m_numReferences) {
                (*m_numReferences)++;
 
                // Trigger copy constructor so that any ManagedArrays in the object
                // are copied to the right data space.
                m_copyConstructor(m_cpu);
-#endif
             }
+#endif
 
             return *this;
          }

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,12 +1,19 @@
 set (managed_array_test_depends
   chai umpire gtest)
 
+set (managed_ptr_test_depends
+  chai umpire gtest)
+
 if (ENABLE_CUDA)
   set (managed_array_test_depends
     ${managed_array_test_depends}
     cuda)
+  set (managed_ptr_test_depends
+    ${managed_ptr_test_depends}
+    cuda)
 endif ()
 
+# ManagedArray tests
 blt_add_executable(
   NAME managed_array_tests
   SOURCES managed_array_tests.cpp
@@ -19,3 +26,17 @@ target_include_directories(
 blt_add_test(
   NAME managed_array_test
   COMMAND managed_array_tests)
+
+# managed_ptr tests
+blt_add_executable(
+  NAME managed_ptr_tests
+  SOURCES managed_ptr_tests.cpp
+  DEPENDS_ON ${managed_ptr_test_depends})
+
+target_include_directories(
+  managed_ptr_tests
+  PUBLIC ${PROJECT_BINARY_DIR}/include)
+
+blt_add_test(
+  NAME managed_ptr_test
+  COMMAND managed_ptr_tests)

--- a/tests/integration/managed_array_tests.cpp
+++ b/tests/integration/managed_array_tests.cpp
@@ -1291,3 +1291,23 @@ CUDA_TEST(ManagedArray, DeviceDeepCopy)
 }
 #endif
 #endif  // defined(CHAI_ENABLE_CUDA)
+
+CUDA_TEST(ManagedArray, CopyConstruct)
+{
+  const int expectedValue = rand();
+
+  chai::ManagedArray<int> array(1, chai::CPU);
+  array[0] = expectedValue;
+
+  chai::ManagedArray<int> array2 = array;
+
+  chai::ManagedArray<int> results(1, chai::GPU);
+
+  forall(cuda(), 0, 1, [=] __device__ (int i) {
+    results[i] = array2[i];
+  });
+
+  results.move(chai::CPU);
+  ASSERT_EQ(results[0], expectedValue);
+}
+

--- a/tests/integration/managed_ptr_tests.cpp
+++ b/tests/integration/managed_ptr_tests.cpp
@@ -1,0 +1,105 @@
+// ---------------------------------------------------------------------
+// Copyright (c) 2016-2018, Lawrence Livermore National Security, LLC. All
+// rights reserved.
+//
+// Produced at the Lawrence Livermore National Laboratory.
+//
+// This file is part of CHAI.
+//
+// LLNL-CODE-705877
+//
+// For details, see https:://github.com/LLNL/CHAI
+// Please also see the NOTICE and LICENSE files.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// - Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+//
+// - Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the
+//   distribution.
+//
+// - Neither the name of the LLNS/LLNL nor the names of its contributors
+//   may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+// WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// ---------------------------------------------------------------------
+#include "gtest/gtest.h"
+
+#define CUDA_TEST(X, Y)              \
+  static void cuda_test_##X##Y();    \
+  TEST(X, Y) { cuda_test_##X##Y(); } \
+  static void cuda_test_##X##Y()
+
+#include "chai/config.hpp"
+
+#include "../src/util/forall.hpp"
+
+#include "chai/managed_ptr.hpp"
+
+// Standard library headers
+#include <cstdlib>
+
+class TestBase {
+   public:
+      TestBase() {}
+
+      CHAI_HOST_DEVICE virtual int getValue(const int i) const = 0;
+};
+
+class TestDerived : public TestBase {
+   public:
+      TestDerived() : TestBase(), m_values(nullptr) {}
+      TestDerived(chai::ManagedArray<int> values) : TestBase(), m_values(values) {}
+
+      CHAI_HOST_DEVICE virtual int getValue(const int i) const { return m_values[i]; }
+
+   private:
+      chai::ManagedArray<int> m_values;
+};
+
+TEST(managed_ptr, inner_ManagedArray)
+{
+  const int expectedValue = rand();
+
+  chai::ManagedArray<int> array(1, chai::CPU);
+  array[0] = expectedValue;
+
+  chai::managed_ptr<TestDerived> derived(new TestDerived(array));
+  ASSERT_EQ(derived->getValue(0), expectedValue);
+}
+
+CUDA_TEST(managed_ptr, cuda_inner_ManagedArray)
+{
+  const int expectedValue = rand();
+
+  chai::ManagedArray<int> array(1, chai::CPU);
+  array[0] = expectedValue;
+
+  chai::managed_ptr<TestBase> derived(new TestDerived(array));
+  chai::ManagedArray<int> results(1, chai::GPU);
+  
+  forall(cuda(), 0, 1, [=] __device__ (int i) {
+    results[i] = derived->getValue(i);
+  });
+
+  results.move(chai::CPU);
+  ASSERT_EQ(results[0], expectedValue);
+}
+

--- a/tests/integration/managed_ptr_tests.cpp
+++ b/tests/integration/managed_ptr_tests.cpp
@@ -48,10 +48,10 @@
   static void cuda_test_##X##Y()
 
 #include "chai/config.hpp"
+#include "chai/ManagedArray.hpp"
+#include "chai/managed_ptr.hpp"
 
 #include "../src/util/forall.hpp"
-
-#include "chai/managed_ptr.hpp"
 
 // Standard library headers
 #include <cstdlib>

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -47,6 +47,9 @@ set (managed_array_test_depends
 set (array_manager_test_depends
   chai umpire gtest)
 
+set (managed_ptr_test_depends
+  chai umpire gtest)
+
 if (ENABLE_CUDA)
   set (managed_array_test_depends
     ${managed_array_test_depends}
@@ -54,8 +57,12 @@ if (ENABLE_CUDA)
   set (array_manager_test_depends
     ${array_manager_test_depends}
     cuda)
+  set (managed_ptr_test_depends
+    ${managed_ptr_test_depends}
+    cuda)
 endif ()
 
+# ManagedArray tests
 blt_add_executable(
   NAME managed_array_unit_tests
   SOURCES managed_array_unit_tests.cpp
@@ -82,4 +89,18 @@ target_include_directories(
 blt_add_test(
   NAME array_manager_unit_test
   COMMAND array_manager_unit_tests)
+
+# managed_ptr tests
+blt_add_executable(
+  NAME managed_ptr_unit_tests
+  SOURCES managed_ptr_unit_tests.cpp
+  DEPENDS_ON ${managed_ptr_test_depends})
+
+target_include_directories(
+  managed_ptr_unit_tests
+  PUBLIC ${PROJECT_BINARY_DIR}/include)
+
+blt_add_test(
+  NAME managed_ptr_unit_test
+  COMMAND managed_ptr_unit_tests)
 

--- a/tests/unit/managed_ptr_unit_tests.cpp
+++ b/tests/unit/managed_ptr_unit_tests.cpp
@@ -315,3 +315,63 @@ TEST(managed_ptr, conversion_copy_assignment_operator_from_default_constructed)
   ASSERT_EQ(nullptr, otherDerived);
 }
 
+TEST(managed_ptr, copy_assignment_operator_from_host_ptr_constructed)
+{
+  const int expectedValue1 = rand();
+  const int expectedValue2 = rand();
+
+  chai::managed_ptr<TestDerived> derived(new TestDerived(expectedValue1));
+  chai::managed_ptr<TestDerived> otherDerived(new TestDerived(expectedValue2));
+  chai::managed_ptr<TestDerived> thirdDerived(otherDerived);
+
+  thirdDerived = derived;
+
+  ASSERT_NE(derived.get(), nullptr);
+  ASSERT_EQ(derived.use_count(), 2);
+  ASSERT_EQ(bool(derived), true);
+  ASSERT_NE(derived, nullptr);
+  ASSERT_NE(nullptr, derived);
+
+  ASSERT_NE(otherDerived.get(), nullptr);
+  ASSERT_EQ(otherDerived.use_count(), 1);
+  ASSERT_EQ(bool(otherDerived), true);
+  ASSERT_NE(otherDerived, nullptr);
+  ASSERT_NE(nullptr, otherDerived);
+
+  ASSERT_NE(thirdDerived.get(), nullptr);
+  ASSERT_EQ(thirdDerived.use_count(), 2);
+  ASSERT_EQ(bool(thirdDerived), true);
+  ASSERT_NE(thirdDerived, nullptr);
+  ASSERT_NE(nullptr, thirdDerived);
+}
+
+TEST(managed_ptr, conversion_copy_assignment_operator_from_host_ptr_constructed)
+{
+  const int expectedValue1 = rand();
+  const int expectedValue2 = rand();
+
+  chai::managed_ptr<TestDerived> derived(new TestDerived(expectedValue1));
+  chai::managed_ptr<TestDerived> otherDerived(new TestDerived(expectedValue2));
+  chai::managed_ptr<TestBase> thirdDerived(otherDerived);
+
+  thirdDerived = derived;
+
+  ASSERT_NE(derived.get(), nullptr);
+  ASSERT_EQ(derived.use_count(), 2);
+  ASSERT_EQ(bool(derived), true);
+  ASSERT_NE(derived, nullptr);
+  ASSERT_NE(nullptr, derived);
+
+  ASSERT_NE(otherDerived.get(), nullptr);
+  ASSERT_EQ(otherDerived.use_count(), 1);
+  ASSERT_EQ(bool(otherDerived), true);
+  ASSERT_NE(otherDerived, nullptr);
+  ASSERT_NE(nullptr, otherDerived);
+
+  ASSERT_NE(thirdDerived.get(), nullptr);
+  ASSERT_EQ(thirdDerived.use_count(), 2);
+  ASSERT_EQ(bool(thirdDerived), true);
+  ASSERT_NE(thirdDerived, nullptr);
+  ASSERT_NE(nullptr, thirdDerived);
+}
+

--- a/tests/unit/managed_ptr_unit_tests.cpp
+++ b/tests/unit/managed_ptr_unit_tests.cpp
@@ -48,10 +48,10 @@
   static void cuda_test_##X##Y()
 
 #include "chai/config.hpp"
+#include "chai/ManagedArray.hpp"
+#include "chai/managed_ptr.hpp"
 
 #include "../src/util/forall.hpp"
-
-#include "chai/managed_ptr.hpp"
 
 // Standard library headers
 #include <cstdlib>

--- a/tests/unit/managed_ptr_unit_tests.cpp
+++ b/tests/unit/managed_ptr_unit_tests.cpp
@@ -202,3 +202,116 @@ CUDA_TEST(managed_ptr, cuda_converting_make_managed)
   ASSERT_EQ(array[0], expectedValue);
 }
 
+TEST(managed_ptr, copy_constructor)
+{
+  const int expectedValue = rand();
+  chai::managed_ptr<TestDerived> derived(new TestDerived(expectedValue));
+  chai::managed_ptr<TestDerived> otherDerived(derived);
+
+  ASSERT_NE(derived.get(), nullptr);
+  ASSERT_EQ(derived.use_count(), 2);
+  ASSERT_EQ(bool(derived), true);
+  ASSERT_NE(derived, nullptr);
+  ASSERT_NE(nullptr, derived);
+
+  ASSERT_NE(otherDerived.get(), nullptr);
+  ASSERT_EQ(otherDerived.use_count(), 2);
+  ASSERT_EQ(bool(otherDerived), true);
+  ASSERT_NE(otherDerived, nullptr);
+  ASSERT_NE(nullptr, otherDerived);
+}
+
+TEST(managed_ptr, copy_assignment_operator)
+{
+  const int expectedValue = rand();
+  chai::managed_ptr<TestDerived> derived(new TestDerived(expectedValue));
+  chai::managed_ptr<TestDerived> otherDerived;
+  otherDerived = derived;
+
+  ASSERT_NE(derived.get(), nullptr);
+  ASSERT_EQ(derived.use_count(), 2);
+  ASSERT_EQ(bool(derived), true);
+  ASSERT_NE(derived, nullptr);
+  ASSERT_NE(nullptr, derived);
+
+  ASSERT_NE(otherDerived.get(), nullptr);
+  ASSERT_EQ(otherDerived.use_count(), 2);
+  ASSERT_EQ(bool(otherDerived), true);
+  ASSERT_NE(otherDerived, nullptr);
+  ASSERT_NE(nullptr, otherDerived);
+}
+
+TEST(managed_ptr, copy_constructor_from_default_constructed)
+{
+  chai::managed_ptr<TestDerived> derived;
+  chai::managed_ptr<TestDerived> otherDerived(derived);
+
+  ASSERT_EQ(derived.get(), nullptr);
+  ASSERT_EQ(derived.use_count(), 0);
+  ASSERT_EQ(bool(derived), false);
+  ASSERT_EQ(derived, nullptr);
+  ASSERT_EQ(nullptr, derived);
+
+  ASSERT_EQ(otherDerived.get(), nullptr);
+  ASSERT_EQ(otherDerived.use_count(), 0);
+  ASSERT_EQ(bool(otherDerived), false);
+  ASSERT_EQ(otherDerived, nullptr);
+  ASSERT_EQ(nullptr, otherDerived);
+}
+
+TEST(managed_ptr, copy_assignment_operator_from_default_constructed)
+{
+  chai::managed_ptr<TestDerived> derived;
+  chai::managed_ptr<TestDerived> otherDerived;
+  otherDerived = derived;
+
+  ASSERT_EQ(derived.get(), nullptr);
+  ASSERT_EQ(derived.use_count(), 0);
+  ASSERT_EQ(bool(derived), false);
+  ASSERT_EQ(derived, nullptr);
+  ASSERT_EQ(nullptr, derived);
+
+  ASSERT_EQ(otherDerived.get(), nullptr);
+  ASSERT_EQ(otherDerived.use_count(), 0);
+  ASSERT_EQ(bool(otherDerived), false);
+  ASSERT_EQ(otherDerived, nullptr);
+  ASSERT_EQ(nullptr, otherDerived);
+}
+
+TEST(managed_ptr, conversion_copy_constructor_from_default_constructed)
+{
+  chai::managed_ptr<TestDerived> derived;
+  chai::managed_ptr<TestBase> otherDerived(derived);
+
+  ASSERT_EQ(derived.get(), nullptr);
+  ASSERT_EQ(derived.use_count(), 0);
+  ASSERT_EQ(bool(derived), false);
+  ASSERT_EQ(derived, nullptr);
+  ASSERT_EQ(nullptr, derived);
+
+  ASSERT_EQ(otherDerived.get(), nullptr);
+  ASSERT_EQ(otherDerived.use_count(), 0);
+  ASSERT_EQ(bool(otherDerived), false);
+  ASSERT_EQ(otherDerived, nullptr);
+  ASSERT_EQ(nullptr, otherDerived);
+}
+
+TEST(managed_ptr, conversion_copy_assignment_operator_from_default_constructed)
+{
+  chai::managed_ptr<TestDerived> derived;
+  chai::managed_ptr<TestBase> otherDerived;
+  otherDerived = derived;
+
+  ASSERT_EQ(derived.get(), nullptr);
+  ASSERT_EQ(derived.use_count(), 0);
+  ASSERT_EQ(bool(derived), false);
+  ASSERT_EQ(derived, nullptr);
+  ASSERT_EQ(nullptr, derived);
+
+  ASSERT_EQ(otherDerived.get(), nullptr);
+  ASSERT_EQ(otherDerived.use_count(), 0);
+  ASSERT_EQ(bool(otherDerived), false);
+  ASSERT_EQ(otherDerived, nullptr);
+  ASSERT_EQ(nullptr, otherDerived);
+}
+

--- a/tests/unit/managed_ptr_unit_tests.cpp
+++ b/tests/unit/managed_ptr_unit_tests.cpp
@@ -58,23 +58,33 @@
 
 class TestBase {
    public:
-      TestBase() : m_value(0) {}
-      TestBase(const int value) : m_value(value) {}
+      TestBase() {}
 
-      CHAI_HOST_DEVICE virtual int getValue() const { return m_value; }
-
-   protected:
-      int m_value;
-
+      CHAI_HOST_DEVICE virtual int getValue() const = 0;
 };
 
 class TestDerived : public TestBase {
    public:
-      TestDerived() : TestBase(1) {}
-      TestDerived(const int value) : TestBase(value) {}
+      TestDerived() : TestBase(), m_value(0) {}
+      TestDerived(const int value) : TestBase(), m_value(value) {}
 
       CHAI_HOST_DEVICE virtual int getValue() const { return m_value; }
+
+   private:
+      int m_value;
 };
+
+TEST(managed_ptr, DefaultConstructor)
+{
+  chai::managed_ptr<TestDerived> derived;
+  ASSERT_EQ(derived.get(), nullptr);
+}
+
+TEST(managed_ptr, nullptrConstructor)
+{
+  chai::managed_ptr<TestDerived> derived = nullptr;
+  ASSERT_EQ(derived.get(), nullptr);
+}
 
 TEST(managed_ptr, HostPtrConstructor)
 {

--- a/tests/unit/managed_ptr_unit_tests.cpp
+++ b/tests/unit/managed_ptr_unit_tests.cpp
@@ -1,0 +1,111 @@
+// ---------------------------------------------------------------------
+// Copyright (c) 2016-2018, Lawrence Livermore National Security, LLC. All
+// rights reserved.
+//
+// Produced at the Lawrence Livermore National Laboratory.
+//
+// This file is part of CHAI.
+//
+// LLNL-CODE-705877
+//
+// For details, see https:://github.com/LLNL/CHAI
+// Please also see the NOTICE and LICENSE files.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+// - Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+//
+// - Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the
+//   distribution.
+//
+// - Neither the name of the LLNS/LLNL nor the names of its contributors
+//   may be used to endorse or promote products derived from this
+//   software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+// OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+// AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+// WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+// ---------------------------------------------------------------------
+#include "gtest/gtest.h"
+
+#define CUDA_TEST(X, Y)              \
+  static void cuda_test_##X##Y();    \
+  TEST(X, Y) { cuda_test_##X##Y(); } \
+  static void cuda_test_##X##Y()
+
+#include "chai/config.hpp"
+
+#include "../src/util/forall.hpp"
+
+#include "chai/managed_ptr.hpp"
+
+// Standard library headers
+#include <cstdlib>
+
+class TestDerived {
+   public:
+      TestDerived() : m_value(0) {}
+      TestDerived(const int value) : m_value(value) {}
+
+      int getValue() const { return m_value; }
+
+   private:
+      int m_value;
+};
+
+TEST(managed_ptr, HostPtrConstructor)
+{
+  const int expectedValue = rand();
+  chai::managed_ptr<TestDerived> derived(new TestDerived(expectedValue));
+  ASSERT_EQ(derived->getValue(), expectedValue);
+}
+
+CUDA_TEST(managed_ptr, cuda_HostPtrConstructor)
+{
+  const int expectedValue = rand();
+  chai::managed_ptr<TestDerived> derived(new TestDerived(expectedValue));
+  chai::ManagedArray<int> array(1, chai::GPU);
+  
+  forall(cuda(), 0, 1, [=] __device__ (int i) {
+    array[i] = derived->getValue();
+  });
+
+  array.move(chai::CPU);
+  ASSERT_EQ(array[0], expectedValue);
+}
+
+TEST(managed_ptr, make_managed)
+{
+  const int expectedValue = rand();
+  auto derived = chai::make_managed<TestDerived>(expectedValue);
+  ASSERT_EQ((*derived).getValue(), expectedValue);
+}
+
+CUDA_TEST(managed_ptr, cuda_make_managed)
+{
+  const int expectedValue = rand();
+  auto derived = chai::make_managed<TestDerived>(expectedValue);
+  chai::ManagedArray<int> array(1, chai::GPU);
+  
+  forall(cuda(), 0, 1, [=] __device__ (int i) {
+    array[i] = (*derived).getValue();
+  });
+
+  array.move(chai::CPU);
+  ASSERT_EQ(array[0], expectedValue);
+}
+

--- a/tests/unit/managed_ptr_unit_tests.cpp
+++ b/tests/unit/managed_ptr_unit_tests.cpp
@@ -58,15 +58,15 @@
 
 class TestBase {
    public:
-      TestBase() {}
+      CHAI_HOST_DEVICE TestBase() {}
 
       CHAI_HOST_DEVICE virtual int getValue() const = 0;
 };
 
 class TestDerived : public TestBase {
    public:
-      TestDerived() : TestBase(), m_value(0) {}
-      TestDerived(const int value) : TestBase(), m_value(value) {}
+      CHAI_HOST_DEVICE TestDerived() : TestBase(), m_value(0) {}
+      CHAI_HOST_DEVICE TestDerived(const int value) : TestBase(), m_value(value) {}
 
       CHAI_HOST_DEVICE virtual int getValue() const { return m_value; }
 
@@ -74,171 +74,428 @@ class TestDerived : public TestBase {
       int m_value;
 };
 
-TEST(managed_ptr, DefaultConstructor)
+TEST(managed_ptr, default_constructor)
 {
   chai::managed_ptr<TestDerived> derived;
-  ASSERT_EQ(derived.get(), nullptr);
-  ASSERT_EQ(derived.use_count(), 0);
-  ASSERT_EQ(bool(derived), false);
-  ASSERT_EQ(derived, nullptr);
-  ASSERT_EQ(nullptr, derived);
+  chai::managed_ptr<TestDerived> otherDerived;
+
+  EXPECT_EQ(derived.get(), nullptr);
+  EXPECT_EQ(derived.use_count(), 0);
+  EXPECT_FALSE(derived);
+  EXPECT_TRUE(derived == nullptr);
+  EXPECT_TRUE(nullptr == derived);
+  EXPECT_FALSE(derived != nullptr);
+  EXPECT_FALSE(nullptr != derived);
+  EXPECT_TRUE(derived == otherDerived);
+  EXPECT_TRUE(otherDerived == derived);
+  EXPECT_FALSE(derived != otherDerived);
+  EXPECT_FALSE(otherDerived != derived);
 }
 
-TEST(managed_ptr, nullptrConstructor)
+CUDA_TEST(managed_ptr, cuda_default_constructor)
+{
+  chai::managed_ptr<TestDerived> derived;
+  chai::managed_ptr<TestDerived> otherDerived;
+
+  chai::ManagedArray<TestDerived*> array(1, chai::GPU);
+  chai::ManagedArray<bool> array2(9, chai::GPU);
+  
+  forall(cuda(), 0, 1, [=] __device__ (int i) {
+    array[i] = derived.get();
+    array2[0] = (bool) derived;
+    array2[1] = derived == nullptr;
+    array2[2] = nullptr == derived;
+    array2[3] = derived != nullptr;
+    array2[4] = nullptr != derived;
+    array2[5] = derived == otherDerived;
+    array2[6] = otherDerived == derived;
+    array2[7] = derived != otherDerived;
+    array2[8] = otherDerived != derived;
+  });
+
+  array.move(chai::CPU);
+  array2.move(chai::CPU);
+
+  EXPECT_EQ(array[0], nullptr);
+  EXPECT_FALSE(array2[0]);
+  EXPECT_TRUE(array2[1]);
+  EXPECT_TRUE(array2[2]);
+  EXPECT_FALSE(array2[3]);
+  EXPECT_FALSE(array2[4]);
+  EXPECT_TRUE(array2[5]);
+  EXPECT_TRUE(array2[6]);
+  EXPECT_FALSE(array2[7]);
+  EXPECT_FALSE(array2[8]);
+}
+
+TEST(managed_ptr, nullptr_constructor)
 {
   chai::managed_ptr<TestDerived> derived = nullptr;
-  ASSERT_EQ(derived.get(), nullptr);
-  ASSERT_EQ(derived.use_count(), 0);
-  ASSERT_EQ(bool(derived), false);
-  ASSERT_EQ(derived, nullptr);
-  ASSERT_EQ(nullptr, derived);
+  chai::managed_ptr<TestDerived> otherDerived = nullptr;
+
+  EXPECT_EQ(derived.get(), nullptr);
+  EXPECT_EQ(derived.use_count(), 0);
+  EXPECT_FALSE(derived);
+  EXPECT_TRUE(derived == nullptr);
+  EXPECT_TRUE(nullptr == derived);
+  EXPECT_FALSE(derived != nullptr);
+  EXPECT_FALSE(nullptr != derived);
+  EXPECT_TRUE(derived == otherDerived);
+  EXPECT_TRUE(otherDerived == derived);
+  EXPECT_FALSE(derived != otherDerived);
+  EXPECT_FALSE(otherDerived != derived);
 }
 
-TEST(managed_ptr, HostPtrConstructor)
+CUDA_TEST(managed_ptr, cuda_nullptr_constructor)
 {
-  const int expectedValue = rand();
-  chai::managed_ptr<TestDerived> derived(new TestDerived(expectedValue));
-  ASSERT_EQ(derived->getValue(), expectedValue);
+  chai::managed_ptr<TestDerived> derived = nullptr;
+  chai::managed_ptr<TestDerived> otherDerived = nullptr;
 
-  ASSERT_NE(derived.get(), nullptr);
-  ASSERT_EQ(derived.use_count(), 1);
-  ASSERT_EQ(bool(derived), true);
-  ASSERT_NE(derived, nullptr);
-  ASSERT_NE(nullptr, derived);
-}
-
-CUDA_TEST(managed_ptr, cuda_HostPtrConstructor)
-{
-  const int expectedValue = rand();
-  chai::managed_ptr<TestDerived> derived(new TestDerived(expectedValue));
-  chai::ManagedArray<int> array(1, chai::GPU);
+  chai::ManagedArray<TestDerived*> array(1, chai::GPU);
+  chai::ManagedArray<bool> array2(7, chai::GPU);
   
   forall(cuda(), 0, 1, [=] __device__ (int i) {
-    array[i] = derived->getValue();
+    array[i] = derived.get();
+    array2[0] = (bool) derived;
+    array2[1] = derived == nullptr;
+    array2[2] = nullptr == derived;
+    array2[3] = derived != nullptr;
+    array2[4] = nullptr != derived;
+    array2[5] = derived == otherDerived;
+    array2[6] = otherDerived == derived;
+    array2[7] = derived != otherDerived;
+    array2[8] = otherDerived != derived;
   });
 
   array.move(chai::CPU);
-  ASSERT_EQ(array[0], expectedValue);
-}
+  array2.move(chai::CPU);
 
-TEST(managed_ptr, ConvertingPtrConstructor)
-{
-  const int expectedValue = rand();
-  chai::managed_ptr<TestBase> derived(new TestDerived(expectedValue));
-  ASSERT_EQ(derived->getValue(), expectedValue);
-
-  ASSERT_NE(derived.get(), nullptr);
-  ASSERT_EQ(derived.use_count(), 1);
-  ASSERT_EQ(bool(derived), true);
-  ASSERT_NE(derived, nullptr);
-  ASSERT_NE(nullptr, derived);
-}
-
-CUDA_TEST(managed_ptr, cuda_ConvertingPtrConstructor)
-{
-  const int expectedValue = rand();
-  chai::managed_ptr<TestBase> derived(new TestDerived(expectedValue));
-  chai::ManagedArray<int> array(1, chai::GPU);
-  
-  forall(cuda(), 0, 1, [=] __device__ (int i) {
-    array[i] = derived->getValue();
-  });
-
-  array.move(chai::CPU);
-  ASSERT_EQ(array[0], expectedValue);
+  EXPECT_EQ(array[0], nullptr);
+  EXPECT_FALSE(array2[0]);
+  EXPECT_TRUE(array2[1]);
+  EXPECT_TRUE(array2[2]);
+  EXPECT_FALSE(array2[3]);
+  EXPECT_FALSE(array2[4]);
+  EXPECT_TRUE(array2[5]);
+  EXPECT_TRUE(array2[6]);
+  EXPECT_FALSE(array2[7]);
+  EXPECT_FALSE(array2[8]);
 }
 
 TEST(managed_ptr, make_managed)
 {
   const int expectedValue = rand();
   auto derived = chai::make_managed<TestDerived>(expectedValue);
-  ASSERT_EQ((*derived).getValue(), expectedValue);
 
-  ASSERT_NE(derived.get(), nullptr);
-  ASSERT_EQ(derived.use_count(), 1);
-  ASSERT_EQ(bool(derived), true);
-  ASSERT_NE(derived, nullptr);
-  ASSERT_NE(nullptr, derived);
+  EXPECT_EQ((*derived).getValue(), expectedValue);
+
+  EXPECT_NE(derived.get(), nullptr);
+  EXPECT_EQ(derived.use_count(), 1);
+  EXPECT_TRUE(derived);
+  EXPECT_FALSE(derived == nullptr);
+  EXPECT_FALSE(nullptr == derived);
+  EXPECT_TRUE(derived != nullptr);
+  EXPECT_TRUE(nullptr != derived);
 }
 
 CUDA_TEST(managed_ptr, cuda_make_managed)
 {
   const int expectedValue = rand();
   auto derived = chai::make_managed<TestDerived>(expectedValue);
+
   chai::ManagedArray<int> array(1, chai::GPU);
+  chai::ManagedArray<TestDerived*> array2(1, chai::GPU);
+  chai::ManagedArray<bool> array3(7, chai::GPU);
   
   forall(cuda(), 0, 1, [=] __device__ (int i) {
-    array[i] = (*derived).getValue();
+    array[i] = derived->getValue();
+    array2[i] = derived.get();
+    array3[0] = (bool) derived;
+    array3[1] = derived == nullptr;
+    array3[2] = nullptr == derived;
+    array3[3] = derived != nullptr;
+    array3[4] = nullptr != derived;
   });
 
   array.move(chai::CPU);
-  ASSERT_EQ(array[0], expectedValue);
-}
+  array2.move(chai::CPU);
+  array3.move(chai::CPU);
 
-TEST(managed_ptr, converting_make_managed)
-{
-  const int expectedValue = rand();
-  chai::managed_ptr<TestBase> derived = chai::make_managed<TestDerived>(expectedValue);
-  ASSERT_EQ((*derived).getValue(), expectedValue);
+  EXPECT_EQ(array[0], expectedValue);
 
-  ASSERT_NE(derived.get(), nullptr);
-  ASSERT_EQ(derived.use_count(), 1);
-  ASSERT_EQ(bool(derived), true);
-  ASSERT_NE(derived, nullptr);
-  ASSERT_NE(nullptr, derived);
-}
-
-CUDA_TEST(managed_ptr, cuda_converting_make_managed)
-{
-  const int expectedValue = rand();
-  chai::managed_ptr<TestBase> derived = chai::make_managed<TestDerived>(expectedValue);
-  chai::ManagedArray<int> array(1, chai::GPU);
-  
-  forall(cuda(), 0, 1, [=] __device__ (int i) {
-    array[i] = (*derived).getValue();
-  });
-
-  array.move(chai::CPU);
-  ASSERT_EQ(array[0], expectedValue);
+  EXPECT_NE(array2[0], nullptr);
+  EXPECT_EQ(derived.use_count(), 1);
+  EXPECT_TRUE(array3[0]);
+  EXPECT_FALSE(array3[1]);
+  EXPECT_FALSE(array3[2]);
+  EXPECT_TRUE(array3[3]);
+  EXPECT_TRUE(array3[4]);
 }
 
 TEST(managed_ptr, copy_constructor)
 {
   const int expectedValue = rand();
-  chai::managed_ptr<TestDerived> derived(new TestDerived(expectedValue));
+  auto derived = chai::make_managed<TestDerived>(expectedValue);
   chai::managed_ptr<TestDerived> otherDerived(derived);
 
-  ASSERT_NE(derived.get(), nullptr);
-  ASSERT_EQ(derived.use_count(), 2);
-  ASSERT_EQ(bool(derived), true);
-  ASSERT_NE(derived, nullptr);
-  ASSERT_NE(nullptr, derived);
+  EXPECT_EQ(derived->getValue(), expectedValue);
+  EXPECT_EQ(otherDerived->getValue(), expectedValue);
 
-  ASSERT_NE(otherDerived.get(), nullptr);
-  ASSERT_EQ(otherDerived.use_count(), 2);
-  ASSERT_EQ(bool(otherDerived), true);
-  ASSERT_NE(otherDerived, nullptr);
-  ASSERT_NE(nullptr, otherDerived);
+  EXPECT_NE(derived.get(), nullptr);
+  EXPECT_EQ(derived.use_count(), 2);
+  EXPECT_TRUE(derived);
+  EXPECT_FALSE(derived == nullptr);
+  EXPECT_FALSE(nullptr == derived);
+  EXPECT_TRUE(derived != nullptr);
+  EXPECT_TRUE(nullptr != derived);
+  EXPECT_TRUE(derived == otherDerived);
+  EXPECT_FALSE(derived != otherDerived);
+
+  EXPECT_NE(otherDerived.get(), nullptr);
+  EXPECT_EQ(otherDerived.use_count(), 2);
+  EXPECT_TRUE(otherDerived);
+  EXPECT_FALSE(otherDerived == nullptr);
+  EXPECT_FALSE(nullptr == otherDerived);
+  EXPECT_TRUE(otherDerived != nullptr);
+  EXPECT_TRUE(nullptr != otherDerived);
+  EXPECT_TRUE(otherDerived == derived);
+  EXPECT_FALSE(otherDerived != derived);
+}
+
+CUDA_TEST(managed_ptr, cuda_copy_constructor)
+{
+  const int expectedValue = rand();
+  auto derived = chai::make_managed<TestDerived>(expectedValue);
+  chai::managed_ptr<TestDerived> otherDerived(derived);
+
+  chai::ManagedArray<int> array(2, chai::GPU);
+  chai::ManagedArray<TestDerived*> array2(2, chai::GPU);
+  chai::ManagedArray<bool> array3(14, chai::GPU);
+  
+  forall(cuda(), 0, 1, [=] __device__ (int i) {
+    array[i] = derived->getValue();
+    array2[0] = derived.get();
+    array3[0] = (bool) derived;
+    array3[1] = derived == nullptr;
+    array3[2] = nullptr == derived;
+    array3[3] = derived != nullptr;
+    array3[4] = nullptr != derived;
+    array3[5] = derived == otherDerived;
+    array3[6] = derived != otherDerived;
+
+    array[1] = otherDerived->getValue();
+    array2[1] = otherDerived.get();
+    array3[7] = (bool) derived;
+    array3[8] = derived == nullptr;
+    array3[9] = nullptr == derived;
+    array3[10] = derived != nullptr;
+    array3[11] = nullptr != derived;
+    array3[12] = derived == otherDerived;
+    array3[13] = derived != otherDerived;
+  });
+
+  array.move(chai::CPU);
+  array2.move(chai::CPU);
+  array3.move(chai::CPU);
+
+  EXPECT_EQ(array[0], expectedValue);
+  EXPECT_EQ(array[1], expectedValue);
+
+  EXPECT_NE(array2[0], nullptr);
+  EXPECT_TRUE(array3[0]);
+  EXPECT_FALSE(array3[1]);
+  EXPECT_FALSE(array3[2]);
+  EXPECT_TRUE(array3[3]);
+  EXPECT_TRUE(array3[4]);
+  EXPECT_TRUE(array3[5]);
+  EXPECT_FALSE(array3[6]);
+
+  EXPECT_NE(array2[1], nullptr);
+  EXPECT_TRUE(array3[7]);
+  EXPECT_FALSE(array3[8]);
+  EXPECT_FALSE(array3[9]);
+  EXPECT_TRUE(array3[10]);
+  EXPECT_TRUE(array3[11]);
+  EXPECT_TRUE(array3[12]);
+  EXPECT_FALSE(array3[13]);
+}
+
+TEST(managed_ptr, converting_constructor)
+{
+  const int expectedValue = rand();
+  auto derived = chai::make_managed<TestDerived>(expectedValue);
+  chai::managed_ptr<TestBase> base = derived;
+
+  EXPECT_EQ(derived->getValue(), expectedValue);
+  EXPECT_EQ(base->getValue(), expectedValue);
+
+  EXPECT_NE(derived.get(), nullptr);
+  EXPECT_EQ(derived.use_count(), 2);
+  EXPECT_TRUE(derived);
+  EXPECT_FALSE(derived == nullptr);
+  EXPECT_FALSE(nullptr == derived);
+  EXPECT_TRUE(derived != nullptr);
+  EXPECT_TRUE(nullptr != derived);
+  EXPECT_TRUE(derived == base);
+  EXPECT_FALSE(derived != base);
+
+  EXPECT_NE(base.get(), nullptr);
+  EXPECT_EQ(base.use_count(), 2);
+  EXPECT_TRUE(base);
+  EXPECT_FALSE(base == nullptr);
+  EXPECT_FALSE(nullptr == base);
+  EXPECT_TRUE(base != nullptr);
+  EXPECT_TRUE(nullptr != base);
+  EXPECT_TRUE(base == derived);
+  EXPECT_FALSE(base != derived);
+}
+
+CUDA_TEST(managed_ptr, cuda_converting_constructor)
+{
+  const int expectedValue = rand();
+  auto derived = chai::make_managed<TestDerived>(expectedValue);
+  chai::managed_ptr<TestBase> base(derived);
+
+  chai::ManagedArray<int> array(2, chai::GPU);
+  chai::ManagedArray<TestBase*> array2(2, chai::GPU);
+  chai::ManagedArray<bool> array3(14, chai::GPU);
+  
+  forall(cuda(), 0, 1, [=] __device__ (int i) {
+    array[i] = derived->getValue();
+    array2[0] = derived.get();
+    array3[0] = (bool) derived;
+    array3[1] = derived == nullptr;
+    array3[2] = nullptr == derived;
+    array3[3] = derived != nullptr;
+    array3[4] = nullptr != derived;
+    array3[5] = derived == base;
+    array3[6] = derived != base;
+
+    array[1] = base->getValue();
+    array2[1] = base.get();
+    array3[7] = (bool) base;
+    array3[8] = base == nullptr;
+    array3[9] = nullptr == base;
+    array3[10] = base != nullptr;
+    array3[11] = nullptr != base;
+    array3[12] = base == derived;
+    array3[13] = base != derived;
+  });
+
+  array.move(chai::CPU);
+  array2.move(chai::CPU);
+  array3.move(chai::CPU);
+
+  EXPECT_EQ(array[0], expectedValue);
+  EXPECT_EQ(array[1], expectedValue);
+
+  EXPECT_NE(array2[0], nullptr);
+  EXPECT_TRUE(array3[0]);
+  EXPECT_FALSE(array3[1]);
+  EXPECT_FALSE(array3[2]);
+  EXPECT_TRUE(array3[3]);
+  EXPECT_TRUE(array3[4]);
+  EXPECT_TRUE(array3[5]);
+  EXPECT_FALSE(array3[6]);
+
+  EXPECT_NE(array2[1], nullptr);
+  EXPECT_TRUE(array3[7]);
+  EXPECT_FALSE(array3[8]);
+  EXPECT_FALSE(array3[9]);
+  EXPECT_TRUE(array3[10]);
+  EXPECT_TRUE(array3[11]);
+  EXPECT_TRUE(array3[12]);
+  EXPECT_FALSE(array3[13]);
 }
 
 TEST(managed_ptr, copy_assignment_operator)
 {
   const int expectedValue = rand();
-  chai::managed_ptr<TestDerived> derived(new TestDerived(expectedValue));
+  auto derived = chai::make_managed<TestDerived>(expectedValue);
   chai::managed_ptr<TestDerived> otherDerived;
   otherDerived = derived;
 
-  ASSERT_NE(derived.get(), nullptr);
-  ASSERT_EQ(derived.use_count(), 2);
-  ASSERT_EQ(bool(derived), true);
-  ASSERT_NE(derived, nullptr);
-  ASSERT_NE(nullptr, derived);
+  EXPECT_EQ(derived->getValue(), expectedValue);
+  EXPECT_EQ(otherDerived->getValue(), expectedValue);
 
-  ASSERT_NE(otherDerived.get(), nullptr);
-  ASSERT_EQ(otherDerived.use_count(), 2);
-  ASSERT_EQ(bool(otherDerived), true);
-  ASSERT_NE(otherDerived, nullptr);
-  ASSERT_NE(nullptr, otherDerived);
+  EXPECT_NE(derived.get(), nullptr);
+  EXPECT_EQ(derived.use_count(), 2);
+  EXPECT_TRUE(derived);
+  EXPECT_FALSE(derived == nullptr);
+  EXPECT_FALSE(nullptr == derived);
+  EXPECT_TRUE(derived != nullptr);
+  EXPECT_TRUE(nullptr != derived);
+  EXPECT_TRUE(derived == otherDerived);
+  EXPECT_FALSE(derived != otherDerived);
+
+  EXPECT_NE(otherDerived.get(), nullptr);
+  EXPECT_EQ(otherDerived.use_count(), 2);
+  EXPECT_TRUE(otherDerived);
+  EXPECT_FALSE(otherDerived == nullptr);
+  EXPECT_FALSE(nullptr == otherDerived);
+  EXPECT_TRUE(otherDerived != nullptr);
+  EXPECT_TRUE(nullptr != otherDerived);
+  EXPECT_TRUE(otherDerived == derived);
+  EXPECT_FALSE(otherDerived != derived);
+}
+
+CUDA_TEST(managed_ptr, cuda_copy_assignment_operator)
+{
+  const int expectedValue = rand();
+  auto derived = chai::make_managed<TestDerived>(expectedValue);
+  chai::managed_ptr<TestDerived> otherDerived;
+  otherDerived = derived;
+
+  chai::ManagedArray<int> array(2, chai::GPU);
+  chai::ManagedArray<TestDerived*> array2(2, chai::GPU);
+  chai::ManagedArray<bool> array3(14, chai::GPU);
+  
+  forall(cuda(), 0, 1, [=] __device__ (int i) {
+    array[i] = derived->getValue();
+    array2[0] = derived.get();
+    array3[0] = (bool) derived;
+    array3[1] = derived == nullptr;
+    array3[2] = nullptr == derived;
+    array3[3] = derived != nullptr;
+    array3[4] = nullptr != derived;
+    array3[5] = derived == otherDerived;
+    array3[6] = derived != otherDerived;
+
+    array[1] = otherDerived->getValue();
+    array2[1] = otherDerived.get();
+    array3[7] = (bool) derived;
+    array3[8] = derived == nullptr;
+    array3[9] = nullptr == derived;
+    array3[10] = derived != nullptr;
+    array3[11] = nullptr != derived;
+    array3[12] = derived == otherDerived;
+    array3[13] = derived != otherDerived;
+  });
+
+  array.move(chai::CPU);
+  array2.move(chai::CPU);
+  array3.move(chai::CPU);
+
+  EXPECT_EQ(array[0], expectedValue);
+  EXPECT_EQ(array[1], expectedValue);
+
+  EXPECT_NE(array2[0], nullptr);
+  EXPECT_TRUE(array3[0]);
+  EXPECT_FALSE(array3[1]);
+  EXPECT_FALSE(array3[2]);
+  EXPECT_TRUE(array3[3]);
+  EXPECT_TRUE(array3[4]);
+  EXPECT_TRUE(array3[5]);
+  EXPECT_FALSE(array3[6]);
+
+  EXPECT_NE(array2[1], nullptr);
+  EXPECT_TRUE(array3[7]);
+  EXPECT_FALSE(array3[8]);
+  EXPECT_FALSE(array3[9]);
+  EXPECT_TRUE(array3[10]);
+  EXPECT_TRUE(array3[11]);
+  EXPECT_TRUE(array3[12]);
+  EXPECT_FALSE(array3[13]);
 }
 
 TEST(managed_ptr, copy_constructor_from_default_constructed)
@@ -246,17 +503,17 @@ TEST(managed_ptr, copy_constructor_from_default_constructed)
   chai::managed_ptr<TestDerived> derived;
   chai::managed_ptr<TestDerived> otherDerived(derived);
 
-  ASSERT_EQ(derived.get(), nullptr);
-  ASSERT_EQ(derived.use_count(), 0);
-  ASSERT_EQ(bool(derived), false);
-  ASSERT_EQ(derived, nullptr);
-  ASSERT_EQ(nullptr, derived);
+  EXPECT_EQ(derived.get(), nullptr);
+  EXPECT_EQ(derived.use_count(), 0);
+  EXPECT_EQ(bool(derived), false);
+  EXPECT_EQ(derived, nullptr);
+  EXPECT_EQ(nullptr, derived);
 
-  ASSERT_EQ(otherDerived.get(), nullptr);
-  ASSERT_EQ(otherDerived.use_count(), 0);
-  ASSERT_EQ(bool(otherDerived), false);
-  ASSERT_EQ(otherDerived, nullptr);
-  ASSERT_EQ(nullptr, otherDerived);
+  EXPECT_EQ(otherDerived.get(), nullptr);
+  EXPECT_EQ(otherDerived.use_count(), 0);
+  EXPECT_EQ(bool(otherDerived), false);
+  EXPECT_EQ(otherDerived, nullptr);
+  EXPECT_EQ(nullptr, otherDerived);
 }
 
 TEST(managed_ptr, copy_assignment_operator_from_default_constructed)
@@ -265,17 +522,17 @@ TEST(managed_ptr, copy_assignment_operator_from_default_constructed)
   chai::managed_ptr<TestDerived> otherDerived;
   otherDerived = derived;
 
-  ASSERT_EQ(derived.get(), nullptr);
-  ASSERT_EQ(derived.use_count(), 0);
-  ASSERT_EQ(bool(derived), false);
-  ASSERT_EQ(derived, nullptr);
-  ASSERT_EQ(nullptr, derived);
+  EXPECT_EQ(derived.get(), nullptr);
+  EXPECT_EQ(derived.use_count(), 0);
+  EXPECT_EQ(bool(derived), false);
+  EXPECT_EQ(derived, nullptr);
+  EXPECT_EQ(nullptr, derived);
 
-  ASSERT_EQ(otherDerived.get(), nullptr);
-  ASSERT_EQ(otherDerived.use_count(), 0);
-  ASSERT_EQ(bool(otherDerived), false);
-  ASSERT_EQ(otherDerived, nullptr);
-  ASSERT_EQ(nullptr, otherDerived);
+  EXPECT_EQ(otherDerived.get(), nullptr);
+  EXPECT_EQ(otherDerived.use_count(), 0);
+  EXPECT_EQ(bool(otherDerived), false);
+  EXPECT_EQ(otherDerived, nullptr);
+  EXPECT_EQ(nullptr, otherDerived);
 }
 
 TEST(managed_ptr, conversion_copy_constructor_from_default_constructed)
@@ -283,17 +540,17 @@ TEST(managed_ptr, conversion_copy_constructor_from_default_constructed)
   chai::managed_ptr<TestDerived> derived;
   chai::managed_ptr<TestBase> otherDerived(derived);
 
-  ASSERT_EQ(derived.get(), nullptr);
-  ASSERT_EQ(derived.use_count(), 0);
-  ASSERT_EQ(bool(derived), false);
-  ASSERT_EQ(derived, nullptr);
-  ASSERT_EQ(nullptr, derived);
+  EXPECT_EQ(derived.get(), nullptr);
+  EXPECT_EQ(derived.use_count(), 0);
+  EXPECT_EQ(bool(derived), false);
+  EXPECT_EQ(derived, nullptr);
+  EXPECT_EQ(nullptr, derived);
 
-  ASSERT_EQ(otherDerived.get(), nullptr);
-  ASSERT_EQ(otherDerived.use_count(), 0);
-  ASSERT_EQ(bool(otherDerived), false);
-  ASSERT_EQ(otherDerived, nullptr);
-  ASSERT_EQ(nullptr, otherDerived);
+  EXPECT_EQ(otherDerived.get(), nullptr);
+  EXPECT_EQ(otherDerived.use_count(), 0);
+  EXPECT_EQ(bool(otherDerived), false);
+  EXPECT_EQ(otherDerived, nullptr);
+  EXPECT_EQ(nullptr, otherDerived);
 }
 
 TEST(managed_ptr, conversion_copy_assignment_operator_from_default_constructed)
@@ -302,17 +559,17 @@ TEST(managed_ptr, conversion_copy_assignment_operator_from_default_constructed)
   chai::managed_ptr<TestBase> otherDerived;
   otherDerived = derived;
 
-  ASSERT_EQ(derived.get(), nullptr);
-  ASSERT_EQ(derived.use_count(), 0);
-  ASSERT_EQ(bool(derived), false);
-  ASSERT_EQ(derived, nullptr);
-  ASSERT_EQ(nullptr, derived);
+  EXPECT_EQ(derived.get(), nullptr);
+  EXPECT_EQ(derived.use_count(), 0);
+  EXPECT_EQ(bool(derived), false);
+  EXPECT_EQ(derived, nullptr);
+  EXPECT_EQ(nullptr, derived);
 
-  ASSERT_EQ(otherDerived.get(), nullptr);
-  ASSERT_EQ(otherDerived.use_count(), 0);
-  ASSERT_EQ(bool(otherDerived), false);
-  ASSERT_EQ(otherDerived, nullptr);
-  ASSERT_EQ(nullptr, otherDerived);
+  EXPECT_EQ(otherDerived.get(), nullptr);
+  EXPECT_EQ(otherDerived.use_count(), 0);
+  EXPECT_EQ(bool(otherDerived), false);
+  EXPECT_EQ(otherDerived, nullptr);
+  EXPECT_EQ(nullptr, otherDerived);
 }
 
 TEST(managed_ptr, copy_assignment_operator_from_host_ptr_constructed)
@@ -320,29 +577,29 @@ TEST(managed_ptr, copy_assignment_operator_from_host_ptr_constructed)
   const int expectedValue1 = rand();
   const int expectedValue2 = rand();
 
-  chai::managed_ptr<TestDerived> derived(new TestDerived(expectedValue1));
-  chai::managed_ptr<TestDerived> otherDerived(new TestDerived(expectedValue2));
+  chai::managed_ptr<TestDerived> derived = chai::make_managed<TestDerived>(expectedValue1);
+  chai::managed_ptr<TestDerived> otherDerived = chai::make_managed<TestDerived>(expectedValue2);
   chai::managed_ptr<TestDerived> thirdDerived(otherDerived);
 
   thirdDerived = derived;
 
-  ASSERT_NE(derived.get(), nullptr);
-  ASSERT_EQ(derived.use_count(), 2);
-  ASSERT_EQ(bool(derived), true);
-  ASSERT_NE(derived, nullptr);
-  ASSERT_NE(nullptr, derived);
+  EXPECT_NE(derived.get(), nullptr);
+  EXPECT_EQ(derived.use_count(), 2);
+  EXPECT_EQ(bool(derived), true);
+  EXPECT_NE(derived, nullptr);
+  EXPECT_NE(nullptr, derived);
 
-  ASSERT_NE(otherDerived.get(), nullptr);
-  ASSERT_EQ(otherDerived.use_count(), 1);
-  ASSERT_EQ(bool(otherDerived), true);
-  ASSERT_NE(otherDerived, nullptr);
-  ASSERT_NE(nullptr, otherDerived);
+  EXPECT_NE(otherDerived.get(), nullptr);
+  EXPECT_EQ(otherDerived.use_count(), 1);
+  EXPECT_EQ(bool(otherDerived), true);
+  EXPECT_NE(otherDerived, nullptr);
+  EXPECT_NE(nullptr, otherDerived);
 
-  ASSERT_NE(thirdDerived.get(), nullptr);
-  ASSERT_EQ(thirdDerived.use_count(), 2);
-  ASSERT_EQ(bool(thirdDerived), true);
-  ASSERT_NE(thirdDerived, nullptr);
-  ASSERT_NE(nullptr, thirdDerived);
+  EXPECT_NE(thirdDerived.get(), nullptr);
+  EXPECT_EQ(thirdDerived.use_count(), 2);
+  EXPECT_EQ(bool(thirdDerived), true);
+  EXPECT_NE(thirdDerived, nullptr);
+  EXPECT_NE(nullptr, thirdDerived);
 }
 
 TEST(managed_ptr, conversion_copy_assignment_operator_from_host_ptr_constructed)
@@ -350,28 +607,28 @@ TEST(managed_ptr, conversion_copy_assignment_operator_from_host_ptr_constructed)
   const int expectedValue1 = rand();
   const int expectedValue2 = rand();
 
-  chai::managed_ptr<TestDerived> derived(new TestDerived(expectedValue1));
-  chai::managed_ptr<TestDerived> otherDerived(new TestDerived(expectedValue2));
+  chai::managed_ptr<TestDerived> derived = chai::make_managed<TestDerived>(expectedValue1);
+  chai::managed_ptr<TestDerived> otherDerived = chai::make_managed<TestDerived>(expectedValue2);
   chai::managed_ptr<TestBase> thirdDerived(otherDerived);
 
   thirdDerived = derived;
 
-  ASSERT_NE(derived.get(), nullptr);
-  ASSERT_EQ(derived.use_count(), 2);
-  ASSERT_EQ(bool(derived), true);
-  ASSERT_NE(derived, nullptr);
-  ASSERT_NE(nullptr, derived);
+  EXPECT_NE(derived.get(), nullptr);
+  EXPECT_EQ(derived.use_count(), 2);
+  EXPECT_EQ(bool(derived), true);
+  EXPECT_NE(derived, nullptr);
+  EXPECT_NE(nullptr, derived);
 
-  ASSERT_NE(otherDerived.get(), nullptr);
-  ASSERT_EQ(otherDerived.use_count(), 1);
-  ASSERT_EQ(bool(otherDerived), true);
-  ASSERT_NE(otherDerived, nullptr);
-  ASSERT_NE(nullptr, otherDerived);
+  EXPECT_NE(otherDerived.get(), nullptr);
+  EXPECT_EQ(otherDerived.use_count(), 1);
+  EXPECT_EQ(bool(otherDerived), true);
+  EXPECT_NE(otherDerived, nullptr);
+  EXPECT_NE(nullptr, otherDerived);
 
-  ASSERT_NE(thirdDerived.get(), nullptr);
-  ASSERT_EQ(thirdDerived.use_count(), 2);
-  ASSERT_EQ(bool(thirdDerived), true);
-  ASSERT_NE(thirdDerived, nullptr);
-  ASSERT_NE(nullptr, thirdDerived);
+  EXPECT_NE(thirdDerived.get(), nullptr);
+  EXPECT_EQ(thirdDerived.use_count(), 2);
+  EXPECT_EQ(bool(thirdDerived), true);
+  EXPECT_NE(thirdDerived, nullptr);
+  EXPECT_NE(nullptr, thirdDerived);
 }
 


### PR DESCRIPTION
Here is another implementation that requires even less changes to the original class hierarchy. In particular, a copy constructor is no longer required. The class can still have raw arrays, and if ManagedArrays are passed to the make_managed factory function, managed_ptr will pass on the appropriate host and device pointers and maintain a copy of the ManagedArrays to call the copy constructor on to trigger the necessary data movement.