### PR TITLE
Various fixes for ManagedArray

### DIFF
--- a/src/chai/ArrayManager.cpp
+++ b/src/chai/ArrayManager.cpp
@@ -58,7 +58,7 @@ void ArrayManager::registerPointer(
   //record->m_last_space = space;
 
   for (int i = 0; i < NUM_EXECUTION_SPACES; i++) {
-    record->m_owned[i] = true;
+    if (!record->m_pointers[i]) record->m_owned[i] = true;
   }
   record->m_owned[space] = owned;
 }

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -358,6 +358,11 @@ ManagedArray<T> makeManagedArray(T* data,
   PointerRecord* record =
       manager->makeManaged(data, sizeof(T) * elems, space, owned);
 
+  for (int space = CPU; space < NUM_EXECUTION_SPACES; space++) {
+    record->m_allocators[space] = 
+      manager->getAllocatorId(ExecutionSpace(space));
+  }
+
   ManagedArray<T> array = ManagedArray<T>(record, space);
 
   if (!std::is_const<T>::value) {

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -343,7 +343,7 @@ void ManagedArray<T>::move(ExecutionSpace space)
 
   /* When moving from GPU to CPU we need to move the inner arrays after the outer array. */
 #if defined(CHAI_ENABLE_CUDA)
-  if (prev_space == GPU) {
+  if (space != GPU && prev_space == GPU) {
     moveInnerImpl(space);
   }
 #endif


### PR DESCRIPTION
This PR fixes a few bugs with ManagedArray:

- When creating an unowned ManagedArray with `chai::makeManagedArray`, the per-execution space allocators in the corresponding PointerRecord aren't set; as a result, when a move to the GPU space is triggered, the GPU space pointer is allocated in the host space.
- Moves on an unowned ManagedArray also overwrite the ownership data in the PointerRecord to all `true`. On a subsequent call to `ManagedArray::free()`, the ArrayManager will try to delete the externally-owned pointer, which will segfault if the pointer isn't allocated through malloc.
- Trying to move a nested ManagedArray to the GPU if it is already in the GPU execution space will segfault; this is because the host-side call to `ManagedArray::moveInnerImpl` attempts to call the underlying nested move on a GPU-side pointer.