### PR TITLE
Use Umpire's MemoryMap inside ArrayManager

### DIFF
--- a/scripts/travis/build_and_test.sh
+++ b/scripts/travis/build_and_test.sh
@@ -9,16 +9,18 @@ function or_die () {
     fi
 }
 
-source ~/.bashrc
-cd ${TRAVIS_BUILD_DIR}
-or_die mkdir travis-build
-or_die mkdir travis-install
+threads=3
+top_dir=$(pwd)
+travis_build_dir=${top_dir}/travis-build
+travis_install_dir=${top_dir}/travis-install
 
-cd travis-build
+or_die mkdir $travis_build_dir
+or_die mkdir $travis_install_dir
 
 if [[ "$DO_BUILD" == "yes" ]] ; then
-    or_die cmake -DCMAKE_CXX_COMPILER="${COMPILER}" -DCMAKE_INSTALL_PREFIX=${TRAVIS_BUILD_DIR}/travis-install ${CMAKE_EXTRA_FLAGS} ../
-    or_die make -j 3 VERBOSE=1
+    or_die cd $travis_build_dir
+    or_die cmake -DCMAKE_CXX_COMPILER="${COMPILER}" ${CMAKE_EXTRA_FLAGS} -DCMAKE_INSTALL_PREFIX=$travis_install_dir ../
+    or_die make -j $threads VERBOSE=1
     or_die make install
     if [[ "${DO_TEST}" == "yes" ]] ; then
         or_die ctest -V
@@ -26,13 +28,13 @@ if [[ "$DO_BUILD" == "yes" ]] ; then
 fi
 
 if [[ "$BUILD_RAJA" == "yes" ]] ; then
-  or_die cd ${TRAVIS_BUILD_DIR}/../
+  or_die cd $top_dir
   or_die git clone --recursive -b develop https://github.com/LLNL/RAJA.git
   or_die cd RAJA
   or_die mkdir build
   or_die cd build
-  or_die cmake -DCMAKE_CXX_COMPILER="${COMPILER}" ${CMAKE_EXTRA_FLAGS} -DENABLE_CHAI=On -Dchai_DIR=${TRAVIS_BUILD_DIR}/travis-install/share/chai/cmake ../
-  or_die make -j 3 VERBOSE=2
+  or_die cmake -DCMAKE_CXX_COMPILER="${COMPILER}" ${CMAKE_EXTRA_FLAGS} -DENABLE_CHAI=On -Dchai_DIR=${travis_install_dir}/share/chai/cmake ../
+  or_die make -j $threads VERBOSE=2
 fi
 
 exit 0

--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -50,6 +50,7 @@
 #include <unordered_map>
 
 #include "umpire/Allocator.hpp"
+#include "umpire/util/MemoryMap.hpp"
 
 namespace chai
 {
@@ -78,6 +79,8 @@ class ArrayManager
 public:
   template <typename T>
   using T_non_const = typename std::remove_const<T>::type;
+
+  using PointerMap = umpire::util::MemoryMap<PointerRecord*>;
 
   static PointerRecord s_null_record;
 
@@ -289,11 +292,6 @@ private:
   void move(PointerRecord* record, ExecutionSpace space);
 
   /*!
-   * Pointer to singleton instance.
-   */
-  static ArrayManager* s_resource_manager_instance;
-
-  /*!
    * Current execution space.
    */
   ExecutionSpace m_current_execution_space;
@@ -306,15 +304,17 @@ private:
   /*!
    * Map of active ManagedArray pointers to their corresponding PointerRecord.
    */
-  std::unordered_map<void*, PointerRecord*> m_pointer_map;
+  PointerMap m_pointer_map;
 
   /*!
    *
    * \brief Array of umpire::Allocators, indexed by ExecutionSpace.
    */
-  umpire::Allocator* m_allocators[NUM_EXECUTION_SPACES] = {};
+  umpire::Allocator* m_allocators[NUM_EXECUTION_SPACES];
 
   umpire::ResourceManager& m_resource_manager;
+
+  mutable std::mutex m_mutex;
 };
 
 }  // end of namespace chai

--- a/src/chai/ArrayManager.inl
+++ b/src/chai/ArrayManager.inl
@@ -1,32 +1,32 @@
 // ---------------------------------------------------------------------
 // Copyright (c) 2016-2018, Lawrence Livermore National Security, LLC. All
 // rights reserved.
-// 
+//
 // Produced at the Lawrence Livermore National Laboratory.
-// 
+//
 // This file is part of CHAI.
-// 
+//
 // LLNL-CODE-705877
-// 
+//
 // For details, see https:://github.com/LLNL/CHAI
 // Please also see the NOTICE and LICENSE files.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
 // are met:
-// 
+//
 // - Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 // - Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
 //   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 // - Neither the name of the LLNS/LLNL nor the names of its contributors
 //   may be used to endorse or promote products derived from this
 //   software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -76,7 +76,7 @@ void* ArrayManager::reallocate(void* pointer, size_t elems, PointerRecord* point
       return pointer_record->m_pointers[my_space];
     }
   }
-  
+
   // only copy however many bytes overlap
   size_t num_bytes_to_copy = std::min(sizeof(T)*elems, pointer_record->m_size);
 
@@ -95,10 +95,10 @@ void* ArrayManager::reallocate(void* pointer, size_t elems, PointerRecord* point
       pointer_record->m_pointers[space] = new_ptr;
 
       m_pointer_map.erase(old_ptr);
-      m_pointer_map[new_ptr] = pointer_record;
+      m_pointer_map.insert(new_ptr, pointer_record);
     }
   }
-    
+
   pointer_record->m_size = sizeof(T) * elems;
   return pointer_record->m_pointers[my_space];
 }


### PR DESCRIPTION
Replaces the `std::unordered_map<void*,chai::PointerRecord*>` by `umpire::util::MemoryMap<chai::PointerRecord*>` and make `chai::ArrayManager` thread-safe.

- [x] Wait for `DynamicPool` PR in Umpire to be merged to `develop`, then update the module