### PR TITLE
Add ability to turn callbacks on or off

### DIFF
--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -258,6 +258,16 @@ public:
 
   int getAllocatorId(ExecutionSpace space) const;
 
+  /*!
+   * \brief Turn callbacks on.
+   */
+  void enableCallbacks() { m_callbacks_active = true; }
+
+  /*!
+   * \brief Turn callbacks off.
+   */
+  void disableCallbacks() { m_callbacks_active = false; }
+
 protected:
   /*!
    * \brief Construct a new ArrayManager.
@@ -294,6 +304,23 @@ private:
   void move(PointerRecord* record, ExecutionSpace space);
 
   /*!
+   * \brief Execute a user callback if callbacks are active
+   *
+   * \param record The pointer record containing the callback
+   * \param action The event that occurred
+   * \param space The space in which the event occurred
+   * \param size The number of bytes in the array associated with this pointer record
+   */
+  inline void callback(PointerRecord* record,
+                       Action action,
+                       ExecutionSpace space,
+                       size_t size) const {
+     if (m_callbacks_active && record) {
+        record->m_user_callback(action, space, size);
+     }
+  }
+
+  /*!
    * Current execution space.
    */
   ExecutionSpace m_current_execution_space;
@@ -317,6 +344,11 @@ private:
   umpire::ResourceManager& m_resource_manager;
 
   mutable std::mutex m_mutex;
+
+  /*!
+   * \brief Controls whether or not callbacks are called.
+   */
+  bool m_callbacks_active;
 };
 
 }  // end of namespace chai

--- a/tests/unit/array_manager_unit_tests.cpp
+++ b/tests/unit/array_manager_unit_tests.cpp
@@ -110,6 +110,9 @@ TEST(ArrayManager, getPointerMap)
             (sizeOfArray1 * sizeof(int)) + (sizeOfArray2 * sizeof(double)));
 }
 
+/*!
+ * \brief Tests to see if callbacks can be turned on or off
+ */
 TEST(ArrayManager, controlCallbacks)
 {
   // First check that callbacks are turned on by default


### PR DESCRIPTION
Callbacks are extremely helpful for debugging, but often we only want to debug a certain part of the code, so it is very helpful to be able to turn callbacks on or off globally (it would simply be impractical to try to update the callback for each ManagedArray, especially since we'd need to save the original callback elsewhere).

EDIT: This code came from @robinson96 