### PR TITLE
Removing HEADERS_OUTPUT_SUBDIR, which won't be recognized by the new …

### DIFF
--- a/src/chai/CMakeLists.txt
+++ b/src/chai/CMakeLists.txt
@@ -72,7 +72,6 @@ blt_add_library(
   NAME chai
   SOURCES ${chai_sources}
   HEADERS ${chai_headers}
-  HEADERS_OUTPUT_SUBDIR chai
   DEPENDS_ON ${chai_depends})
 
 install(FILES ${chai_headers} DESTINATION include/chai/)


### PR DESCRIPTION
Removing HEADERS_OUTPUT_SUBDIR before the update to the latest BLT.