### PR TITLE
Add a global callback

### DIFF
--- a/src/chai/ArrayManager.cpp
+++ b/src/chai/ArrayManager.cpp
@@ -333,6 +333,11 @@ void ArrayManager::setUserCallback(void* pointer, UserCallback const& f)
   pointer_record->m_user_callback = f;
 }
 
+void ArrayManager::setUserCallback(UserCallback const& f)
+{
+  m_user_callback = f;
+}
+
 PointerRecord* ArrayManager::getPointerRecord(void* pointer)
 {
   std::lock_guard<std::mutex> lock(m_mutex);

--- a/src/chai/ArrayManager.cpp
+++ b/src/chai/ArrayManager.cpp
@@ -333,7 +333,7 @@ void ArrayManager::setUserCallback(void* pointer, UserCallback const& f)
   pointer_record->m_user_callback = f;
 }
 
-void ArrayManager::setUserCallback(UserCallback const& f)
+void ArrayManager::setGlobalUserCallback(UserCallback const& f)
 {
   m_user_callback = f;
 }

--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -185,7 +185,7 @@ public:
    * \brief Assign a user-defined callback triggered upon memory operations.
    *        This callback applies to all ManagedArrays.
    */
-  CHAISHAREDDLL_API void setUserCallback(UserCallback const& f);
+  CHAISHAREDDLL_API void setGlobalUserCallback(UserCallback const& f);
 
   /*!
    * \brief Set touched to false in all spaces for the given PointerRecord.

--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -176,9 +176,16 @@ public:
                              bool owned);
 
   /*!
-   * \brief Assign a user-defined callback triggerd upon memory operations.
+   * \brief Assign a user-defined callback triggered upon memory operations.
+   *        This callback applies to a single ManagedArray.
    */
   CHAISHAREDDLL_API void setUserCallback(void* pointer, UserCallback const& f);
+
+  /*!
+   * \brief Assign a user-defined callback triggered upon memory operations.
+   *        This callback applies to all ManagedArrays.
+   */
+  CHAISHAREDDLL_API void setUserCallback(UserCallback const& f);
 
   /*!
    * \brief Set touched to false in all spaces for the given PointerRecord.
@@ -332,8 +339,16 @@ private:
   inline void callback(const PointerRecord* record,
                        Action action,
                        ExecutionSpace space) const {
-     if (m_callbacks_active && record) {
-        record->m_user_callback(record, action, space);
+     if (m_callbacks_active) {
+        // Callback for this ManagedArray only
+        if (record && record->m_user_callback) {
+           record->m_user_callback(record, action, space);
+        }
+
+        // Callback for all ManagedArrays
+        if (m_user_callback) {
+           m_user_callback(record, action, space);
+        }
      }
   }
 
@@ -343,7 +358,7 @@ private:
   ExecutionSpace m_current_execution_space;
 
   /**
-   * Default space for new allocations
+   * Default space for new allocations.
    */
   ExecutionSpace m_default_allocation_space;
 
@@ -358,9 +373,20 @@ private:
    */
   umpire::Allocator* m_allocators[NUM_EXECUTION_SPACES];
 
+  /*!
+   * \brief The umpire resource manager.
+   */
   umpire::ResourceManager& m_resource_manager;
 
+  /*!
+   * \brief Used for thread-safe operations.
+   */
   mutable std::mutex m_mutex;
