### PR TITLE
Support for AMD's HIP in CHAI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ cmake_policy(SET CMP0057 NEW)
 project(Chai LANGUAGES CXX)
 
 set(ENABLE_CUDA On CACHE BOOL "Enable CUDA")
+set(ENABLE_HIP On CACHE BOOL "Enable HIP")
 set(ENABLE_OPENMP On CACHE BOOL "Enable OpenMP")
 set(ENABLE_BENCHMARKS On CACHE BOOL "Enable benchmarks")
 option(ENABLE_IMPLICIT_CONVERSIONS "Enable implicit conversions to-from raw pointers" On)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,8 @@ cmake_policy(SET CMP0057 NEW)
 
 project(Chai LANGUAGES CXX)
 
-set(ENABLE_CUDA On CACHE BOOL "Enable CUDA")
-set(ENABLE_HIP On CACHE BOOL "Enable HIP")
+set(ENABLE_CUDA Off CACHE BOOL "Enable CUDA")
+set(ENABLE_HIP Off CACHE BOOL "Enable HIP")
 set(ENABLE_OPENMP On CACHE BOOL "Enable OpenMP")
 set(ENABLE_BENCHMARKS On CACHE BOOL "Enable benchmarks")
 option(ENABLE_IMPLICIT_CONVERSIONS "Enable implicit conversions to-from raw pointers" On)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -50,6 +50,11 @@ if (ENABLE_CUDA)
     ${chai_benchmark_depends}
     cuda)
 endif ()
