### PR TITLE
Feature/probinso/null move inner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@ install*/
 .vscode/
 *.swp
 *.swo
+Win32/chai.vcxproj.user
+Win32/.vs/
+Win32/x64/
 *.aps

--- a/docs/sphinx/advanced_configuration.rst
+++ b/docs/sphinx/advanced_configuration.rst
@@ -37,7 +37,7 @@ These arguments are explained in more detail below:
   GPU_SIMULATION_MODE support, then only the ``CPU`` execution space is available for use.
 
 * ENABLE_GPU_SIMULATION_MODE
-  This option simulates GPU support by enableing the GPU execution space, backed by a HOST
+  This option simulates GPU support by enabling the GPU execution space, backed by a HOST
   umpire allocator. If CHAI is built without CUDA, HIP, or GPU_SIMULATION_MODE support, 
   then only the ``CPU`` execution space is available for use.
 

--- a/src/chai/ArrayManager.cpp
+++ b/src/chai/ArrayManager.cpp
@@ -15,7 +15,6 @@ namespace chai
 
 PointerRecord ArrayManager::s_null_record = PointerRecord();
 
-CHAI_HOST_DEVICE
 ArrayManager* ArrayManager::getInstance()
 {
   static ArrayManager s_resource_manager_instance;

--- a/src/chai/ArrayManager.cpp
+++ b/src/chai/ArrayManager.cpp
@@ -67,7 +67,7 @@ void ArrayManager::registerPointer(
      PointerRecord ** found_pointer_record_addr = found_pointer_record_pair->second;
      if (found_pointer_record_addr != nullptr) {
 
-        PointerRecord *foundRecord = *(found_pointer_record_pair->second);
+        PointerRecord *foundRecord = *found_pointer_record_addr;
         // if it's actually the same pointer record, then we're OK. If it's a different
         // one, delete the old one.
         if (foundRecord != record) {
@@ -76,7 +76,7 @@ void ArrayManager::registerPointer(
 
            callback(foundRecord, ACTION_FOUND_ABANDONED, space);
 
-           for (int fspace = 0; fspace < NUM_EXECUTION_SPACES; ++fspace) {
+           for (int fspace = CPU; fspace < NUM_EXECUTION_SPACES; ++fspace) {
               foundRecord->m_pointers[fspace] = nullptr;
            }
 
@@ -122,7 +122,7 @@ void ArrayManager::deregisterPointer(PointerRecord* record, bool deregisterFromU
        if (deregisterFromUmpire) {
           m_resource_manager.deregisterAllocation(pointer);
        }
-       CHAI_LOG(Debug, "DeRegistering " << pointer);
+       CHAI_LOG(Debug, "De-registering " << pointer);
        m_pointer_map.erase(pointer);
     }
   }
@@ -176,7 +176,6 @@ ExecutionSpace ArrayManager::getExecutionSpace()
 
 void ArrayManager::registerTouch(PointerRecord* pointer_record)
 {
-  if (m_current_execution_space == NONE) return;
   registerTouch(pointer_record, m_current_execution_space);
 }
 
@@ -300,7 +299,7 @@ void ArrayManager::free(PointerRecord* pointer_record, ExecutionSpace spaceToFre
         }
         else
         {
-          m_resource_manager.deregisterAllocation(pointer_record->m_pointers[space]);
+          m_resource_manager.deregisterAllocation(space_ptr);
         }
         {
           std::lock_guard<std::mutex> lock(m_mutex);

--- a/src/chai/ArrayManager.cpp
+++ b/src/chai/ArrayManager.cpp
@@ -214,7 +214,7 @@ void ArrayManager::move(PointerRecord* record, ExecutionSpace space)
   }
 #endif
 
-  callback(record, ACTION_CAPTURED, space, record->m_size);
+  callback(record, ACTION_CAPTURED, space);
 
   if (space == record->m_last_space) {
     return;

--- a/src/chai/ArrayManager.cpp
+++ b/src/chai/ArrayManager.cpp
@@ -358,6 +358,10 @@ PointerRecord* ArrayManager::makeManaged(void* pointer,
                                          ExecutionSpace space,
                                          bool owned)
 {
+  if (space == NONE) {
+    space = getDefaultAllocationSpace();
+  }
+
   m_resource_manager.registerAllocation(
       pointer,
       {pointer, size, m_allocators[space]->getAllocationStrategy()});

--- a/src/chai/ArrayManager.cpp
+++ b/src/chai/ArrayManager.cpp
@@ -391,13 +391,6 @@ PointerRecord* ArrayManager::makeManaged(void* pointer,
      registerPointer(pointer_record, space, owned);
   }
 
-  // TODO Is this a problem?
-  // for (int i = 0; i < NUM_EXECUTION_SPACES; i++) {
-  //   // If pointer is already active on some execution space, return that
-  //   pointer if(pointer_record->m_touched[i] == true)
-  //     return pointer_record->m_pointers[i];
-  // }
-
   return pointer_record;
 }
 

--- a/src/chai/ArrayManager.cpp
+++ b/src/chai/ArrayManager.cpp
@@ -172,18 +172,16 @@ ExecutionSpace ArrayManager::getExecutionSpace()
 void ArrayManager::registerTouch(PointerRecord* pointer_record)
 {
   if (m_current_execution_space == NONE) return;
-  if (pointer_record) {
-     registerTouch(pointer_record, m_current_execution_space);
-  }
+  registerTouch(pointer_record, m_current_execution_space);
 }
 
 void ArrayManager::registerTouch(PointerRecord* pointer_record,
                                  ExecutionSpace space)
 {
-  if (pointer_record) {
-     CHAI_LOG(Debug, pointer_record->m_pointers[space] << " touched in space " << space);
+  if (pointer_record && pointer_record != s_null_record) {
 
      if (space != NONE) {
+       CHAI_LOG(Debug, pointer_record->m_pointers[space] << " touched in space " << space);
        std::lock_guard<std::mutex> lock(m_mutex);
        pointer_record->m_touched[space] = true;
        pointer_record->m_last_space = space;
@@ -316,7 +314,6 @@ void ArrayManager::free(PointerRecord* pointer_record, ExecutionSpace spaceToFre
   }
 }
 
-
 size_t ArrayManager::getSize(void* ptr)
 {
   // TODO
@@ -365,7 +362,11 @@ PointerRecord* ArrayManager::makeManaged(void* pointer,
 
   auto pointer_record = getPointerRecord(pointer);
   if (pointer_record == &s_null_record) {
-     pointer_record = new PointerRecord();
+     if (pointer) {
+        pointer_record = new PointerRecord();
+     } else {
+        return pointer_record;
+     }
   }
   pointer_record->m_pointers[space] = pointer;
   pointer_record->m_owned[space] = owned;

--- a/src/chai/ArrayManager.cpp
+++ b/src/chai/ArrayManager.cpp
@@ -183,7 +183,7 @@ void ArrayManager::registerTouch(PointerRecord* pointer_record)
 void ArrayManager::registerTouch(PointerRecord* pointer_record,
                                  ExecutionSpace space)
 {
-  if (pointer_record && pointer_record != s_null_record) {
+  if (pointer_record && pointer_record != &s_null_record) {
 
      if (space != NONE) {
        CHAI_LOG(Debug, pointer_record->m_pointers[space] << " touched in space " << space);

--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -237,11 +237,20 @@ public:
    */
   CHAISHAREDDLL_API size_t getTotalSize() const;
 
+  /*!
+   * \brief Calls callbacks of pointers still in the map with ACTION_LEAKED.
+   */
+  CHAISHAREDDLL_API void reportLeaks() const;
+
+  /*!
+   * \brief Get the allocator ID
+   *
+   * \return The allocator ID.
+   */
   CHAISHAREDDLL_API int getAllocatorId(ExecutionSpace space) const;
 
   /*!
    * \brief Wraps our resource manager's copy.
-   *
    */
   CHAISHAREDDLL_API void copy(void * dst, void * src, size_t size); 
   

--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -61,7 +61,6 @@ public:
    *
    */
   CHAISHAREDDLL_API
-  CHAI_HOST_DEVICE
   static ArrayManager* getInstance();
 
   /*!

--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -151,7 +151,7 @@ public:
 
   /*!
    * \brief Free allocation(s) associated with the given PointerRecord.
-   *        Default (space == NONE) will free all allocations and delete 
+   *        Default (space == NONE) will free all allocations and delete
    *        the pointer record.
    */
   CHAISHAREDDLL_API void free(PointerRecord* pointer, ExecutionSpace space = NONE);

--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -126,7 +126,9 @@ public:
    * \return Pointer to the allocated memory.
    */
   template <typename T>
-  void* reallocate(void* pointer, size_t elems, PointerRecord* record);
+  void* reallocate(void* pointer,
+                   size_t elems,
+                   PointerRecord* record);
 
   /*!
    * \brief Set the default space for new ManagedArray allocations.
@@ -149,17 +151,17 @@ public:
 
   /*!
    * \brief Free allocation(s) associated with the given PointerRecord.
-   *        Default (space == NONE) will free all allocations and delete
+   *        Default (space == NONE) will free all allocations and delete 
    *        the pointer record.
    */
   CHAISHAREDDLL_API void free(PointerRecord* pointer, ExecutionSpace space = NONE);
 
 #if defined(CHAI_ENABLE_PICK)
   template <typename T>
-  T_non_const<T> pick(T* src_ptr, size_t index);
+   T_non_const<T> pick(T* src_ptr, size_t index);
 
   template <typename T>
-  void set(T* dst_ptr, size_t index, const T& val);
+   void set(T* dst_ptr, size_t index, const T& val);
 #endif
 
   /*!
@@ -171,9 +173,9 @@ public:
   CHAISHAREDDLL_API size_t getSize(void* pointer);
 
   CHAISHAREDDLL_API PointerRecord* makeManaged(void* pointer,
-                             size_t size,
-                             ExecutionSpace space,
-                             bool owned);
+                                               size_t size,
+                                               ExecutionSpace space,
+                                               bool owned);
 
   /*!
    * \brief Assign a user-defined callback triggerd upon memory operations.
@@ -234,9 +236,43 @@ public:
    * \brief Wraps our resource manager's copy.
    *
    */
-  CHAISHAREDDLL_API void copy(void * dst, void * src, size_t size);
+  CHAISHAREDDLL_API void copy(void * dst, void * src, size_t size); 
+  
+  /*!
+   * \brief Registering an allocation with the ArrayManager
+   *
+   * \param record PointerRecord of this allocation.
+   * \param space Space in which the pointer was allocated.
+   * \param owned Should the allocation be free'd by CHAI?
+   */
+  CHAISHAREDDLL_API void registerPointer(PointerRecord* record,
+                                         ExecutionSpace space,
+                                         bool owned = true);
 
   /*!
+   * \brief Deregister a PointerRecord from the ArrayManager.
+   *
+   * \param record PointerRecord of allocation to deregister.
+   * \param deregisterFromUmpire If true, deregister from umpire as well.
+   */
+  CHAISHAREDDLL_API void deregisterPointer(PointerRecord* record, bool deregisterFromUmpire=false);
+
+  /*!
+   * \brief Returns the front of the allocation associated with this pointer, nullptr if allocation not found.
+   *
+   * \param pointer Pointer to address of that we want the front of the allocation for.
+   */
+  CHAISHAREDDLL_API void * frontOfAllocation(void * pointer);
+
+  /*!
+   * \brief set the allocator for an execution space.
+   *
+   * \param space Execution space to set the default allocator for.
+   * \param allocator The allocator to use for this space. Will be copied into chai.
+   */
+  void setAllocator(ExecutionSpace space, umpire::Allocator &allocator);
+
+ /*!
    * \brief Turn callbacks on.
    */
   void enableCallbacks() { m_callbacks_active = true; }
@@ -270,6 +306,7 @@ public:
    */
   CHAISHAREDDLL_API void evict(ExecutionSpace space, ExecutionSpace destinationSpace);
 
+
 protected:
   /*!
    * \brief Construct a new ArrayManager.
@@ -279,39 +316,9 @@ protected:
    */
   ArrayManager();
 
+
+
 private:
-
-  /*!
-   * \brief Registering an allocation with the ArrayManager
-   *
-   * \param record PointerRecord of this allocation.
-   * \param space Space in which the pointer was allocated.
-   * \param owned Should the allocation be free'd by CHAI?
-   */
-  void registerPointer(PointerRecord* record,
-                       ExecutionSpace space,
-                       bool owned = true);
-
-  /*!
-   * \brief Deregister a PointerRecord from the ArrayManager.
-   */
-  void deregisterPointer(PointerRecord* record, bool deregisterFromUmpire=false);
-
-  /*!
-   * \brief Returns the front of the allocation associated with this pointer, nullptr if allocation not found.
-   *
-   * \param pointer Pointer to address of that we want the front of the allocation for.
-   */
-  CHAISHAREDDLL_API void * frontOfAllocation(void * pointer);
-
-
-  /*!
-   * \brief set the allocator for an execution space.
-   *
-   * \param space Execution space to set the default allocator for.
-   * \param allocator The allocator to use for this space. Will be copied into chai.
-   */
-  void setAllocator(ExecutionSpace space, umpire::Allocator &allocator);
 
   /*!
    * \brief Move data in PointerRecord to the corresponding ExecutionSpace.
@@ -320,8 +327,8 @@ private:
    * \param space
    */
   void move(PointerRecord* record, ExecutionSpace space);
-
-  /*!
+  
+    /*!
    * \brief Execute a user callback if callbacks are active
    *
    * \param record The pointer record containing the callback

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -378,18 +378,20 @@ private:
   // trigger a moveInnerImpl, which expects inner values to be initialized.
   template <bool B = std::is_base_of<CHAICopyable, T>::value,
             typename std::enable_if<B, int>::type = 0>
-  CHAI_HOST void initInner(size_t start = 0)
+  CHAI_HOST bool initInner(size_t start = 0)
   {
     for (size_t i = start; i < m_elems; ++i) {
       m_active_base_pointer[i] = nullptr;
     }
+    return true;
   }
 
   // Do not deep initialize if T is not a CHAICopyable.
   template <bool B = std::is_base_of<CHAICopyable, T>::value,
             typename std::enable_if<!B, int>::type = 0>
-  CHAI_HOST void initInner(size_t = 0)
+  CHAI_HOST bool initInner(size_t = 0)
   {
+    return false;
   }
 #endif
 protected:

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -112,7 +112,7 @@ public:
    */
   CHAI_HOST_DEVICE ManagedArray(std::nullptr_t other);
 
-  CHAI_HOST_DEVICE ManagedArray(PointerRecord* record, ExecutionSpace space);
+  CHAI_HOST ManagedArray(PointerRecord* record, ExecutionSpace space);
 
   /*!
    * \brief Allocate data for the ManagedArray in the specified space.
@@ -342,7 +342,7 @@ private:
    */
   template <bool B = std::is_base_of<CHAICopyable, T>::value,
             typename std::enable_if<!B, int>::type = 0>
-  CHAI_HOST_DEVICE void moveInnerImpl();
+  CHAI_HOST void moveInnerImpl();
 #endif
 
 public:

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -89,9 +89,7 @@ public:
    * \param elems Number of elements in the array.
    * \param space Execution space in which to allocate the array.
    */
-  CHAI_HOST_DEVICE ManagedArray(
-      size_t elems,
-      ExecutionSpace space = NONE);
+  CHAI_HOST_DEVICE ManagedArray(size_t elems, ExecutionSpace space = NONE);
 
   CHAI_HOST_DEVICE ManagedArray(
       size_t elems,
@@ -130,6 +128,7 @@ public:
                           UserCallback const& cback =
                           [](Action, ExecutionSpace, size_t) {});
 
+
   /*!
    * \brief Reallocate data for the ManagedArray.
    *
@@ -142,7 +141,7 @@ public:
   /*!
    * \brief Free all data allocated by this ManagedArray.
    */
-  CHAI_HOST void free();
+  CHAI_HOST void free(ExecutionSpace space = NONE);
 
   /*!
    * \brief Reset array state.
@@ -166,9 +165,10 @@ public:
    */
   CHAI_HOST void registerTouch(ExecutionSpace space);
 
-  CHAI_HOST void move(ExecutionSpace space);
+  CHAI_HOST void move(ExecutionSpace space=NONE);
 
   CHAI_HOST_DEVICE ManagedArray<T> slice(size_t begin, size_t elems=(size_t)-1) const;
+
   /*!
    * \brief Return reference to i-th element of the ManagedArray.
    *
@@ -181,7 +181,7 @@ public:
 
   /*!
    * \brief get access to m_active_pointer
-   * @return a copy of m_active_pointer
+   * @return a copy of m_active_base_pointer
    */
   CHAI_HOST_DEVICE T* getActiveBasePointer() const;
 
@@ -222,6 +222,7 @@ public:
 
   CHAI_HOST_DEVICE ManagedArray<T>& operator=(std::nullptr_t);
 
+
   CHAI_HOST_DEVICE bool operator==(ManagedArray<T>& rhs) const;
   CHAI_HOST_DEVICE bool operator!=(ManagedArray<T>& from) const;
 
@@ -233,6 +234,7 @@ public:
 
 
   CHAI_HOST_DEVICE explicit operator bool() const;
+
 
 #if defined(CHAI_ENABLE_PICK)
   /*!
@@ -291,8 +293,8 @@ public:
    */
   template <bool Q = false>
   CHAI_HOST_DEVICE ManagedArray(T* data,
-                               CHAIDISAMBIGUATE test = CHAIDISAMBIGUATE(),
-                               bool foo = Q);
+                                CHAIDISAMBIGUATE test = CHAIDISAMBIGUATE(),
+                                bool foo = Q);
 #endif
 
 
@@ -310,14 +312,13 @@ public:
    */
   CHAI_HOST void setUserCallback(UserCallback const& cback)
   {
-    m_pointer_record->m_user_callback = cback;
+    if (m_pointer_record && m_pointer_record != &ArrayManager::s_null_record) {
+      m_pointer_record->m_user_callback = cback;
+    }
   }
-#endif
 
 
 private:
-  CHAI_HOST void modify(size_t i, const T& val) const;
-
   /*!
    * \brief Moves the inner data of a ManagedArray.
    *
@@ -328,7 +329,7 @@ private:
    */
   template <bool B = std::is_base_of<CHAICopyable, T>::value,
             typename std::enable_if<B, int>::type = 0>
-  CHAI_HOST void moveInnerImpl(ExecutionSpace space);
+  CHAI_HOST void moveInnerImpl();
 
   /*!
    * \brief Does nothing since the inner data type does not inherit from
@@ -341,8 +342,56 @@ private:
    */
   template <bool B = std::is_base_of<CHAICopyable, T>::value,
             typename std::enable_if<!B, int>::type = 0>
-  CHAI_HOST void moveInnerImpl(ExecutionSpace space);
+  CHAI_HOST_DEVICE void moveInnerImpl();
+#endif
 
+public:
+  CHAI_HOST_DEVICE void shallowCopy(ManagedArray<T> const& other) const
+  {
+    m_active_pointer = other.m_active_pointer;
+    m_active_base_pointer = other.m_active_base_pointer;
+    m_resource_manager = other.m_resource_manager;
+    m_elems = other.m_elems;
+    m_offset = other.m_offset;
+    m_pointer_record = other.m_pointer_record;
+    m_is_slice = other.m_is_slice;
+#ifndef CHAI_DISABLE_RM
+#ifndef __CUDA_ARCH__
+  // if we can, ensure elems is based off the pointer_record size to protect against
+  // casting leading to incorrect size info in m_elems.
+  if (m_pointer_record != nullptr) {
+     m_elems = m_pointer_record->m_size / sizeof(T);
+  }
+#endif
+#endif
+  }
+
+
+private:
+  CHAI_HOST void modify(size_t i, const T& val) const;
+  // The following are only used by ManagedArray.inl, but for template
+  // shenanigan reasons need to be defined here.
+#if !defined(CHAI_DISABLE_RM)
+  // if T is a CHAICopyable, then it is important to initialize all the
+  // ManagedArrays to nullptr at allocation, since it is extremely easy to
+  // trigger a moveInnerImpl, which expects inner values to be initialized.
+  template <bool B = std::is_base_of<CHAICopyable, T>::value,
+            typename std::enable_if<B, int>::type = 0>
+  CHAI_HOST void initInner(size_t start = 0)
+  {
+    for (size_t i = start; i < m_elems; ++i) {
+      m_active_base_pointer[i] = nullptr;
+    }
+  }
+
+  // Do not deep initialize if T is not a CHAICopyable.
+  template <bool B = std::is_base_of<CHAICopyable, T>::value,
+            typename std::enable_if<!B, int>::type = 0>
+  CHAI_HOST void initInner(size_t = 0)
+  {
+  }
+#endif
+protected:
   /*!
    * Currently active data pointer.
    */
@@ -364,9 +413,8 @@ private:
    * Pointer to PointerRecord data.
    */
   mutable PointerRecord* m_pointer_record = nullptr;
- 
+
   mutable bool m_is_slice = false;
- 
 };
 
 /*!
@@ -424,7 +472,7 @@ template <typename T>
 ManagedArray<T> deepCopy(ManagedArray<T> const& array)
 {
   T* data_ptr = array.getActiveBasePointer();
-  
+
   ArrayManager* manager = ArrayManager::getInstance();
 
   PointerRecord const* record = manager->getPointerRecord(data_ptr);
@@ -465,5 +513,4 @@ CHAI_INLINE CHAI_HOST_DEVICE ManagedArray<T> ManagedArray<T>::slice( size_t offs
 #else
 #include "chai/ManagedArray.inl"
 #endif
-
 #endif  // CHAI_ManagedArray_HPP

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -166,7 +166,7 @@ public:
    */
   CHAI_HOST void registerTouch(ExecutionSpace space);
 
-  CHAI_HOST void move(ExecutionSpace space=NONE);
+  CHAI_HOST void move(ExecutionSpace space=NONE) const;
 
   CHAI_HOST_DEVICE ManagedArray<T> slice(size_t begin, size_t elems=(size_t)-1) const;
 
@@ -330,7 +330,7 @@ private:
    */
   template <bool B = std::is_base_of<CHAICopyable, T>::value,
             typename std::enable_if<B, int>::type = 0>
-  CHAI_HOST void moveInnerImpl();
+  CHAI_HOST void moveInnerImpl() const; 
 
   /*!
    * \brief Does nothing since the inner data type does not inherit from
@@ -343,7 +343,7 @@ private:
    */
   template <bool B = std::is_base_of<CHAICopyable, T>::value,
             typename std::enable_if<!B, int>::type = 0>
-  CHAI_HOST void moveInnerImpl();
+  CHAI_HOST void moveInnerImpl() const;
 #endif
 
 public:

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -129,6 +129,7 @@ public:
                           [] (const PointerRecord*, Action, ExecutionSpace) {});
 
 
+
   /*!
    * \brief Reallocate data for the ManagedArray.
    *

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -364,7 +364,7 @@ CHAI_HOST_DEVICE void ManagedArray<T>::decr(size_t i) const {
 template <typename T>
 CHAI_INLINE
 CHAI_HOST
-void ManagedArray<T>::move(ExecutionSpace space)
+void ManagedArray<T>::move(ExecutionSpace space) const
 {
   if (m_pointer_record != &ArrayManager::s_null_record) {
      ExecutionSpace prev_space = m_pointer_record->m_last_space;
@@ -594,7 +594,7 @@ template<bool B, typename std::enable_if<B, int>::type>
 CHAI_INLINE
 CHAI_HOST
 void
-ManagedArray<T>::moveInnerImpl()
+ManagedArray<T>::moveInnerImpl() const
 {
   int len = m_pointer_record->m_size / sizeof(T);
   T * host_ptr = (T *) m_pointer_record->m_pointers[CPU]; 
@@ -612,7 +612,7 @@ template<bool B, typename std::enable_if<!B, int>::type>
 CHAI_INLINE
 CHAI_HOST
 void
-ManagedArray<T>::moveInnerImpl()
+ManagedArray<T>::moveInnerImpl() const
 {
 }
 

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -168,8 +168,11 @@ CHAI_HOST void ManagedArray<T>::allocate(
           space = m_resource_manager->getDefaultAllocationSpace();
        }
        if (m_pointer_record == &ArrayManager::s_null_record) {
-          // since we are about to allocate, this will get registered
-          m_pointer_record = new PointerRecord();
+         // since we are about to allocate, this will get registered
+         m_pointer_record = new PointerRecord();
+         for (int space = CPU; space < NUM_EXECUTION_SPACES; ++space) {
+           m_pointer_record->m_allocators[space] = m_resource_manager->getAllocatorId(ExecutionSpace(space));
+         }
        }
 
        m_pointer_record->m_user_callback = cback;

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -25,7 +25,7 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray():
 {
 #if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
   m_resource_manager = ArrayManager::getInstance();
-  m_pointer_record = &s_null_record;
+  m_pointer_record = &ArrayManager::s_null_record;
 #endif
 }
 
@@ -102,7 +102,7 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(std::nullptr_t) :
 {
 #if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
    m_resource_manager = ArrayManager::getInstance();
-   m_pointer_record = &ArrayManager::s_null_record();
+   m_pointer_record = &ArrayManager::s_null_record;
 #endif
 }
 
@@ -163,7 +163,7 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(T* data, ArrayManager* array_mana
    if (m_resource_manager == nullptr) {
       m_resource_manager = ArrayManager::getInstance();
    }
-   if (m_pointer_record == &chai::ArrayManager::s_null_record || m_pointer_record==nullptr) {
+   if (m_pointer_record == &ArrayManager::s_null_record || m_pointer_record==nullptr) {
       bool owned = true;
       m_pointer_record = m_resource_manager->makeManaged((void *) data, sizeof(T)*m_elems,ExecutionSpace(CPU),true);
    }
@@ -185,7 +185,7 @@ CHAI_HOST void ManagedArray<T>::allocate(
        if (space == NONE) {
           space = m_resource_manager->getDefaultAllocationSpace();
        }
-       if (m_pointer_record == &chai::ArrayManager::s_null_record) {
+       if (m_pointer_record == &ArrayManager::s_null_record) {
           m_pointer_record = m_resource_manager->makeManaged((void *) m_active_base_pointer,m_elems*sizeof(T),CPU,true);
        }
 
@@ -221,7 +221,7 @@ CHAI_HOST void ManagedArray<T>::reallocate(size_t elems)
         return allocate(elems, CPU);
       }
       CHAI_LOG(Debug, "Reallocating array of size " << m_elems << " with new size" << elems);
-      if (m_pointer_record == &chai::ArrayManager::s_null_record) {
+      if (m_pointer_record == &ArrayManager::s_null_record) {
          m_pointer_record = m_resource_manager->makeManaged((void *)m_active_base_pointer,m_elems*sizeof(T),CPU,true);
       }
       size_t old_size = m_elems;
@@ -264,7 +264,7 @@ CHAI_HOST void ManagedArray<T>::free(ExecutionSpace space)
     m_offset = 0;
     // The call to m_resource_manager::free, above, has deallocated m_pointer_record if space == NONE.
     if (space == NONE) {
-       m_pointer_record = &s_null_record;
+       m_pointer_record = &ArrayManager::s_null_record;
     }
     m_is_slice = false;
   } else {
@@ -540,7 +540,7 @@ ManagedArray<T>::operator= (std::nullptr_t) {
   m_elems = 0;
   m_offset = 0;
   #if !defined(__CUDA_ARCH__) && !defined(__HIP_DEVICE_COMPILE__)
-  m_pointer_record = ArrayManager::&s_null_record;
+  m_pointer_record = &ArrayManager::s_null_record;
   #else
   m_pointer_record = nullptr;
   #endif

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -168,7 +168,8 @@ CHAI_HOST void ManagedArray<T>::allocate(
           space = m_resource_manager->getDefaultAllocationSpace();
        }
        if (m_pointer_record == &ArrayManager::s_null_record) {
-          m_pointer_record = m_resource_manager->makeManaged((void *) m_active_base_pointer,m_elems*sizeof(T),space,true);
+          // since we are about to allocate, this will get registered
+          m_pointer_record = new PointerRecord();
        }
 
        m_pointer_record->m_user_callback = cback;

--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -56,9 +56,15 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(size_t elems, ExecutionSpace spac
 }
 
 
-template<typename T>
-CHAI_INLINE
-CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(std::nullptr_t)
+template <typename T>
+CHAI_INLINE CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(std::nullptr_t)
+    : m_active_pointer(nullptr),
+      m_active_base_pointer(nullptr),
+      m_resource_manager(nullptr),
+      m_elems(0),
+      m_offset(0),
+      m_pointer_record(nullptr),
+      m_is_slice(false)
 {
 }
 
@@ -260,6 +266,7 @@ ManagedArray<T>::ManagedArray(T* data, CHAIDISAMBIGUATE, bool) :
   m_resource_manager(nullptr),
   m_elems(-1),
   m_pointer_record(nullptr),
+  m_offset(0),
   m_is_slice(false)
 {
 }

--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -16,11 +16,10 @@
 namespace chai {
 
 template <typename T>
-CHAI_INLINE
-CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(
-   std::initializer_list<chai::ExecutionSpace> spaces,
-   std::initializer_list<umpire::Allocator> allocators) :
-  ManagedArray()
+CHAI_INLINE CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(
+    std::initializer_list<chai::ExecutionSpace> spaces,
+    std::initializer_list<umpire::Allocator> allocators)
+    : ManagedArray()
 {
   if (m_pointer_record) {
      int i = 0;
@@ -55,6 +54,7 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(size_t elems, ExecutionSpace spac
 {
   this->allocate(elems, space);
 }
+
 
 template<typename T>
 CHAI_INLINE
@@ -155,114 +155,127 @@ CHAI_HOST void ManagedArray<T>::reallocate(size_t new_elems)
   }
 }
 
-template<typename T>
-CHAI_INLINE
-CHAI_HOST void ManagedArray<T>::free()
+template <typename T>
+CHAI_INLINE CHAI_HOST void ManagedArray<T>::free(ExecutionSpace space)
 {
-  if (!m_is_slice) {
-  #if defined(CHAI_ENABLE_UM)
-    cudaFree(m_active_base_pointer);
-  #else
-    ::free((void *)m_active_base_pointer);
-  #endif
-
-    m_active_base_pointer = nullptr;
-    m_active_pointer = nullptr;
-  }
-  else {
-    CHAI_LOG(Debug, "tried to free slice!");
+  if (space == CPU || space == NONE) {
+    if (!m_is_slice) {
+#if defined(CHAI_ENABLE_UM)
+      cudaFree(m_active_pointer);
+#else
+      ::free(m_active_pointer);
+#endif
+      m_active_pointer = nullptr;
+      m_active_base_pointer = nullptr;
+    } else {
+      CHAI_LOG(Debug, "tried to free slice!");
+    }
   }
 }
 
-template<typename T>
-CHAI_INLINE
-CHAI_HOST void ManagedArray<T>::reset()
+
+template <typename T>
+CHAI_INLINE CHAI_HOST void ManagedArray<T>::reset()
 {
 }
 
 
 #if defined(CHAI_ENABLE_PICK)
-template<typename T>
-CHAI_INLINE
-CHAI_HOST_DEVICE
-typename ManagedArray<T>::T_non_const ManagedArray<T>::pick(size_t i) const { 
+template <typename T>
+CHAI_INLINE CHAI_HOST_DEVICE typename ManagedArray<T>::T_non_const ManagedArray<
+    T>::pick(size_t i) const
+{
 #if !defined(__CUDA_ARCH__) && defined(CHAI_ENABLE_UM)
   cudaDeviceSynchronize();
 #endif
-  return (T_non_const) m_active_pointer[i]; 
+  return (T_non_const)m_active_pointer[i];
 }
 
-template<typename T>
-CHAI_INLINE
-CHAI_HOST_DEVICE void ManagedArray<T>::set(size_t i, T val) const {
+template <typename T>
+CHAI_INLINE CHAI_HOST_DEVICE void ManagedArray<T>::set(size_t i, T val) const
+{
 #if !defined(__CUDA_ARCH__) && defined(CHAI_ENABLE_UM)
   cudaDeviceSynchronize();
 #endif
-  m_active_pointer[i] = val; 
+  m_active_pointer[i] = val;
 }
 
-template<typename T>
-CHAI_INLINE
-CHAI_HOST_DEVICE void ManagedArray<T>::incr(size_t i) const { 
+template <typename T>
+CHAI_INLINE CHAI_HOST_DEVICE void ManagedArray<T>::incr(size_t i) const
+{
 #if !defined(__CUDA_ARCH__) && defined(CHAI_ENABLE_UM)
   cudaDeviceSynchronize();
 #endif
-  ++m_active_pointer[i]; 
+  ++m_active_pointer[i];
 }
 
-template<typename T>
-CHAI_INLINE
-CHAI_HOST_DEVICE void ManagedArray<T>::decr(size_t i) const { 
+template <typename T>
+CHAI_INLINE CHAI_HOST_DEVICE void ManagedArray<T>::decr(size_t i) const
+{
 #if !defined(__CUDA_ARCH__) && defined(CHAI_ENABLE_UM)
   cudaDeviceSynchronize();
 #endif
-  --m_active_pointer[i]; 
+  --m_active_pointer[i];
 }
 #endif
 
-template<typename T>
-CHAI_INLINE
-CHAI_HOST size_t ManagedArray<T>::size() const {
+template <typename T>
+CHAI_INLINE CHAI_HOST_DEVICE size_t ManagedArray<T>::size() const
+{
   return m_elems;
 }
 
-template<typename T>
-template<typename Idx>
-CHAI_INLINE
-CHAI_HOST_DEVICE T& ManagedArray<T>::operator[](const Idx i) const {
+template <typename T>
+CHAI_INLINE CHAI_HOST void ManagedArray<T>::registerTouch(ExecutionSpace)
+{
+}
+
+template <typename T>
+CHAI_INLINE CHAI_HOST void ManagedArray<T>::move(ExecutionSpace)
+{
+}
+
+template <typename T>
+template <typename Idx>
+CHAI_INLINE CHAI_HOST_DEVICE T& ManagedArray<T>::operator[](const Idx i) const
+{
   return m_active_pointer[i];
 }
 
 #if defined(CHAI_ENABLE_IMPLICIT_CONVERSIONS)
-template<typename T>
-CHAI_INLINE
-CHAI_HOST_DEVICE ManagedArray<T>::operator T*() const {
+template <typename T>
+CHAI_INLINE CHAI_HOST_DEVICE ManagedArray<T>::operator T*() const
+{
   return m_active_pointer;
 }
 
-template<typename T>
-template<bool Q>
-CHAI_INLINE
-CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(T* data, CHAIDISAMBIGUATE, bool) :
+template <typename T>
+template <bool Q>
+CHAI_INLINE CHAI_HOST_DEVICE
+ManagedArray<T>::ManagedArray(T* data, CHAIDISAMBIGUATE, bool) :
   m_active_pointer(data),
-  m_resource_manager(ArrayManager::getInstance()),
-  m_elems(m_resource_manager->getSize(m_active_pointer)),
+  m_active_base_pointer(data),
+  m_resource_manager(nullptr),
+  m_elems(-1),
+  m_pointer_record(nullptr),
   m_is_slice(false)
 {
 }
 #endif
 
-template<typename T>
-template< typename U>
-ManagedArray<T>::operator 
-typename std::enable_if< !std::is_const<U>::value , 
-                         ManagedArray<const U> >::type () const
+template <typename T>
+template <typename U>
+ManagedArray<T>::operator typename std::
+    enable_if<!std::is_const<U>::value, ManagedArray<const U> >::type() const
 {
-  return ManagedArray<const T>(const_cast<const T*>(m_active_pointer), m_resource_manager, m_elems, nullptr);
+  return ManagedArray<const T>(const_cast<const T*>(m_active_pointer),
+                               m_resource_manager,
+                               m_elems,
+                               nullptr);
 }
 
-template<typename T>
-CHAI_INLINE CHAI_HOST_DEVICE ManagedArray<T>& ManagedArray<T>::operator= (std::nullptr_t from) 
+template <typename T>
+CHAI_INLINE CHAI_HOST_DEVICE ManagedArray<T>& ManagedArray<T>::operator=(std::nullptr_t from)
 {
   m_active_pointer = from;
   m_active_base_pointer = from;
@@ -299,13 +312,12 @@ CHAI_INLINE CHAI_HOST_DEVICE bool ManagedArray<T>::operator!=(T* from) const
 }
 
 template <typename T>
-CHAI_INLINE CHAI_HOST_DEVICE bool ManagedArray<T>::operator==(std::nullptr_t from) const
+CHAI_INLINE CHAI_HOST_DEVICE bool ManagedArray<T>::operator==( std::nullptr_t from) const
 {
   return m_active_pointer == from;
 }
 template <typename T>
-CHAI_INLINE CHAI_HOST_DEVICE bool ManagedArray<T>::operator!=(
-    std::nullptr_t from) const
+CHAI_INLINE CHAI_HOST_DEVICE bool ManagedArray<T>::operator!=( std::nullptr_t from) const
 {
   return m_active_pointer != from;
 }
@@ -316,6 +328,6 @@ CHAI_INLINE CHAI_HOST_DEVICE ManagedArray<T>::operator bool() const
   return m_active_pointer != nullptr;
 }
 
-} // end of namespace chai
+}  // end of namespace chai
 
-#endif // CHAI_ManagedArray_thin_INL
+#endif  // CHAI_ManagedArray_thin_INL

--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -158,8 +158,8 @@ CHAI_HOST void ManagedArray<T>::reallocate(size_t new_elems)
 template <typename T>
 CHAI_INLINE CHAI_HOST void ManagedArray<T>::free(ExecutionSpace space)
 {
-  if (space == CPU || space == NONE) {
-    if (!m_is_slice) {
+  if (!m_is_slice) {
+    if (space == CPU || space == NONE) {
 #if defined(CHAI_ENABLE_UM)
       cudaFree(m_active_pointer);
 #else
@@ -167,9 +167,11 @@ CHAI_INLINE CHAI_HOST void ManagedArray<T>::free(ExecutionSpace space)
 #endif
       m_active_pointer = nullptr;
       m_active_base_pointer = nullptr;
-    } else {
-      CHAI_LOG(Debug, "tried to free slice!");
+      m_elems = 0;
     }
+  }
+  else {
+    CHAI_LOG(Debug, "tried to free slice!");
   }
 }
 

--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -169,7 +169,7 @@ CHAI_INLINE CHAI_HOST void ManagedArray<T>::free(ExecutionSpace space)
 #if defined(CHAI_ENABLE_UM)
       cudaFree(m_active_pointer);
 #else
-      ::free(m_active_pointer);
+      ::free((void *)m_active_pointer);
 #endif
       m_active_pointer = nullptr;
       m_active_base_pointer = nullptr;
@@ -239,7 +239,7 @@ CHAI_INLINE CHAI_HOST void ManagedArray<T>::registerTouch(ExecutionSpace)
 }
 
 template <typename T>
-CHAI_INLINE CHAI_HOST void ManagedArray<T>::move(ExecutionSpace)
+CHAI_INLINE CHAI_HOST void ManagedArray<T>::move(ExecutionSpace) const
 {
 }
 

--- a/src/chai/RajaExecutionSpacePlugin.cpp
+++ b/src/chai/RajaExecutionSpacePlugin.cpp
@@ -75,6 +75,7 @@ RajaExecutionSpacePlugin::postLaunch(RAJA::util::PluginContext)
 }
 
 }
+RAJA_INSTANTIATE_REGISTRY(RAJA::util::PluginRegistry);
 
 // this is needed to link a dynamic lib as RAJA does not provide an exported definition of this symbol.
 #if defined(_WIN32) && !defined(CHAISTATICLIB)
@@ -96,8 +97,10 @@ RAJA::util::PluginRegistry::Add<chai::RajaExecutionSpacePlugin> P(
      "RajaExecutionSpacePlugin",
      "Plugin to set CHAI execution space based on RAJA execution platform");
 
+
 namespace chai {
 
   void linkRajaPlugin() {}
 
 }
+

--- a/src/chai/Types.hpp
+++ b/src/chai/Types.hpp
@@ -24,7 +24,7 @@ namespace chai
 
 typedef unsigned int uint;
 
-enum Action { ACTION_ALLOC, ACTION_FREE, ACTION_MOVE, ACTION_FOUND_ABANDONED };
+enum Action { ACTION_ALLOC, ACTION_FREE, ACTION_MOVE, ACTION_CAPTURED, ACTION_FOUND_ABANDONED };
 
 using UserCallback = std::function<void(Action, ExecutionSpace, std::size_t)>;
 

--- a/src/chai/Types.hpp
+++ b/src/chai/Types.hpp
@@ -29,7 +29,7 @@ namespace chai
 
   typedef unsigned int uint;
 
-  enum Action { ACTION_ALLOC, ACTION_FREE, ACTION_MOVE, ACTION_CAPTURED, ACTION_FOUND_ABANDONED };
+  enum Action { ACTION_ALLOC, ACTION_FREE, ACTION_MOVE, ACTION_CAPTURED, ACTION_FOUND_ABANDONED, ACTION_LEAKED };
 
   using UserCallback = std::function<void(const PointerRecord*, Action, ExecutionSpace)>;
 } // end of namespace chai

--- a/src/chai/config.hpp.in
+++ b/src/chai/config.hpp.in
@@ -14,6 +14,7 @@
 #cmakedefine CHAI_DISABLE_RM
 #cmakedefine CHAI_ENABLE_UM
 #cmakedefine CHAI_DEBUG
+#cmakedefine CHAI_ENABLE_GPU_ERROR_CHECKING
 #cmakedefine CHAI_ENABLE_RAJA_PLUGIN
 #cmakedefine CHAI_ENABLE_GPU_SIMULATION_MODE
 

--- a/src/chai/managed_ptr.hpp
+++ b/src/chai/managed_ptr.hpp
@@ -173,7 +173,7 @@ namespace chai {
          ///
          /// Default constructor.
          ///
-         CHAI_HOST_DEVICE constexpr managed_ptr() noexcept = default;
+         constexpr managed_ptr() noexcept = default;
 
          ///
          /// @author Alan Dayton

--- a/src/util/forall.hpp
+++ b/src/util/forall.hpp
@@ -25,7 +25,7 @@ struct gpu {
 template <typename LOOP_BODY>
 void forall_kernel_cpu(int begin, int end, LOOP_BODY body)
 {
-  for (int i = 0; i < (end - begin); ++i) {
+  for (int i = begin; i < end; ++i) {
     body(i);
   }
 }
@@ -56,7 +56,7 @@ __global__ void forall_kernel_gpu(int start, int length, LOOP_BODY body)
   int idx = blockDim.x * blockIdx.x + threadIdx.x;
 
   if (idx < length) {
-    body(idx);
+    body(idx+start);
   }
 }
 

--- a/src/util/forall.hpp
+++ b/src/util/forall.hpp
@@ -80,6 +80,8 @@ void forall(gpu, int begin, int end, LOOP_BODY&& body)
   hipLaunchKernelGGL(forall_kernel_gpu, dim3(gridSize), dim3(blockSize), 0,0,
                      begin, end - begin, body);
   hipDeviceSynchronize();
+#elif defined(CHAI_ENABLE_GPU_SIMULATION_MODE)
+  forall_kernel_cpu(begin, end, body);
 #endif
   
   rm->setExecutionSpace(chai::NONE);

--- a/src/util/forall.hpp
+++ b/src/util/forall.hpp
@@ -73,15 +73,15 @@ void forall(gpu, int begin, int end, LOOP_BODY&& body)
   size_t blockSize = 32;
   size_t gridSize = (end - begin + blockSize - 1) / blockSize;
 
-#if defined(CHAI_ENABLE_CUDA)
+#if defined(CHAI_ENABLE_GPU_SIMULATION_MODE)
+  forall_kernel_cpu(begin, end, body);
+#elif defined(CHAI_ENABLE_CUDA)
   forall_kernel_gpu<<<gridSize, blockSize>>>(begin, end - begin, body);
   cudaDeviceSynchronize();
 #elif defined(CHAI_ENABLE_HIP)
   hipLaunchKernelGGL(forall_kernel_gpu, dim3(gridSize), dim3(blockSize), 0,0,
                      begin, end - begin, body);
   hipDeviceSynchronize();
-#elif defined(CHAI_ENABLE_GPU_SIMULATION_MODE)
-  forall_kernel_cpu(begin, end, body);
 #endif
   
   rm->setExecutionSpace(chai::NONE);

--- a/tests/integration/managed_array_tests.cpp
+++ b/tests/integration/managed_array_tests.cpp
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////
 #include "gtest/gtest.h"
-
 #define GPU_TEST(X, Y)              \
   static void gpu_test_##X##Y();    \
   TEST(X, Y) { gpu_test_##X##Y(); } \
@@ -16,6 +15,8 @@
 #else
 #define device_assert(EXP) assert(EXP)
 #endif
+
+#define assert_empty_map(IGNORED) ASSERT_EQ(chai::ArrayManager::getInstance()->getPointerMap().size(),0)
 
 #include "chai/config.hpp"
 
@@ -38,6 +39,8 @@ TEST(ManagedArray, SetOnHost)
   forall(sequential(), 0, 10, [=](int i) { ASSERT_EQ(array[i], i); });
 
   array.free();
+
+  assert_empty_map(true);
 }
 
 #if (!defined(CHAI_DISABLE_RM))
@@ -52,6 +55,7 @@ TEST(ManagedArray, Const)
   forall(sequential(), 0, 10, [=](int i) { ASSERT_EQ(array_const[i], i); });
 
   array.free();
+  assert_empty_map(true);
 }
 
 TEST(ManagedArray, UserCallbackHost)
@@ -79,6 +83,7 @@ TEST(ManagedArray, Slice) {
   chai::ManagedArray<float> sl = array.slice(0,5);
   sl.free();
   array.free();
+  assert_empty_map(true);
 }
 
 TEST(ManagedArray, SliceOfSlice) {
@@ -102,6 +107,7 @@ TEST(ManagedArray, SliceOfSlice) {
   sl1.free();
   sl2.free();
   array.free();
+  assert_empty_map(true);
 }
 
 #if defined(CHAI_ENABLE_PICK)
@@ -117,6 +123,7 @@ TEST(ManagedArray, PickHostFromHostConst) {
   ASSERT_EQ(temp, 5);
 
   array.free();
+  assert_empty_map(true);
 }
 #endif
 
@@ -130,6 +137,7 @@ TEST(ManagedArray, PickHostFromHost)
   ASSERT_EQ(temp, 5);
 
   array.free();
+  assert_empty_map(true);
 }
 
 TEST(ManagedArray, SetHostToHost)
@@ -143,6 +151,7 @@ TEST(ManagedArray, SetHostToHost)
   ASSERT_EQ(array[5], 10);
 
   array.free();
+  assert_empty_map(true);
 }
 
 
@@ -168,6 +177,7 @@ TEST(ManagedArray, IncrementDecrementOnHost)
 
   arrayI.free();
   arrayD.free();
+  assert_empty_map(true);
 }
 
 
@@ -184,7 +194,7 @@ TEST(ManagedArray, PickHostFromHostConstUM) {
   ASSERT_EQ(temp, 5);
 
   array.free();
-  // array_const.free();
+  assert_empty_map(true);
 }
 #endif
 
@@ -198,6 +208,7 @@ TEST(ManagedArray, PickHostFromHostUM)
   ASSERT_EQ(temp, 5);
 
   array.free();
+  assert_empty_map(true);
 }
 
 TEST(ManagedArray, SetHostToHostUM)
@@ -211,6 +222,7 @@ TEST(ManagedArray, SetHostToHostUM)
   ASSERT_EQ(array[5], 10);
 
   array.free();
+  assert_empty_map(true);
 }
 
 TEST(ManagedArray, IncrementDecrementOnHostUM)
@@ -235,6 +247,7 @@ TEST(ManagedArray, IncrementDecrementOnHostUM)
 
   arrayI.free();
   arrayD.free();
+  assert_empty_map(true);
 }
 #endif
 
@@ -260,6 +273,7 @@ GPU_TEST(ManagedArray, PickandSetDeviceToDeviceUM)
 
   array1.free();
   array2.free();
+  assert_empty_map(true);
 }
 
 GPU_TEST(ManagedArray, PickHostFromDeviceUM)
@@ -272,6 +286,7 @@ GPU_TEST(ManagedArray, PickHostFromDeviceUM)
   ASSERT_EQ(temp, 5);
 
   array.free();
+  assert_empty_map(true);
 }
 
 #if (!defined(CHAI_DISABLE_RM))
@@ -286,7 +301,7 @@ GPU_TEST(ManagedArray, PickHostFromDeviceConstUM) {
   ASSERT_EQ(temp, 5);
 
   array.free();
-  // array_const.free();
+  assert_empty_map(true);
 }
 #endif
 
@@ -302,6 +317,7 @@ GPU_TEST(ManagedArray, SetHostToDeviceUM)
   ASSERT_EQ(temp, 10);
 
   array.free();
+  assert_empty_map(true);
 }
 
 GPU_TEST(ManagedArray, IncrementDecrementOnDeviceUM)
@@ -326,6 +342,7 @@ GPU_TEST(ManagedArray, IncrementDecrementOnDeviceUM)
 
   arrayI.free();
   arrayD.free();
+  assert_empty_map(true);
 }
 
 GPU_TEST(ManagedArray, IncrementDecrementFromHostOnDeviceUM)
@@ -345,6 +362,7 @@ GPU_TEST(ManagedArray, IncrementDecrementFromHostOnDeviceUM)
   ASSERT_EQ(temp, 8);
 
   array.free();
+  assert_empty_map(true);
 }
 
 GPU_TEST(ManagedArray, PickandSetSliceDeviceToDeviceUM) {
@@ -367,6 +385,7 @@ GPU_TEST(ManagedArray, PickandSetSliceDeviceToDeviceUM) {
   });
 
   array.free();
+  assert_empty_map(true);
 }
 #endif
 
@@ -390,6 +409,7 @@ GPU_TEST(ManagedArray, PickandSetDeviceToDevice)
 
   array1.free();
   array2.free();
+  assert_empty_map(true);
 }
 
 GPU_TEST(ManagedArray, PickandSetSliceDeviceToDevice) {
@@ -412,6 +432,7 @@ GPU_TEST(ManagedArray, PickandSetSliceDeviceToDevice) {
   });
 
   array.free();
+  assert_empty_map(true);
 }
 
 
@@ -425,6 +446,7 @@ GPU_TEST(ManagedArray, PickHostFromDevice)
   ASSERT_EQ(temp, 5);
 
   array.free();
+  assert_empty_map(true);
 }
 
 GPU_TEST(ManagedArray, PickHostFromDeviceConst)
@@ -441,7 +463,7 @@ GPU_TEST(ManagedArray, PickHostFromDeviceConst)
   ASSERT_EQ(temp, 5);
 
   array.free();
-  // array_const.free();
+  assert_empty_map(true);
 }
 
 GPU_TEST(ManagedArray, SetHostToDevice)
@@ -456,6 +478,7 @@ GPU_TEST(ManagedArray, SetHostToDevice)
   ASSERT_EQ(temp, 10);
 
   array.free();
+  assert_empty_map(true);
 }
 GPU_TEST(ManagedArray, IncrementDecrementOnDevice)
 {
@@ -479,6 +502,7 @@ GPU_TEST(ManagedArray, IncrementDecrementOnDevice)
 
   arrayI.free();
   arrayD.free();
+  assert_empty_map(true);
 }
 
 GPU_TEST(ManagedArray, IncrementDecrementFromHostOnDevice)
@@ -498,6 +522,7 @@ GPU_TEST(ManagedArray, IncrementDecrementFromHostOnDevice)
   ASSERT_EQ(temp, 8);
 
   array.free();
+  assert_empty_map(true);
 }
 #endif
 #endif
@@ -523,6 +548,7 @@ GPU_TEST(ManagedArray, SliceOfSliceDevice) {
   sl1.free();
   sl2.free();
   array.free();
+  assert_empty_map(true);
 }
 
 GPU_TEST(ManagedArray, SliceDevice) {
@@ -546,6 +572,7 @@ GPU_TEST(ManagedArray, SliceDevice) {
   sl1.free();
   sl2.free();
   array.free();
+  assert_empty_map(true);
 }
 
 GPU_TEST(ManagedArray, SetOnDevice) {
@@ -558,6 +585,7 @@ GPU_TEST(ManagedArray, SetOnDevice) {
   forall(sequential(), 0, 10, [=](int i) { ASSERT_EQ(array[i], 2 * i); });
 
   array.free();
+  assert_empty_map(true);
 }
 
 GPU_TEST(ManagedArray, GetGpuOnHost)
@@ -569,6 +597,7 @@ GPU_TEST(ManagedArray, GetGpuOnHost)
   forall(sequential(), 0, 10, [=](int i) { ASSERT_EQ(array[i], i); });
 
   array.free();
+  assert_empty_map(true);
 }
 
 #if defined(CHAI_ENABLE_UM)
@@ -581,6 +610,7 @@ GPU_TEST(ManagedArray, SetOnDeviceUM)
   forall(sequential(), 0, 10, [=](int i) { ASSERT_EQ(array[i], i); });
 
   array.free();
+  assert_empty_map(true);
 }
 #endif
 #endif
@@ -594,6 +624,7 @@ TEST(ManagedArray, Allocate)
   ASSERT_EQ(array.size(), 10u);
 
   array.free();
+  assert_empty_map(true);
 }
 
 TEST(ManagedArray, ReallocateCPU)
@@ -616,6 +647,7 @@ TEST(ManagedArray, ReallocateCPU)
   });
 
   array.free();
+  assert_empty_map(true);
 }
 
 #if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
@@ -639,6 +671,7 @@ GPU_TEST(ManagedArray, ReallocateGPU)
   });
 
   array.free();
+  assert_empty_map(true);
 }
 #endif
 
@@ -658,6 +691,7 @@ TEST(ManagedArray, NullpointerConversions)
   chai::ManagedArray<float> c(nullptr);
 
   ASSERT_EQ(c.size(), 0u);
+  assert_empty_map(true);
 }
 
 #if defined(CHAI_ENABLE_IMPLICIT_CONVERSIONS)
@@ -671,6 +705,7 @@ TEST(ManagedArray, ImplicitConversions)
 
   a.free();
   SUCCEED();
+  assert_empty_map(true);
 }
 #endif
 
@@ -689,6 +724,7 @@ TEST(ManagedArray, PodTest)
   });
 
   array.free();
+  assert_empty_map(true);
 }
 
 #if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
@@ -707,6 +743,7 @@ GPU_TEST(ManagedArray, PodTestGPU)
   });
 
   array.free();
+  assert_empty_map(true);
 }
 #endif
 
@@ -731,6 +768,7 @@ TEST(ManagedArray, ExternalConstructorUnowned)
   }
 
   std::free(data);
+  assert_empty_map(true);
 }
 
 TEST(ManagedArray, ExternalConstructorOwned)
@@ -747,6 +785,7 @@ TEST(ManagedArray, ExternalConstructorOwned)
   forall(sequential(), 0, 20, [=](int i) { ASSERT_EQ(data[i], array[i]); });
 
   array.free();
+  assert_empty_map(true);
 }
 #if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
 GPU_TEST(ManagedArray, ExternalUnownedMoveToGPU)
@@ -764,6 +803,7 @@ GPU_TEST(ManagedArray, ExternalUnownedMoveToGPU)
   forall(sequential(), 0, 20, [=] (int i) { ASSERT_EQ(array[i], 1.0f * i); });
 
   array.free();
+  assert_empty_map(true);
 }
 #endif
 #endif
@@ -776,6 +816,7 @@ TEST(ManagedArray, Reset)
 
   array.reset();
   array.free();
+  assert_empty_map(true);
 }
 
 #if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
@@ -793,6 +834,7 @@ GPU_TEST(ManagedArray, ResetDevice)
   forall(sequential(), 0, 20, [=](int i) { ASSERT_EQ(array[i], 0.0f); });
 
   array.free();
+  assert_empty_map(true);
 }
 #endif
 #endif
@@ -850,6 +892,7 @@ GPU_TEST(ManagedArray, UserCallback)
 
   ASSERT_EQ(bytes_alloc, 2 * 20 * sizeof(float));
   ASSERT_EQ(bytes_free, 2 * 20 * sizeof(float));
+  assert_empty_map(true);
 }
 
 GPU_TEST(ManagedArray, CallBackConst)
@@ -873,6 +916,10 @@ GPU_TEST(ManagedArray, CallBackConst)
         printf("Moved to device\n");
         ++num_h2d;
       }
+    }
+    if (act == chai::ACTION_FOUND_ABANDONED) {
+       printf("in abandoned!\n");
+       ASSERT_EQ(false,true);
     }
   };
 
@@ -907,6 +954,7 @@ GPU_TEST(ManagedArray, CallBackConst)
   ASSERT_EQ(num_d2h, 0);
 
   array.free();
+  assert_empty_map(true);
 }
 
 GPU_TEST(ManagedArray, CallBackConstArray)
@@ -931,6 +979,12 @@ GPU_TEST(ManagedArray, CallBackConstArray)
         ++num_h2d;
       }
     }
+    if (act == chai::ACTION_FOUND_ABANDONED) {
+       printf("in abandoned!\n");
+       while(true) {
+
+       }
+    }
   };
 
   const int N = 5;
@@ -951,12 +1005,9 @@ GPU_TEST(ManagedArray, CallBackConstArray)
 
       chai::ManagedArray<int> errorTemp(N);
 
-      forall(sequential(), 0, N,
-        [=](int j)
-        {
-          temp[j] = N * i + j;
-        }
-      );
+      forall(sequential(), 0, N, [=](int j) {
+        temp[j] = N * i + j;
+      });
 
       outerArray[i] = temp;
       outerErrorArray[i] = errorTemp;
@@ -1007,6 +1058,7 @@ GPU_TEST(ManagedArray, CallBackConstArray)
 
   outerArray.free();
   outerErrorArray.free();
+  assert_empty_map(true);
 }
 
 GPU_TEST(ManagedArray, CallBackConstArrayConst)
@@ -1108,6 +1160,7 @@ GPU_TEST(ManagedArray, CallBackConstArrayConst)
 
   outerArray.free();
   outerErrorArray.free();
+  assert_empty_map(true);
 }
 
 #endif
@@ -1127,6 +1180,7 @@ GPU_TEST(ManagedArray, Move)
   ASSERT_EQ(array[5], 5);
 
   array.free();
+  assert_empty_map(true);
 }
 
 /**
@@ -1175,6 +1229,7 @@ GPU_TEST(ManagedArray, MoveInnerToHost)
   }
 
   outerArray.free();
+  assert_empty_map(true);
 }
 
 /**
@@ -1237,6 +1292,7 @@ GPU_TEST(ManagedArray, MoveInnerToDevice)
   }
 
   outerArray.free();
+  assert_empty_map(true);
 }
 
 /**
@@ -1315,6 +1371,7 @@ GPU_TEST(ManagedArray, MoveInnerToDevice2)
     outerArray[i].free();
   }
   outerArray.free();
+  assert_empty_map(true);
 }
 
 GPU_TEST(ManagedArray, MoveInnerToDeviceAgain)
@@ -1382,6 +1439,7 @@ GPU_TEST(ManagedArray, MoveInnerToDeviceAgain)
   }
 
   outerArray.free();
+  assert_empty_map(true);
 }
 #endif  // CHAI_DISABLE_RM
 #endif  // defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
@@ -1407,6 +1465,7 @@ TEST(ManagedArray, DeepCopy)
 
   array.free();
   copy.free();
+  assert_empty_map(true);
 }
 #endif
 
@@ -1431,18 +1490,18 @@ GPU_TEST(ManagedArray, DeviceDeepCopy)
 
   array.free();
   copy.free();
+  assert_empty_map(true);
 }
-#endif
-#endif  // defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
-
-#ifdef CHAI_ENABLE_CUDA
 
 GPU_TEST(ManagedArray, CopyConstruct)
 {
   const int expectedValue = rand();
 
   chai::ManagedArray<int> array(1, chai::CPU);
-  array[0] = expectedValue;
+
+  forall(sequential(), 0, 1, [=] (int i) {
+    array[i] = expectedValue;
+  });
 
   chai::ManagedArray<int> array2 = array;
 
@@ -1454,8 +1513,13 @@ GPU_TEST(ManagedArray, CopyConstruct)
 
   results.move(chai::CPU);
   ASSERT_EQ(results[0], expectedValue);
+
+  array.free();
+  results.free();
+  assert_empty_map(true);
 }
 
+#endif
 #endif
 
 TEST(ManagedArray, SizeZero)
@@ -1464,6 +1528,7 @@ TEST(ManagedArray, SizeZero)
   ASSERT_EQ(array.size(), 0u);
   array.allocate(0);
   ASSERT_EQ(array.size(), 0u);
+  assert_empty_map(true);
 }
 
 #if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
@@ -1482,5 +1547,6 @@ GPU_TEST(ManagedArray, CopyZero)
   });
 
   array.free();
+  assert_empty_map(true);
 }
 #endif

--- a/tests/integration/managed_array_tests.cpp
+++ b/tests/integration/managed_array_tests.cpp
@@ -1417,6 +1417,29 @@ GPU_TEST(ManagedArray, DeviceDeepCopy)
 #endif
 #endif  // defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
 
+#ifdef CHAI_ENABLE_CUDA
+
+CUDA_TEST(ManagedArray, CopyConstruct)
+{
+  const int expectedValue = rand();
+
+  chai::ManagedArray<int> array(1, chai::CPU);
+  array[0] = expectedValue;
+
+  chai::ManagedArray<int> array2 = array;
+
+  chai::ManagedArray<int> results(1, chai::GPU);
+
+  forall(cuda(), 0, 1, [=] __device__ (int i) {
+    results[i] = array2[i];
+  });
+
+  results.move(chai::CPU);
+  ASSERT_EQ(results[0], expectedValue);
+}
+
+#endif
+
 TEST(ManagedArray, SizeZero)
 {
   chai::ManagedArray<double> array;

--- a/tests/integration/managed_array_tests.cpp
+++ b/tests/integration/managed_array_tests.cpp
@@ -1423,7 +1423,7 @@ GPU_TEST(ManagedArray, DeviceDeepCopy)
 
 #ifdef CHAI_ENABLE_CUDA
 
-CUDA_TEST(ManagedArray, CopyConstruct)
+GPU_TEST(ManagedArray, CopyConstruct)
 {
   const int expectedValue = rand();
 

--- a/tests/integration/managed_array_tests.cpp
+++ b/tests/integration/managed_array_tests.cpp
@@ -1434,7 +1434,7 @@ GPU_TEST(ManagedArray, CopyConstruct)
 
   chai::ManagedArray<int> results(1, chai::GPU);
 
-  forall(cuda(), 0, 1, [=] __device__ (int i) {
+  forall(gpu(), 0, 1, [=] __device__ (int i) {
     results[i] = array2[i];
   });
 

--- a/tests/integration/managed_array_tests.cpp
+++ b/tests/integration/managed_array_tests.cpp
@@ -16,7 +16,12 @@
 #define device_assert(EXP) assert(EXP)
 #endif
 
+#ifdef CHAI_DISABLE_RM
+#define assert_empty_map(IGNORED)
+#else
 #define assert_empty_map(IGNORED) ASSERT_EQ(chai::ArrayManager::getInstance()->getPointerMap().size(),0)
+#endif
+
 
 #include "chai/config.hpp"
 
@@ -982,9 +987,7 @@ GPU_TEST(ManagedArray, CallBackConstArray)
     }
     if (act == chai::ACTION_FOUND_ABANDONED) {
        printf("in abandoned!\n");
-       while(true) {
-
-       }
+       ASSERT_TRUE(false);
     }
   };
 

--- a/tests/integration/managed_array_tests.cpp
+++ b/tests/integration/managed_array_tests.cpp
@@ -697,7 +697,8 @@ TEST(ManagedArray, NullpointerConversions)
 #if defined(CHAI_ENABLE_IMPLICIT_CONVERSIONS)
 TEST(ManagedArray, ImplicitConversions)
 {
-  chai::ManagedArray<float> a(10);
+  chai::ManagedArray<float> a(1);
+  a[0] = 3.14159;
 
   chai::ManagedArray<float> a2 = a;
   


### PR DESCRIPTION
Do not new a Pointer Record in default initialization of a ManagedArray
Refactors migrateInner to handle issues associated with MA<MA<T>>. 
Allows free of a particular execution space.