+
+  /*!
+   * \brief A callback triggered upon memory operations on all ManagedArrays.
+   */
+  UserCallback m_user_callback;
 
   /*!
    * \brief Controls whether or not callbacks are called.

--- a/tests/integration/managed_array_tests.cpp
+++ b/tests/integration/managed_array_tests.cpp
@@ -53,6 +53,20 @@ TEST(ManagedArray, Const)
 
   array.free();
 }
+
+TEST(ManagedArray, UserCallbackHost)
+{
+   bool callbackCalled = false;
+
+   chai::ManagedArray<float> array(10);
+   array.setUserCallback([&] (const chai::PointerRecord*, chai::Action, chai::ExecutionSpace) {
+                           callbackCalled = true;
+                         });
+
+   array.free();
+   ASSERT_TRUE(callbackCalled);
+}
+
 #endif
 
 TEST(ManagedArray, Slice) {

--- a/tests/unit/array_manager_unit_tests.cpp
+++ b/tests/unit/array_manager_unit_tests.cpp
@@ -132,4 +132,52 @@ TEST(ArrayManager, controlCallbacks)
   ASSERT_TRUE(callbacksAreOn);
 }
 
+/*!
+ * \brief Tests to see if global callback can be turned on or off
+ */
+TEST(ArrayManager, controlGlobalCallback)
+{
+  // First check that callbacks are turned on by default
+  chai::ArrayManager* arrayManager = chai::ArrayManager::getInstance();
+
+  // Variable for testing if callbacks are on or off
+  bool callbacksAreOn = false;
+
+  // Set a global callback
+  arrayManager->setUserCallback([&] (const chai::PointerRecord*, chai::Action, chai::ExecutionSpace) {
+                                  callbacksAreOn = true;
+                                });
+
+  // Allocate an array and make sure the callback was called
+  size_t sizeOfArray = 5;
+  chai::ManagedArray<int> array(sizeOfArray, chai::CPU);
+  ASSERT_TRUE(callbacksAreOn);
+
+  // Now turn off callbacks
+  arrayManager->disableCallbacks();
+
+  // Reset the variable for testing if callbacks are on or off
+  callbacksAreOn = false;
+
+  // Realloc the array and make sure the callback was NOT called
+  array.reallocate(2 * sizeOfArray);
+  ASSERT_FALSE(callbacksAreOn);
+
+  // Now make sure the order doesn't matter for when the callback is set compared
+  // to when callbacks are enabled
+  arrayManager->setUserCallback([&] (const chai::PointerRecord*, chai::Action, chai::ExecutionSpace) {
+                                  callbacksAreOn = true;
+                                });
+
+  // Reset the variable for testing if callbacks are on or off
+  callbacksAreOn = false;
+
+  // Turn on callbacks
+  arrayManager->enableCallbacks();
+
+  // Make sure the callback is called
+  array.free();
+  ASSERT_TRUE(callbacksAreOn);
+}
+
 #endif // !CHAI_DISABLE_RM

--- a/tests/unit/array_manager_unit_tests.cpp
+++ b/tests/unit/array_manager_unit_tests.cpp
@@ -144,9 +144,9 @@ TEST(ArrayManager, controlGlobalCallback)
   bool callbacksAreOn = false;
 
   // Set a global callback
-  arrayManager->setUserCallback([&] (const chai::PointerRecord*, chai::Action, chai::ExecutionSpace) {
-                                  callbacksAreOn = true;
-                                });
+  arrayManager->setGlobalUserCallback([&] (const chai::PointerRecord*, chai::Action, chai::ExecutionSpace) {
+                                        callbacksAreOn = true;
+                                      });
 
   // Allocate an array and make sure the callback was called
   size_t sizeOfArray = 5;
@@ -165,9 +165,9 @@ TEST(ArrayManager, controlGlobalCallback)
 
   // Now make sure the order doesn't matter for when the callback is set compared
   // to when callbacks are enabled
-  arrayManager->setUserCallback([&] (const chai::PointerRecord*, chai::Action, chai::ExecutionSpace) {
-                                  callbacksAreOn = true;
-                                });
+  arrayManager->setGlobalUserCallback([&] (const chai::PointerRecord*, chai::Action, chai::ExecutionSpace) {
+                                        callbacksAreOn = true;
+                                      });
 
   // Reset the variable for testing if callbacks are on or off
   callbacksAreOn = false;


### PR DESCRIPTION
This pull request adds a global callback that applies to all ManagedArrays. This can provide a greatly simplified interface to work with in many cases.