+if (ENABLE_HIP)
+  set (chai_benchmark_depends
+    ${chai_benchmark_depends}
+    hip)
+endif ()
 
 blt_add_executable(
   NAME arraymanager_benchmarks

--- a/benchmarks/chai_managedarray_benchmarks.cpp
+++ b/benchmarks/chai_managedarray_benchmarks.cpp
@@ -72,7 +72,7 @@ void benchmark_managedarray_alloc_cpu(benchmark::State& state)
 BENCHMARK(benchmark_managedarray_alloc_default)->Range(1, INT_MAX);
 BENCHMARK(benchmark_managedarray_alloc_cpu)->Range(1, INT_MAX);
 
-#if defined(CHAI_ENABLE_CUDA)
+#if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
 void benchmark_managedarray_alloc_gpu(benchmark::State& state)
 {
   while (state.KeepRunning()) {
@@ -86,7 +86,7 @@ BENCHMARK(benchmark_managedarray_alloc_gpu)->Range(1, INT_MAX);
 #endif
 
 
-#if defined(CHAI_ENABLE_CUDA)
+#if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
 void benchmark_managedarray_move(benchmark::State& state)
 {
   chai::ManagedArray<char> array(state.range(0));
@@ -99,7 +99,7 @@ void benchmark_managedarray_move(benchmark::State& state)
    * Kernels just touch the data, but are still included in timing.
    */
   while (state.KeepRunning()) {
-    forall(cuda(), 0, 1, [=] __device__(int i) { array[i] = 'a'; });
+    forall(gpu(), 0, 1, [=] __device__(int i) { array[i] = 'a'; });
 
     forall(sequential(), 0, 1, [=](int i) { array[i] = 'b'; });
   }

--- a/cmake/ChaiBasics.cmake
+++ b/cmake/ChaiBasics.cmake
@@ -43,4 +43,9 @@
 
 set (CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda")
 
+if (ENABLE_HIP)
+  #bug in ROCm 2.4 is incorrectly warning about missing overrides
+  set(HIP_HIPCC_FLAGS "${HIP_HIPCC_FLAGS} -Wno-inconsistent-missing-override")
+endif()
+
 include(${PROJECT_SOURCE_DIR}/cmake/thirdparty/SetupChaiThirdparty.cmake)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -49,15 +49,20 @@ if (ENABLE_CUDA)
     ${chai_umpire_example_depends}
     cuda)
 endif()
+if (ENABLE_HIP)
+  set (chai_umpire_example_depends
+    ${chai_umpire_example_depends}
+    hip)
+endif()
 
 blt_add_executable(
   NAME chai-umpire-example.exe
   SOURCES chai-umpire-allocators.cpp
   DEPENDS_ON ${chai_umpire_example_depends})
 
-if (ENABLE_CUDA)
+if (ENABLE_CUDA OR ENABLE_HIP)
   blt_add_executable(
     NAME chai-example.exe
     SOURCES example.cpp
-    DEPENDS_ON cuda chai)
+    DEPENDS_ON ${chai_umpire_example_depends})
 endif ()

--- a/examples/chai-umpire-allocators.cpp
+++ b/examples/chai-umpire-allocators.cpp
@@ -57,7 +57,7 @@ int main(int CHAI_UNUSED_ARG(argc), char** CHAI_UNUSED_ARG(argv))
       rm.makeAllocator<umpire::strategy::DynamicPool>("cpu_pool",
                                                       rm.getAllocator("HOST"));
 
-#if defined(CHAI_ENABLE_CUDA)
+#if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
   auto gpu_pool =
       rm.makeAllocator<umpire::strategy::DynamicPool>("gpu_pool",
                                                       rm.getAllocator("DEVICE"));
@@ -65,20 +65,20 @@ int main(int CHAI_UNUSED_ARG(argc), char** CHAI_UNUSED_ARG(argv))
 
   chai::ManagedArray<float> array(100, 
       std::initializer_list<chai::ExecutionSpace>{chai::CPU
-#if defined(CHAI_ENABLE_CUDA)
+#if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
       , chai::GPU
 #endif
       },
       std::initializer_list<umpire::Allocator>{cpu_pool
-#if defined(CHAI_ENABLE_CUDA)
+#if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
       , gpu_pool
 #endif
       });
 
   forall(sequential(), 0, 100, [=](int i) { array[i] = 0.0f; });
 
-#if defined(CHAI_ENABLE_CUDA)
-  forall(cuda(), 0, 100, [=] __device__(int i) { array[i] = 1.0f * i; });
+#if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
+  forall(gpu(), 0, 100, [=] __device__(int i) { array[i] = 1.0f * i; });
 #else
   forall(sequential(), 0, 100, [=] (int i) { array[i] = 1.0f * i; });
 #endif

--- a/examples/ex1.cpp
+++ b/examples/ex1.cpp
@@ -53,7 +53,7 @@ int main(int CHAI_UNUSED_ARG(argc), char** CHAI_UNUSED_ARG(argv))
   /*
    * Fill data on the device
    */
-  forall(cuda(), 0, 50, [=] __device__(int i) { array[i] = i * 2.0f; });
+  forall(gpu(), 0, 50, [=] __device__(int i) { array[i] = i * 2.0f; });
 
   /*
    * Print the array on the host, data is automatically copied back.

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -72,7 +72,7 @@ int main(int CHAI_UNUSED_ARG(argc), char** CHAI_UNUSED_ARG(argv))
   std::cout << " ]" << std::endl;
 
   std::cout << "Setting v2 and device_array on device." << std::endl;
-  forall(cuda(), 0, 10, [=] __device__(int i) {
+  forall(gpu(), 0, 10, [=] __device__(int i) {
     v2[i] = v1[i] * 2.0f;
     device_array[i] = i;
   });
@@ -82,7 +82,7 @@ int main(int CHAI_UNUSED_ARG(argc), char** CHAI_UNUSED_ARG(argv))
   std::cout << " ]" << std::endl;
 
   std::cout << "Doubling v2 on device." << std::endl;
-  forall(cuda(), 0, 10, [=] __device__(int i) { v2[i] *= 2.0f; });
+  forall(gpu(), 0, 10, [=] __device__(int i) { v2[i] *= 2.0f; });
 
   std::cout << "Casting v2 to a pointer." << std::endl;
   float* raw_v2 = v2;

--- a/src/chai/ArrayManager.cpp
+++ b/src/chai/ArrayManager.cpp
@@ -52,6 +52,7 @@ namespace chai
 ArrayManager* ArrayManager::s_resource_manager_instance = nullptr;
 PointerRecord ArrayManager::s_null_record = PointerRecord();
 
+CHAI_HOST_DEVICE
 ArrayManager* ArrayManager::getInstance()
 {
   if (!s_resource_manager_instance) {
@@ -71,7 +72,7 @@ ArrayManager::ArrayManager()
 
   m_allocators[CPU] =
       new umpire::Allocator(m_resource_manager.getAllocator("HOST"));
-#if defined(CHAI_ENABLE_CUDA)
+#if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
   m_allocators[GPU] =
       new umpire::Allocator(m_resource_manager.getAllocator("DEVICE"));
 #endif
@@ -259,7 +260,7 @@ void ArrayManager::free(PointerRecord* pointer_record)
       }
       else
       {
-        delete m_resource_manager.deregisterAllocation(pointer_record->m_pointers[space]);
+        m_resource_manager.deregisterAllocation(pointer_record->m_pointers[space]);
       }
     }
   }
@@ -310,7 +311,7 @@ PointerRecord* ArrayManager::makeManaged(void* pointer,
 {
   m_resource_manager.registerAllocation(
       pointer,
-      new umpire::util::AllocationRecord{
+      umpire::util::AllocationRecord{
           pointer, size, m_allocators[space]->getAllocationStrategy()});
 
   auto pointer_record = new PointerRecord{};

--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -43,6 +43,7 @@
 #ifndef CHAI_ArrayManager_HPP
 #define CHAI_ArrayManager_HPP
 
+#include "chai/ChaiMacros.hpp"
 #include "chai/ExecutionSpaces.hpp"
 #include "chai/PointerRecord.hpp"
 #include "chai/Types.hpp"
@@ -87,6 +88,7 @@ public:
    * \return Pointer to the ArrayManager instance.
    *
    */
+  CHAI_HOST_DEVICE
   static ArrayManager* getInstance();
 
   /*!

--- a/src/chai/CMakeLists.txt
+++ b/src/chai/CMakeLists.txt
@@ -43,6 +43,7 @@
 
 set(CHAI_ENABLE_PICK ${ENABLE_PICK})
 set(CHAI_ENABLE_CUDA ${ENABLE_CUDA})
+set(CHAI_ENABLE_HIP ${ENABLE_HIP})
 set(CHAI_ENABLE_IMPLICIT_CONVERSIONS ${ENABLE_IMPLICIT_CONVERSIONS})
 set(CHAI_DISABLE_RM ${DISABLE_RM})
 set(CHAI_ENABLE_UM ${ENABLE_UM})
@@ -78,6 +79,12 @@ if (ENABLE_CUDA)
     ${chai_depends}
     cuda_runtime)
 endif ()
+if (ENABLE_HIP)
+  set (chai_depends
+    ${chai_depends}
+    hip_runtime)
+endif ()
+
 
 blt_add_library(
   NAME chai

--- a/src/chai/ChaiMacros.hpp
+++ b/src/chai/ChaiMacros.hpp
@@ -51,6 +51,14 @@
 #define CHAI_DEVICE __device__
 #define CHAI_HOST_DEVICE __device__ __host__
 
+#elif defined(CHAI_ENABLE_HIP) && defined(__HIPCC__)
+
+#include <hip/hip_runtime.h>
+
+#define CHAI_HOST __host__
+#define CHAI_DEVICE __device__
+#define CHAI_HOST_DEVICE __device__ __host__
+
 #else
 
 #define CHAI_HOST

--- a/src/chai/ExecutionSpaces.hpp
+++ b/src/chai/ExecutionSpaces.hpp
@@ -56,7 +56,7 @@ enum ExecutionSpace {
   NONE = 0,
   /*! Executing in CPU space */
   CPU,
-#if defined(CHAI_ENABLE_CUDA)
+#if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
   /*! Execution in GPU space */
   GPU,
 #endif

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -59,7 +59,7 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray():
   m_pointer_record(nullptr),
   m_is_slice(false)
 {
-#if !defined(__CUDA_ARCH__)
+#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
   m_resource_manager = ArrayManager::getInstance();
 
   m_pointer_record = new PointerRecord{};
@@ -80,7 +80,7 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(
     std::initializer_list<umpire::Allocator> allocators):
   ManagedArray()
 {
-#if !defined(__CUDA_ARCH__)
+#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
   int i = 0;
   for (auto& space : spaces) {
     m_pointer_record->m_allocators[space] = allocators.begin()[i++].getId();
@@ -96,7 +96,7 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(
     ExecutionSpace space) :
   ManagedArray()
 {
-#if !defined(__CUDA_ARCH__)
+#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
   m_elems = elems;
   m_pointer_record->m_size = sizeof(T)*m_elems;
 
@@ -120,7 +120,7 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(
     ExecutionSpace space):
   ManagedArray(spaces, allocators)
 {
-#if !defined(__CUDA_ARCH__)
+#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
   m_elems = elems;
   m_pointer_record->m_size = sizeof(T)*elems;
 
@@ -173,7 +173,7 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(ManagedArray const& other):
   m_pointer_record(other.m_pointer_record),
   m_is_slice(other.m_is_slice)
 {
-#if !defined(__CUDA_ARCH__)
+#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
   move(m_resource_manager->getExecutionSpace());
 #endif
 }
@@ -289,7 +289,7 @@ template<typename T>
 CHAI_INLINE
 CHAI_HOST_DEVICE
 typename ManagedArray<T>::T_non_const ManagedArray<T>::pick(size_t i) const { 
-  #if !defined(__CUDA_ARCH__)
+  #if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
     #if defined(CHAI_ENABLE_UM)
       if(m_pointer_record->m_pointers[UM] == m_active_base_pointer) {
         cudaDeviceSynchronize();
@@ -305,7 +305,7 @@ typename ManagedArray<T>::T_non_const ManagedArray<T>::pick(size_t i) const {
 template<typename T>
 CHAI_INLINE
 CHAI_HOST_DEVICE void ManagedArray<T>::set(size_t i, T& val) const { 
-  #if !defined(__CUDA_ARCH__)
+  #if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
     #if defined(CHAI_ENABLE_UM)
       if(m_pointer_record->m_pointers[UM] == m_active_pointer) {
         cudaDeviceSynchronize();
@@ -337,7 +337,7 @@ CHAI_HOST void ManagedArray<T>::modify(size_t i, const T& val) const {
 template<typename T>
 CHAI_INLINE
 CHAI_HOST_DEVICE void ManagedArray<T>::incr(size_t i) const { 
-  #if !defined(__CUDA_ARCH__)
+  #if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
     modify(i, (T)1);
   #else
      ++m_active_pointer[i]; 
@@ -347,7 +347,7 @@ CHAI_HOST_DEVICE void ManagedArray<T>::incr(size_t i) const {
 template<typename T>
 CHAI_INLINE
 CHAI_HOST_DEVICE void ManagedArray<T>::decr(size_t i) const { 
-  #if !defined(__CUDA_ARCH__)
+  #if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
     modify(i, (T)-1);
   #else
      --m_active_pointer[i]; 
@@ -396,7 +396,7 @@ CHAI_HOST_DEVICE T& ManagedArray<T>::operator[](const Idx i) const {
 template<typename T>
 CHAI_INLINE
 CHAI_HOST_DEVICE ManagedArray<T>::operator T*() const {
-#if !defined(__CUDA_ARCH__)
+#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
   ExecutionSpace prev_space = m_resource_manager->getExecutionSpace();
   m_resource_manager->setExecutionSpace(CPU);
   auto non_const_active_base_pointer = const_cast<T_non_const*>(static_cast<T*>(m_active_base_pointer));
@@ -422,7 +422,7 @@ CHAI_INLINE
 CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(T* data, bool ) :
   m_active_pointer(data),
   m_active_base_pointer(data),
-#if !defined(__CUDA_ARCH__)
+#if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
   m_resource_manager(ArrayManager::getInstance()),
   m_elems(m_resource_manager->getSize(m_active_base_pointer)),
   m_pointer_record(m_resource_manager->getPointerRecord(data)),

--- a/src/chai/config.hpp.in
+++ b/src/chai/config.hpp.in
@@ -45,6 +45,7 @@
 
 #cmakedefine CHAI_ENABLE_PICK
 #cmakedefine CHAI_ENABLE_CUDA 
+#cmakedefine CHAI_ENABLE_HIP 
 #cmakedefine CHAI_ENABLE_IMPLICIT_CONVERSIONS
 #cmakedefine CHAI_DISABLE_RM
 #cmakedefine CHAI_ENABLE_UM

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -6,6 +6,11 @@ if (ENABLE_CUDA)
     ${managed_array_test_depends}
     cuda)
 endif ()
+if (ENABLE_HIP)
+  set (managed_array_test_depends
+    ${managed_array_test_depends}
+    hip)
+endif ()
 
 blt_add_executable(
   NAME managed_array_tests

--- a/tests/integration/managed_array_tests.cpp
+++ b/tests/integration/managed_array_tests.cpp
@@ -42,10 +42,10 @@
 // ---------------------------------------------------------------------
 #include "gtest/gtest.h"
 
-#define CUDA_TEST(X, Y)              \
-  static void cuda_test_##X##Y();    \
-  TEST(X, Y) { cuda_test_##X##Y(); } \
-  static void cuda_test_##X##Y()
+#define GPU_TEST(X, Y)              \
+  static void gpu_test_##X##Y();    \
+  TEST(X, Y) { gpu_test_##X##Y(); } \
+  static void gpu_test_##X##Y()
 
 #ifdef NDEBUG
 #define device_assert(EXP) if( !EXP ) asm ("trap;")
@@ -262,18 +262,18 @@ TEST(ManagedArray, IncrementDecrementOnHostUM)
 
 #endif
 
-#if defined(CHAI_ENABLE_CUDA)
+#if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
 #if defined(CHAI_ENABLE_PICK)
 
 #if defined(CHAI_ENABLE_UM)
-CUDA_TEST(ManagedArray, PickandSetDeviceToDeviceUM)
+GPU_TEST(ManagedArray, PickandSetDeviceToDeviceUM)
 {
   chai::ManagedArray<int> array1(10, chai::UM);
   chai::ManagedArray<int> array2(10, chai::UM);
 
-  forall(cuda(), 0, 10, [=] __device__(int i) { array1[i] = i; });
+  forall(gpu(), 0, 10, [=] __device__(int i) { array1[i] = i; });
 
-  forall(cuda(), 0, 10, [=] __device__(int i) {
+  forall(gpu(), 0, 10, [=] __device__(int i) {
     int temp = array1.pick(i);
     array2.set(i, temp);
   });
@@ -284,11 +284,11 @@ CUDA_TEST(ManagedArray, PickandSetDeviceToDeviceUM)
   array2.free();
 }
 
-CUDA_TEST(ManagedArray, PickHostFromDeviceUM)
+GPU_TEST(ManagedArray, PickHostFromDeviceUM)
 {
   chai::ManagedArray<int> array(10, chai::UM);
 
-  forall(cuda(), 0, 10, [=] __device__(int i) { array[i] = i; });
+  forall(gpu(), 0, 10, [=] __device__(int i) { array[i] = i; });
 
   int temp = array.pick(5);
   ASSERT_EQ(temp, 5);
@@ -297,10 +297,10 @@ CUDA_TEST(ManagedArray, PickHostFromDeviceUM)
 }
 
 #if (!defined(CHAI_DISABLE_RM))
-CUDA_TEST(ManagedArray, PickHostFromDeviceConstUM) {
+GPU_TEST(ManagedArray, PickHostFromDeviceConstUM) {
   chai::ManagedArray<int> array(10, chai::UM);
 
-  forall(cuda(), 0, 10, [=] __device__(int i) { array[i] = i; });
+  forall(gpu(), 0, 10, [=] __device__(int i) { array[i] = i; });
 
   chai::ManagedArray<const int> array_const(array);
 
@@ -312,11 +312,11 @@ CUDA_TEST(ManagedArray, PickHostFromDeviceConstUM) {
 }
 #endif
 
-CUDA_TEST(ManagedArray, SetHostToDeviceUM)
+GPU_TEST(ManagedArray, SetHostToDeviceUM)
 {
   chai::ManagedArray<int> array(10);
 
-  forall(cuda(), 0, 10, [=] __device__(int i) { array[i] = i; });
+  forall(gpu(), 0, 10, [=] __device__(int i) { array[i] = i; });
 
   int temp = 10;
   array.set(5, temp);
@@ -326,17 +326,17 @@ CUDA_TEST(ManagedArray, SetHostToDeviceUM)
   array.free();
 }
 
-CUDA_TEST(ManagedArray, IncrementDecrementOnDeviceUM)
+GPU_TEST(ManagedArray, IncrementDecrementOnDeviceUM)
 {
   chai::ManagedArray<int> arrayI(10, chai::UM);
   chai::ManagedArray<int> arrayD(10, chai::UM);
 
-  forall(cuda(), 0, 10, [=] __device__(int i) {
+  forall(gpu(), 0, 10, [=] __device__(int i) {
     arrayI[i] = i;
     arrayD[i] = i;
   });
 
-  forall(cuda(), 0, 10, [=] __device__(int i) {
+  forall(gpu(), 0, 10, [=] __device__(int i) {
     arrayI.incr(i);
     arrayD.decr(i);
   });
@@ -350,11 +350,11 @@ CUDA_TEST(ManagedArray, IncrementDecrementOnDeviceUM)
   arrayD.free();
 }
 
-CUDA_TEST(ManagedArray, IncrementDecrementFromHostOnDeviceUM)
+GPU_TEST(ManagedArray, IncrementDecrementFromHostOnDeviceUM)
 {
   chai::ManagedArray<int> array(10, chai::UM);
 
-  forall(cuda(), 0, 10, [=] __device__(int i) { array[i] = i; });
+  forall(gpu(), 0, 10, [=] __device__(int i) { array[i] = i; });
 
   array.incr(5);
   array.decr(9);
@@ -369,16 +369,16 @@ CUDA_TEST(ManagedArray, IncrementDecrementFromHostOnDeviceUM)
   array.free();
 }
 
-CUDA_TEST(ManagedArray, PickandSetSliceDeviceToDeviceUM) {
+GPU_TEST(ManagedArray, PickandSetSliceDeviceToDeviceUM) {
   chai::ManagedArray<int> array(10, chai::UM);
   chai::ManagedArray<int> sl1 = array.slice(0,5);
   chai::ManagedArray<int> sl2 = array.slice(5,5);
 
-  forall(cuda(), 0, 10, [=] __device__ (int i) {
+  forall(gpu(), 0, 10, [=] __device__ (int i) {
       array[i] = i;
   });
 
-  forall(cuda(), 0, 5, [=] __device__ (int i) {
+  forall(gpu(), 0, 5, [=] __device__ (int i) {
       int temp = sl2.pick(i);
       temp += sl2.pick(i);
       sl1.set(i, temp);
@@ -393,16 +393,16 @@ CUDA_TEST(ManagedArray, PickandSetSliceDeviceToDeviceUM) {
 #endif
 
 #if (!defined(CHAI_DISABLE_RM))
-CUDA_TEST(ManagedArray, PickandSetDeviceToDevice)
+GPU_TEST(ManagedArray, PickandSetDeviceToDevice)
 {
   chai::ManagedArray<int> array1(10);
   chai::ManagedArray<int> array2(10);
 
-  forall(cuda(), 0, 10, [=] __device__(int i) { array1[i] = i; });
+  forall(gpu(), 0, 10, [=] __device__(int i) { array1[i] = i; });
 
   chai::ManagedArray<const int> array_const(array1);
 
-  forall(cuda(), 0, 10, [=] __device__(int i) {
+  forall(gpu(), 0, 10, [=] __device__(int i) {
     int temp = array1.pick(i);
     temp += array_const.pick(i);
     array2.set(i, temp);
@@ -414,16 +414,16 @@ CUDA_TEST(ManagedArray, PickandSetDeviceToDevice)
   array2.free();
 }
 
-CUDA_TEST(ManagedArray, PickandSetSliceDeviceToDevice) {
+GPU_TEST(ManagedArray, PickandSetSliceDeviceToDevice) {
   chai::ManagedArray<int> array(10);
   chai::ManagedArray<int> sl1 = array.slice(0,5);
   chai::ManagedArray<int> sl2 = array.slice(5,5);
 
-  forall(cuda(), 0, 10, [=] __device__ (int i) {
+  forall(gpu(), 0, 10, [=] __device__ (int i) {
       array[i] = i;
   });
 
-  forall(cuda(), 0, 5, [=] __device__ (int i) {
+  forall(gpu(), 0, 5, [=] __device__ (int i) {
       int temp = sl2.pick(i);
       temp += sl2.pick(i);
       sl1.set(i, temp);
@@ -437,11 +437,11 @@ CUDA_TEST(ManagedArray, PickandSetSliceDeviceToDevice) {
 }
 
 
-CUDA_TEST(ManagedArray, PickHostFromDevice)
+GPU_TEST(ManagedArray, PickHostFromDevice)
 {
   chai::ManagedArray<int> array(10);
 
-  forall(cuda(), 0, 10, [=] __device__(int i) { array[i] = i; });
+  forall(gpu(), 0, 10, [=] __device__(int i) { array[i] = i; });
 
   int temp = array.pick(5);
   ASSERT_EQ(temp, 5);
@@ -449,11 +449,11 @@ CUDA_TEST(ManagedArray, PickHostFromDevice)
   array.free();
 }
 
-CUDA_TEST(ManagedArray, PickHostFromDeviceConst)
+GPU_TEST(ManagedArray, PickHostFromDeviceConst)
 {
   chai::ManagedArray<int> array(10);
 
-  forall(cuda(), 0, 10, [=] __device__(int i) { array[i] = i; });
+  forall(gpu(), 0, 10, [=] __device__(int i) { array[i] = i; });
 
   chai::ManagedArray<const int> array_const(array);
 
@@ -466,11 +466,11 @@ CUDA_TEST(ManagedArray, PickHostFromDeviceConst)
   // array_const.free();
 }
 
-CUDA_TEST(ManagedArray, SetHostToDevice)
+GPU_TEST(ManagedArray, SetHostToDevice)
 {
   chai::ManagedArray<int> array(10);
 
-  forall(cuda(), 0, 10, [=] __device__(int i) { array[i] = i; });
+  forall(gpu(), 0, 10, [=] __device__(int i) { array[i] = i; });
 
   int temp = 10;
   array.set(5, temp);
@@ -479,17 +479,17 @@ CUDA_TEST(ManagedArray, SetHostToDevice)
 
   array.free();
 }
-CUDA_TEST(ManagedArray, IncrementDecrementOnDevice)
+GPU_TEST(ManagedArray, IncrementDecrementOnDevice)
 {
   chai::ManagedArray<int> arrayI(10);
   chai::ManagedArray<int> arrayD(10);
 
-  forall(cuda(), 0, 10, [=] __device__(int i) {
+  forall(gpu(), 0, 10, [=] __device__(int i) {
     arrayI[i] = i;
     arrayD[i] = i;
   });
 
-  forall(cuda(), 0, 10, [=] __device__(int i) {
+  forall(gpu(), 0, 10, [=] __device__(int i) {
     arrayI.incr(i);
     arrayD.decr(i);
   });
@@ -503,11 +503,11 @@ CUDA_TEST(ManagedArray, IncrementDecrementOnDevice)
   arrayD.free();
 }
 
-CUDA_TEST(ManagedArray, IncrementDecrementFromHostOnDevice)
+GPU_TEST(ManagedArray, IncrementDecrementFromHostOnDevice)
 {
   chai::ManagedArray<int> array(10);
 
-  forall(cuda(), 0, 10, [=] __device__(int i) { array[i] = i; });
+  forall(gpu(), 0, 10, [=] __device__(int i) { array[i] = i; });
 
   array.incr(5);
   array.decr(9);
@@ -524,7 +524,7 @@ CUDA_TEST(ManagedArray, IncrementDecrementFromHostOnDevice)
 #endif
 #endif
 
-CUDA_TEST(ManagedArray, SliceOfSliceDevice) {
+GPU_TEST(ManagedArray, SliceOfSliceDevice) {
   chai::ManagedArray<float> array(10);
 
   forall(sequential(), 0, 10, [=] (int i) {
@@ -534,7 +534,7 @@ CUDA_TEST(ManagedArray, SliceOfSliceDevice) {
   chai::ManagedArray<float> sl1 = array.slice(0,6);
   chai::ManagedArray<float> sl2 = sl1.slice(3,3);
 
-  forall(cuda(), 0, 3, [=] __device__ (int i) {
+  forall(gpu(), 0, 3, [=] __device__ (int i) {
       sl1[i] = sl2[i];
   });
 
@@ -547,7 +547,7 @@ CUDA_TEST(ManagedArray, SliceOfSliceDevice) {
   array.free();
 }
 
-CUDA_TEST(ManagedArray, SliceDevice) {
+GPU_TEST(ManagedArray, SliceDevice) {
   chai::ManagedArray<float> array(10);
 
   forall(sequential(), 0, 10, [=] (int i) {
@@ -557,7 +557,7 @@ CUDA_TEST(ManagedArray, SliceDevice) {
   chai::ManagedArray<float> sl1 = array.slice(0,5);
   chai::ManagedArray<float> sl2 = array.slice(5,5);
 
-  forall(cuda(), 0, 5, [=] __device__ (int i) {
+  forall(gpu(), 0, 5, [=] __device__ (int i) {
       sl1[i] = sl2[i];
   });
 
@@ -570,23 +570,23 @@ CUDA_TEST(ManagedArray, SliceDevice) {
   array.free();
 }
 
-CUDA_TEST(ManagedArray, SetOnDevice) {
+GPU_TEST(ManagedArray, SetOnDevice) {
   chai::ManagedArray<int> array(10);
 
   forall(sequential(), 0, 10, [=](int i) { array[i] = i; });
 
-  forall(cuda(), 0, 10, [=] __device__(int i) { array[i] *= 2; });
+  forall(gpu(), 0, 10, [=] __device__(int i) { array[i] *= 2; });
 
   forall(sequential(), 0, 10, [=](int i) { ASSERT_EQ(array[i], 2 * i); });
 
   array.free();
 }
 
-CUDA_TEST(ManagedArray, GetGpuOnHost)
+GPU_TEST(ManagedArray, GetGpuOnHost)
 {
   chai::ManagedArray<float> array(10, chai::GPU);
 
-  forall(cuda(), 0, 10, [=] __device__(int i) { array[i] = i; });
+  forall(gpu(), 0, 10, [=] __device__(int i) { array[i] = i; });
 
   forall(sequential(), 0, 10, [=](int i) { ASSERT_EQ(array[i], i); });
 
@@ -594,11 +594,11 @@ CUDA_TEST(ManagedArray, GetGpuOnHost)
 }
 
 #if defined(CHAI_ENABLE_UM)
-CUDA_TEST(ManagedArray, SetOnDeviceUM)
+GPU_TEST(ManagedArray, SetOnDeviceUM)
 {
   chai::ManagedArray<float> array(10, chai::UM);
 
-  forall(cuda(), 0, 10, [=] __device__(int i) { array[i] = i; });
+  forall(gpu(), 0, 10, [=] __device__(int i) { array[i] = i; });
 
   forall(sequential(), 0, 10, [=](int i) { ASSERT_EQ(array[i], i); });
 
@@ -640,13 +640,13 @@ TEST(ManagedArray, ReallocateCPU)
   array.free();
 }
 
-#if defined(CHAI_ENABLE_CUDA)
-CUDA_TEST(ManagedArray, ReallocateGPU)
+#if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
+GPU_TEST(ManagedArray, ReallocateGPU)
 {
   chai::ManagedArray<float> array(10);
   ASSERT_EQ(array.size(), 10u);
 
-  forall(cuda(), 0, 10, [=] __device__(int i) { array[i] = i; });
+  forall(gpu(), 0, 10, [=] __device__(int i) { array[i] = i; });
 
   array.reallocate(20);
   ASSERT_EQ(array.size(), 20u);
@@ -713,12 +713,12 @@ TEST(ManagedArray, PodTest)
   array.free();
 }
 
-#if defined(CHAI_ENABLE_CUDA)
-CUDA_TEST(ManagedArray, PodTestGPU)
+#if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
+GPU_TEST(ManagedArray, PodTestGPU)
 {
   chai::ManagedArray<my_point> array(1);
 
-  forall(cuda(), 0, 1, [=] __device__(int i) {
+  forall(gpu(), 0, 1, [=] __device__(int i) {
     array[i].x = (double)i;
     array[i].y = (double)i * 2.0;
   });
@@ -782,15 +782,15 @@ TEST(ManagedArray, Reset)
   array.free();
 }
 
-#if defined(CHAI_ENABLE_CUDA)
+#if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
 #ifndef CHAI_DISABLE_RM
-CUDA_TEST(ManagedArray, ResetDevice)
+GPU_TEST(ManagedArray, ResetDevice)
 {
   chai::ManagedArray<float> array(20);
 
   forall(sequential(), 0, 20, [=](int i) { array[i] = 0.0f; });
 
-  forall(cuda(), 0, 20, [=] __device__(int i) { array[i] = 1.0f * i; });
+  forall(gpu(), 0, 20, [=] __device__(int i) { array[i] = 1.0f * i; });
 
   array.reset();
 
@@ -802,9 +802,9 @@ CUDA_TEST(ManagedArray, ResetDevice)
 #endif
 
 
-#if defined(CHAI_ENABLE_CUDA)
+#if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
 #ifndef CHAI_DISABLE_RM
-CUDA_TEST(ManagedArray, UserCallback)
+GPU_TEST(ManagedArray, UserCallback)
 {
   int num_h2d = 0;
   int num_d2h = 0;
@@ -840,7 +840,7 @@ CUDA_TEST(ManagedArray, UserCallback)
   for (int iter = 0; iter < 10; ++iter) {
     forall(sequential(), 0, 20, [=](int i) { array[i] = 0.0f; });
 
-    forall(cuda(), 0, 20, [=] __device__(int i) { array[i] = 1.0f * i; });
+    forall(gpu(), 0, 20, [=] __device__(int i) { array[i] = 1.0f * i; });
   }
 
 
@@ -855,7 +855,7 @@ CUDA_TEST(ManagedArray, UserCallback)
   ASSERT_EQ(bytes_free, 2 * 20 * sizeof(float));
 }
 
-CUDA_TEST(ManagedArray, CallBackConst)
+GPU_TEST(ManagedArray, CallBackConst)
 {
   int num_h2d = 0;
   int num_d2h = 0;
@@ -886,7 +886,15 @@ CUDA_TEST(ManagedArray, CallBackConst)
 
   // Create a const copy and move it to the device.
   chai::ManagedArray<int const> array_const = array;
-  forall(cuda(), 0, 100, [=] __device__(int i) { device_assert(array_const[i] == i); });
+
+  /* array to store error flags on device */
+  chai::ManagedArray<int> error_flag(100);
+
+  forall(gpu(), 0, 100, [=] __device__(int i) { error_flag[i] = (array_const[i] == i) ? 0 : 1; });
+
+  // Check error flags on host
+  forall(sequential(), 0, 100, [=](int i) { ASSERT_EQ(error_flag[i], 0); });
+  error_flag.free();
 
   // Change the values, use a for-loop so as to not trigger a movement.
   for (int i = 0; i < 100; ++i)
@@ -903,7 +911,7 @@ CUDA_TEST(ManagedArray, CallBackConst)
   array.free();
 }
 
-CUDA_TEST(ManagedArray, CallBackConstArray)
+GPU_TEST(ManagedArray, CallBackConstArray)
 {
   int num_h2d = 0;
   int num_d2h = 0;
@@ -932,12 +940,17 @@ CUDA_TEST(ManagedArray, CallBackConstArray)
   chai::ManagedArray<chai::ManagedArray<int>> outerArray(N);
   outerArray.setUserCallback(callBack);
 
+  /* array to store error flags on device */
+  chai::ManagedArray<chai::ManagedArray<int>> outerErrorArray(N); 
+
   /* Loop over the outer array and populate it with arrays on the CPU. */
   forall(sequential(), 0, N,
     [=](int i)
     {
       chai::ManagedArray<int> temp(N);
       temp.setUserCallback(callBack);
+
+      chai::ManagedArray<int> errorTemp(N);
 
       forall(sequential(), 0, N,
         [=](int j)
@@ -947,17 +960,29 @@ CUDA_TEST(ManagedArray, CallBackConstArray)
       );
 
       outerArray[i] = temp;
+      outerErrorArray[i] = errorTemp;
     }
   );
 
   // Create a const copy and move it to the device.
   chai::ManagedArray<chai::ManagedArray<int> const> outerArrayConst = outerArray;
-  forall(cuda(), 0, N,
+  forall(gpu(), 0, N,
     [=] __device__(int i)
     {
       for( int j = 0; j < N; ++j)
       {
-        device_assert(outerArrayConst[i][j] == N * i + j);
+        outerErrorArray[i][j] = (outerArrayConst[i][j] == N * i + j) ? 0 : 1;
+      }
+    }
+  );
+
+  // Check error flags on host
+  forall(sequential(), 0, N,
+    [=](int i)
+    {
+      for (int j = 0; j < N; ++j)
+      {
+        ASSERT_EQ(outerErrorArray[i][j], 0);
       }
     }
   );
@@ -978,12 +1003,14 @@ CUDA_TEST(ManagedArray, CallBackConstArray)
 
   for (int i = 0; i < N; ++i) {
     outerArray[i].free();
+    outerErrorArray[i].free();
   }
 
   outerArray.free();
+  outerErrorArray.free();
 }
 
-CUDA_TEST(ManagedArray, CallBackConstArrayConst)
+GPU_TEST(ManagedArray, CallBackConstArrayConst)
 {
   int num_h2d = 0;
   int num_d2h = 0;
@@ -1012,12 +1039,17 @@ CUDA_TEST(ManagedArray, CallBackConstArrayConst)
   chai::ManagedArray<chai::ManagedArray<int>> outerArray(N);
   outerArray.setUserCallback(callBack);
 
+  /* array to store error flags on device */
+  chai::ManagedArray<chai::ManagedArray<int>> outerErrorArray(N); 
+
   /* Loop over the outer array and populate it with arrays on the CPU. */
   forall(sequential(), 0, N,
     [=](int i)
     {
       chai::ManagedArray<int> temp(N);
       temp.setUserCallback(callBack);
+
+      chai::ManagedArray<int> errorTemp(N);
 
       forall(sequential(), 0, N,
         [=](int j)
@@ -1027,18 +1059,30 @@ CUDA_TEST(ManagedArray, CallBackConstArrayConst)
       );
 
       outerArray[i] = temp;
+      outerErrorArray[i] = errorTemp;
     }
   );
 
   // Create a const copy of int const and move it to the device.
   chai::ManagedArray<chai::ManagedArray<int const> const> outerArrayConst = 
     reinterpret_cast<chai::ManagedArray<chai::ManagedArray<int const> const> &>(outerArray);
-  forall(cuda(), 0, N,
+  forall(gpu(), 0, N,
     [=] __device__(int i)
     {
       for( int j = 0; j < N; ++j)
       {
-        device_assert(outerArrayConst[i][j] == N * i + j);
+        outerErrorArray[i][j] = (outerArrayConst[i][j] == N * i + j) ? 0 : 1;
+      }
+    }
+  );
+
+  // Check error flags on host
+  forall(sequential(), 0, N,
+    [=](int i)
+    {
+      for (int j = 0; j < N; ++j)
+      {
+        ASSERT_EQ(outerErrorArray[i][j], 0);
       }
     }
   );
@@ -1059,22 +1103,24 @@ CUDA_TEST(ManagedArray, CallBackConstArrayConst)
 
   for (int i = 0; i < N; ++i) {
     outerArray[i].free();
+    outerErrorArray[i].free();
   }
 
   outerArray.free();
+  outerErrorArray.free();
 }
 
 #endif
 #endif
 
 
-#if defined(CHAI_ENABLE_CUDA)
+#if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
 #ifndef CHAI_DISABLE_RM
-CUDA_TEST(ManagedArray, Move)
+GPU_TEST(ManagedArray, Move)
 {
   chai::ManagedArray<float> array(10, chai::GPU);
 
-  forall(cuda(), 0, 10, [=] __device__(int i) { array[i] = i; });
+  forall(gpu(), 0, 10, [=] __device__(int i) { array[i] = i; });
 
   array.move(chai::CPU);
 
@@ -1088,7 +1134,7 @@ CUDA_TEST(ManagedArray, Move)
  * CPU and the inner arrays are on the GPU. It then captures the outer array
  * on the CPU and checks that the inner arrays were moved to the CPU.
  */
-CUDA_TEST(ManagedArray, MoveInnerToHost)
+GPU_TEST(ManagedArray, MoveInnerToHost)
 {
   const int N = 5;
 
@@ -1101,7 +1147,7 @@ CUDA_TEST(ManagedArray, MoveInnerToHost)
     {
       chai::ManagedArray<int> temp(N, chai::GPU);
 
-      forall(cuda(), 0, N,
+      forall(gpu(), 0, N,
         [=] __device__(int j)
         {
           temp[j] = N * i + j;
@@ -1138,7 +1184,7 @@ CUDA_TEST(ManagedArray, MoveInnerToHost)
  * on the CPU and checks that the values of the inner arrays were modified
  * correctly. 
  */
-CUDA_TEST(ManagedArray, MoveInnerToDevice)
+GPU_TEST(ManagedArray, MoveInnerToDevice)
 {
   const int N = 5;
 
@@ -1164,7 +1210,7 @@ CUDA_TEST(ManagedArray, MoveInnerToDevice)
 
   /* Capture the outer array on the GPU and update the values of the inner
    * arrays. */
-  forall(cuda(), 0, N,
+  forall(gpu(), 0, N,
     [=] __device__(int i)
     {
       for( int j = 0; j < N; ++j)
@@ -1200,7 +1246,7 @@ CUDA_TEST(ManagedArray, MoveInnerToDevice)
  * on the CPU and checks that the values of the innermost arrays were modified
  * correctly. 
  */
-CUDA_TEST(ManagedArray, MoveInnerToDevice2)
+GPU_TEST(ManagedArray, MoveInnerToDevice2)
 {
   const int N = 5;
 
@@ -1234,7 +1280,7 @@ CUDA_TEST(ManagedArray, MoveInnerToDevice2)
 
   /* Capture the outermost array on the GPU and update the values of the
    * innermost arrays. */
-  forall(cuda(), 0, N,
+  forall(gpu(), 0, N,
     [=] __device__(int i)
     {
       for( int j = 0; j < N; ++j)
@@ -1272,7 +1318,7 @@ CUDA_TEST(ManagedArray, MoveInnerToDevice2)
 }
 
 #endif  // CHAI_DISABLE_RM
-#endif  // defined(CHAI_ENABLE_CUDA)
+#endif  // defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
 
 
 #ifndef CHAI_DISABLE_RM
@@ -1298,19 +1344,19 @@ TEST(ManagedArray, DeepCopy)
 }
 #endif
 
-#if defined(CHAI_ENABLE_CUDA)
+#if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
 #ifndef CHAI_DISABLE_RM
-CUDA_TEST(ManagedArray, DeviceDeepCopy)
+GPU_TEST(ManagedArray, DeviceDeepCopy)
 {
   chai::ManagedArray<float> array(10, chai::GPU);
   ASSERT_EQ(array.size(), 10u);
 
-  forall(cuda(), 0, 10, [=] __device__(int i) { array[i] = i; });
+  forall(gpu(), 0, 10, [=] __device__(int i) { array[i] = i; });
 
   chai::ManagedArray<float> copy = chai::deepCopy(array);
   ASSERT_EQ(copy.size(), 10u);
 
-  forall(cuda(), 0, 10, [=] __device__(int i) { array[i] = -5.5 * i; });
+  forall(gpu(), 0, 10, [=] __device__(int i) { array[i] = -5.5 * i; });
 
   forall(sequential(), 0, 10, [=](int i) {
     ASSERT_EQ(copy[i], i);
@@ -1321,4 +1367,4 @@ CUDA_TEST(ManagedArray, DeviceDeepCopy)
   copy.free();
 }
 #endif
-#endif  // defined(CHAI_ENABLE_CUDA)
+#endif  // defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -55,6 +55,14 @@ if (ENABLE_CUDA)
     ${array_manager_test_depends}
     cuda)
 endif ()
+if (ENABLE_HIP)
+  set (managed_array_test_depends
+    ${managed_array_test_depends}
+    hip)
+  set (array_manager_test_depends
+    ${array_manager_test_depends}
+    hip)
+endif ()
 
 blt_add_executable(
   NAME managed_array_unit_tests

--- a/tests/unit/managed_array_unit_tests.cpp
+++ b/tests/unit/managed_array_unit_tests.cpp
@@ -42,10 +42,10 @@
 // ---------------------------------------------------------------------
 #include "gtest/gtest.h"
 
-#define CUDA_TEST(X, Y)              \
-  static void cuda_test_##X##Y();    \
-  TEST(X, Y) { cuda_test_##X##Y(); } \
-  static void cuda_test_##X##Y()
+#define GPU_TEST(X, Y)              \
+  static void gpu_test_##X##Y();    \
+  TEST(X, Y) { gpu_test_##X##Y(); } \
+  static void gpu_test_##X##Y()
 
 #include "chai/config.hpp"
 
@@ -71,7 +71,7 @@ TEST(ManagedArray, SpaceConstructorCPU)
   array.free();
 }
 
-#if defined(CHAI_ENABLE_CUDA)
+#if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
 TEST(ManagedArray, SpaceConstructorGPU)
 {
   chai::ManagedArray<float> array(10, chai::GPU);


### PR DESCRIPTION
Tested on ROCm 2.2 with the following cmake command 

```cmake -DENABLE_CUDA=Off -DENABLE_HIP=On ..```

Some changes were required to use the most recent Umpire version. I'll need someone to check that these are ok. 