### PR TITLE
Lazy allocation for ManagedArrays

### DIFF
--- a/src/chai/ArrayManager.cpp
+++ b/src/chai/ArrayManager.cpp
@@ -256,7 +256,8 @@ void ArrayManager::move(PointerRecord* record, ExecutionSpace space)
     dst_pointer = record->m_pointers[space];
   }
 
-  if (!record->m_touched[record->m_last_space]) {
+
+  if ( (!record->m_touched[record->m_last_space]) || (! src_pointer )) {
     return;
   } else if (dst_pointer != src_pointer) {
     // Exclude the copy if src and dst are the same (can happen for PINNED memory)

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -20,6 +20,13 @@
 namespace chai
 {
 
+namespace {
+inline ExecutionSpace get_default_space() {
+  return ArrayManager::getInstance()->getDefaultAllocationSpace();
+}
+
+}
+
 
 struct InvalidConstCast;
 
@@ -89,7 +96,7 @@ public:
    * \param elems Number of elements in the array.
    * \param space Execution space in which to allocate the array.
    */
-  CHAI_HOST_DEVICE ManagedArray(size_t elems, ExecutionSpace space = NONE);
+  CHAI_HOST_DEVICE ManagedArray(size_t elems, ExecutionSpace space = get_default_space());
 
   CHAI_HOST_DEVICE ManagedArray(
       size_t elems,

--- a/tests/integration/managed_array_tests.cpp
+++ b/tests/integration/managed_array_tests.cpp
@@ -1613,3 +1613,29 @@ GPU_TEST(ManagedArray, CopyZero)
   assert_empty_map(true);
 }
 #endif
+
+TEST(ManagedArray, NoAllocation)
+{
+  chai::ManagedArray<double> array(10, chai::NONE);
+  double* data = array.getPointer(chai::NONE, false);
+  ASSERT_EQ(data, nullptr);
+
+  forall(sequential(), 0, 10, [=] (int i) {
+    array[i] = i;
+  });
+
+  forall(sequential(), 0, 10, [=](int i) { ASSERT_EQ(array[i], i); });
+}
+
+#if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
+GPU_TEST(ManagedArray, NoAllocationGPU)
+{
+  chai::ManagedArray<double> array(10, chai::NONE);
+
+  forall(gpu(), 0, 10, [=] __device__ (int i) {
+    array[i] = i;
+  });
+
+  forall(sequential(), 0, 10, [=](int i) { ASSERT_EQ(array[i], i); });
+}
+#endif

--- a/tests/integration/managed_array_tests.cpp
+++ b/tests/integration/managed_array_tests.cpp
@@ -1627,10 +1627,34 @@ TEST(ManagedArray, NoAllocation)
   forall(sequential(), 0, 10, [=](int i) { ASSERT_EQ(array[i], i); });
 }
 
+TEST(ManagedArray, NoAllocationNull)
+{
+  chai::ManagedArray<double> array;
+  array.allocate(10, chai::NONE);
+
+  forall(sequential(), 0, 10, [=] (int i) {
+    array[i] = i;
+  });
+
+  forall(sequential(), 0, 10, [=](int i) { ASSERT_EQ(array[i], i); });
+}
+
 #if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
 GPU_TEST(ManagedArray, NoAllocationGPU)
 {
   chai::ManagedArray<double> array(10, chai::NONE);
+
+  forall(gpu(), 0, 10, [=] __device__ (int i) {
+    array[i] = i;
+  });
+
+  forall(sequential(), 0, 10, [=](int i) { ASSERT_EQ(array[i], i); });
+}
+
+GPU_TEST(ManagedArray, NoAllocationNullGPU)
+{
+  chai::ManagedArray<double> array;
+  array.allocate(10, chai::NONE);
 
   forall(gpu(), 0, 10, [=] __device__ (int i) {
     array[i] = i;


### PR DESCRIPTION
Arrays created/allocated in the `NONE` ExecutionSpace will not be allocated until they are first used. The _must_ be used inside a region that correctly sets the ExecutionSpace and ensures the ManagedArray copy-constructor is called (e.g. inside a RAJA kernel)