### PR TITLE
Give more info to callbacks

### DIFF
--- a/src/chai/ArrayManager.cpp
+++ b/src/chai/ArrayManager.cpp
@@ -71,8 +71,7 @@ void ArrayManager::registerPointer(
                    pointer << " already there.  Deleting abandoned pointer record.");
 
         PointerRecord *foundRecord = *(found_pointer_record_pair->second);
-
-        callback(foundRecord, ACTION_FOUND_ABANDONED, space, foundRecord->m_size);
+        callback(foundRecord, ACTION_FOUND_ABANDONED, space);
 
         for (int fspace = 0; fspace < NUM_EXECUTION_SPACES; ++fspace) {
            foundRecord->m_pointers[fspace] = nullptr;
@@ -224,9 +223,12 @@ void ArrayManager::move(PointerRecord* record, ExecutionSpace space)
   if (!record->m_touched[record->m_last_space]) {
     return;
   } else {
-    callback(record, ACTION_MOVE, space, record->m_size);
-    std::lock_guard<std::mutex> lock(m_mutex);
-    m_resource_manager.copy(dst_pointer, src_pointer);
+    {
+      std::lock_guard<std::mutex> lock(m_mutex);
+      m_resource_manager.copy(dst_pointer, src_pointer);
+    }
+
+    callback(record, ACTION_MOVE, space);
   }
 
   resetTouch(record);
@@ -239,8 +241,8 @@ void ArrayManager::allocate(
   auto size = pointer_record->m_size;
   auto alloc = m_resource_manager.getAllocator(pointer_record->m_allocators[space]);
 
-  callback(pointer_record, ACTION_ALLOC, space, size);
-  pointer_record->m_pointers[space] =  alloc.allocate(size);
+  pointer_record->m_pointers[space] = alloc.allocate(size);
+  callback(pointer_record, ACTION_ALLOC, space);
 
   registerPointer(pointer_record, space);
 
@@ -260,8 +262,7 @@ void ArrayManager::free(PointerRecord* pointer_record, ExecutionSpace spaceToFre
           if (space_ptr == pointer_record->m_pointers[UM]) {
             callback(pointer_record,
                      ACTION_FREE,
-                     ExecutionSpace(UM),
-                     pointer_record->m_size);
+                     ExecutionSpace(UM));
             {
               std::lock_guard<std::mutex> lock(m_mutex);
               m_pointer_map.erase(space_ptr);
@@ -279,8 +280,7 @@ void ArrayManager::free(PointerRecord* pointer_record, ExecutionSpace spaceToFre
 #endif
             callback(pointer_record,
                      ACTION_FREE,
-                     ExecutionSpace(space),
-                     pointer_record->m_size);
+                     ExecutionSpace(space));
             {
               std::lock_guard<std::mutex> lock(m_mutex);
               m_pointer_map.erase(space_ptr);
@@ -354,7 +354,7 @@ PointerRecord* ArrayManager::makeManaged(void* pointer,
   pointer_record->m_pointers[space] = pointer;
   pointer_record->m_owned[space] = owned;
   pointer_record->m_size = size;
-  pointer_record->m_user_callback = [](Action, ExecutionSpace, size_t) {};
+  pointer_record->m_user_callback = [] (const PointerRecord*, Action, ExecutionSpace) {};
 
   registerPointer(pointer_record, space, owned);
 
@@ -373,7 +373,7 @@ PointerRecord* ArrayManager::deepCopyRecord(PointerRecord const* record)
   PointerRecord* copy = new PointerRecord{};
   const size_t size = record->m_size;
   copy->m_size = size;
-  copy->m_user_callback = [](Action, ExecutionSpace, size_t) {};
+  copy->m_user_callback = [] (const PointerRecord*, Action, ExecutionSpace) {};
 
   const ExecutionSpace last_space = record->m_last_space;
 

--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -329,12 +329,11 @@ private:
    * \param space The space in which the event occurred
    * \param size The number of bytes in the array associated with this pointer record
    */
-  inline void callback(PointerRecord* record,
+  inline void callback(const PointerRecord* record,
                        Action action,
-                       ExecutionSpace space,
-                       size_t size) const {
+                       ExecutionSpace space) const {
      if (m_callbacks_active && record) {
-        record->m_user_callback(action, space, size);
+        record->m_user_callback(record, action, space);
      }
   }
 

--- a/src/chai/ArrayManager.inl
+++ b/src/chai/ArrayManager.inl
@@ -36,35 +36,43 @@ void* ArrayManager::reallocate(void* pointer, size_t elems, PointerRecord* point
   }
 
   for (int space = CPU; space < NUM_EXECUTION_SPACES; ++space) {
-    if(!pointer_record->m_owned[space]) {
+    if (!pointer_record->m_owned[space]) {
       CHAI_LOG(Debug, "Cannot reallocate unowned pointer");
       return pointer_record->m_pointers[my_space];
     }
   }
 
+  // Call callback with ACTION_FREE before changing the size
+  for (int space = CPU; space < NUM_EXECUTION_SPACES; ++space) {
+    if (pointer_record->m_pointers[space]) {
+       callback(pointer_record, ACTION_FREE, ExecutionSpace(space));
+    }
+  }
+
+  // Update the pointer record size
+  size_t old_size = pointer_record->m_size;
+  size_t new_size = sizeof(T) * elems;
+  pointer_record->m_size = new_size;
+
   // only copy however many bytes overlap
-  size_t num_bytes_to_copy = std::min(sizeof(T)*elems, pointer_record->m_size);
+  size_t num_bytes_to_copy = std::min(old_size, new_size);
 
   for (int space = CPU; space < NUM_EXECUTION_SPACES; ++space) {
     void* old_ptr = pointer_record->m_pointers[space];
 
     if (old_ptr) {
-      callback(pointer_record, ACTION_ALLOC, ExecutionSpace(space), sizeof(T) * elems);
-      void* new_ptr = m_allocators[space]->allocate(sizeof(T)*elems);
-
+      void* new_ptr = m_allocators[space]->allocate(new_size);
       m_resource_manager.copy(new_ptr, old_ptr, num_bytes_to_copy);
-
-      callback(pointer_record, ACTION_FREE, ExecutionSpace(space), sizeof(T) * elems);
       m_allocators[space]->deallocate(old_ptr);
 
       pointer_record->m_pointers[space] = new_ptr;
+      callback(pointer_record, ACTION_ALLOC, ExecutionSpace(space));
 
       m_pointer_map.erase(old_ptr);
       m_pointer_map.insert(new_ptr, pointer_record);
     }
   }
 
-  pointer_record->m_size = sizeof(T) * elems;
   return pointer_record->m_pointers[my_space];
 }
 

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -128,7 +128,7 @@ public:
   CHAI_HOST void allocate(size_t elems,
                           ExecutionSpace space = CPU,
                           UserCallback const& cback =
-                          [](Action, ExecutionSpace, size_t) {});
+                          [] (const PointerRecord*, Action, ExecutionSpace) {});
 
   /*!
    * \brief Reallocate data for the ManagedArray.

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -28,7 +28,7 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray():
 
   m_pointer_record = new PointerRecord{};
   m_pointer_record->m_size = 0;
-  m_pointer_record->m_user_callback = [](Action, ExecutionSpace, size_t) {};
+  m_pointer_record->m_user_callback = [] (const PointerRecord*, Action, ExecutionSpace) {};
 
   for (int space = CPU;  space < NUM_EXECUTION_SPACES; space++) {
     m_pointer_record->m_allocators[space] = 

--- a/src/chai/PointerRecord.hpp
+++ b/src/chai/PointerRecord.hpp
@@ -61,7 +61,7 @@ struct PointerRecord {
    *
    */
   PointerRecord() : m_size(0), m_last_space(NONE) { 
-     m_user_callback = [] (Action, ExecutionSpace, size_t) {};
+     m_user_callback = [] (const PointerRecord*, Action, ExecutionSpace) {};
      for (int space = 0; space < NUM_EXECUTION_SPACES; ++space ) {
         m_pointers[space] = nullptr;
         m_touched[space] = false;

--- a/src/chai/Types.hpp
+++ b/src/chai/Types.hpp
@@ -7,7 +7,11 @@
 #ifndef CHAI_Types_HPP
 #define CHAI_Types_HPP
 
+// Std library headers
 #include <functional>
+
+// CHAI headers
+#include "chai/ExecutionSpaces.hpp"
 
 #if defined(_WIN32) && !defined(CHAISTATICLIB)
 #ifdef CHAISHAREDDLL_EXPORTS
@@ -21,13 +25,13 @@
 
 namespace chai
 {
+  struct PointerRecord;
 
-typedef unsigned int uint;
+  typedef unsigned int uint;
 
-enum Action { ACTION_ALLOC, ACTION_FREE, ACTION_MOVE, ACTION_FOUND_ABANDONED };
+  enum Action { ACTION_ALLOC, ACTION_FREE, ACTION_MOVE, ACTION_FOUND_ABANDONED };
 
-using UserCallback = std::function<void(Action, ExecutionSpace, std::size_t)>;
-
+  using UserCallback = std::function<void(const PointerRecord*, Action, ExecutionSpace)>;
 } // end of namespace chai
 
 

--- a/tests/integration/managed_array_tests.cpp
+++ b/tests/integration/managed_array_tests.cpp
@@ -798,7 +798,8 @@ GPU_TEST(ManagedArray, UserCallback)
   chai::ManagedArray<float> array;
   array.allocate(20,
                  chai::CPU,
-                 [&](chai::Action act, chai::ExecutionSpace s, size_t bytes) {
+                 [&] (const chai::PointerRecord* record, chai::Action act, chai::ExecutionSpace s) {
+                    const size_t bytes = record->m_size;
                     printf("cback: act=%d, space=%d, bytes=%ld\n",
                       (int)act, (int)s, (long)bytes);
                    if (act == chai::ACTION_MOVE) {
@@ -842,8 +843,9 @@ GPU_TEST(ManagedArray, CallBackConst)
   int num_h2d = 0;
   int num_d2h = 0;
 
-  auto callBack = [&](chai::Action act, chai::ExecutionSpace s, size_t bytes)
+  auto callBack = [&](const chai::PointerRecord* record, chai::Action act, chai::ExecutionSpace s)
   {
+    const size_t bytes = record->m_size;
     printf("cback: act=%d, space=%d, bytes=%ld\n", (int) act, (int) s, (long) bytes);
     if (act == chai::ACTION_MOVE)
     {
@@ -898,8 +900,9 @@ GPU_TEST(ManagedArray, CallBackConstArray)
   int num_h2d = 0;
   int num_d2h = 0;
 
-  auto callBack = [&](chai::Action act, chai::ExecutionSpace s, size_t bytes)
+  auto callBack = [&] (const chai::PointerRecord* record, chai::Action act, chai::ExecutionSpace s)
   {
+    const size_t bytes = record->m_size;
     printf("cback: act=%d, space=%d, bytes=%ld\n", (int) act, (int) s, (long) bytes);
     if (act == chai::ACTION_MOVE)
     {
@@ -997,8 +1000,9 @@ GPU_TEST(ManagedArray, CallBackConstArrayConst)
   int num_h2d = 0;
   int num_d2h = 0;
 
-  auto callBack = [&](chai::Action act, chai::ExecutionSpace s, size_t bytes)
+  auto callBack = [&] (const chai::PointerRecord* record, chai::Action act, chai::ExecutionSpace s)
   {
+    const size_t bytes = record->m_size;
     printf("cback: act=%d, space=%d, bytes=%ld\n", (int) act, (int) s, (long) bytes);
     if (act == chai::ACTION_MOVE)
     {

--- a/tests/unit/array_manager_unit_tests.cpp
+++ b/tests/unit/array_manager_unit_tests.cpp
@@ -88,7 +88,7 @@ TEST(ArrayManager, controlCallbacks)
   // Allocate one array and set a callback
   size_t sizeOfArray = 5;
   chai::ManagedArray<int> array1(sizeOfArray, chai::CPU);
-  array1.setUserCallback([&] (chai::Action, chai::ExecutionSpace, std::size_t) {
+  array1.setUserCallback([&] (const chai::PointerRecord*, chai::Action, chai::ExecutionSpace) {
                            callbacksAreOn = true;
                          });
 
@@ -104,7 +104,7 @@ TEST(ArrayManager, controlCallbacks)
 
   // Allocate another array and set a callback
   chai::ManagedArray<int> array2(sizeOfArray, chai::CPU);
-  array2.setUserCallback([&] (chai::Action, chai::ExecutionSpace, std::size_t) {
+  array2.setUserCallback([&] (const chai::PointerRecord*, chai::Action, chai::ExecutionSpace) {
                            callbacksAreOn = true;
                          });
 
@@ -120,7 +120,7 @@ TEST(ArrayManager, controlCallbacks)
 
   // Allocate a third array and set a callback
   chai::ManagedArray<int> array3(sizeOfArray, chai::CPU);
-  array3.setUserCallback([&] (chai::Action, chai::ExecutionSpace, std::size_t) {
+  array3.setUserCallback([&] (const chai::PointerRecord*, chai::Action, chai::ExecutionSpace) {
                            callbacksAreOn = true;
                          });
 


### PR DESCRIPTION
This PR updates the callback signature to take the (const) PointerRecord instead of the size. From the pointer record, the size can easily be regained. To that effect, I have moved calls to the callback so the pointer record always has the correct size and data (ALLOC after the allocation has happened, MOVE after the move has happened, and FREE before the deallocation has happened).

The more important effect of this is to allow functors and data encapsulation to be used more easily. See the example below. That functor encapsulates the data I need cleanly and allows me to easily update that data (in a lambda, I would need to have pointers to static global data).

```
class MemoryMotionLogger {
   public:
      void operator(const PointerRecord* record, Action action, ExecutionSpace space) {
         if (action == ACTION_MOVE) {
            std::string name = m_records_to_names[record];
            printf("%s: At location %s moved %lu bytes to space %i\n", name.c_str(), m_location.c_str(), record->m_size, space);
         }

      static void setLocation(std::string location) { m_location = location; }

      static void setName(const PointerRecord* record, std::string name) {
         m_records_to_names[record] = name;
      }

   private:
      static std::string location;
      static std::unordered_map<const PointerRecord*, std::string> m_records_to_names;
};
```