### PR TITLE
small build fix for HIP

### DIFF
--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -480,14 +480,14 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(T* data, CHAIDISAMBIGUATE, bool )
 #endif
 
 template<typename T>
-T*
+CHAI_HOST_DEVICE T*
 ManagedArray<T>::getActiveBasePointer() const
 {
   return m_active_base_pointer;
 }
 
 template<typename T>
-T*
+CHAI_HOST_DEVICE T*
 ManagedArray<T>::getActivePointer() const
 {
   return m_active_pointer;


### PR DESCRIPTION
When I was trying to build CARE (linking in CHAI), I got the following some errors relating to how certain functions are host only but the functions that they derive from (base class) are host device. Fixed.

There were a ton of warnings that I did not address, only the errors that were blocking my progress.

/usr/workspace/taller1/CARE_TESTING_CORONA/chailib/include/chai/ManagedArray.inl:484:18: error: __host__ function 'getActiveBasePointer' cannot overload __host__ __device__ function 'getActiveBasePointer'
ManagedArray<T>::getActiveBasePointer() const
                 ^
/usr/workspace/taller1/CARE_TESTING_CORONA/chailib/include/chai/ManagedArray.hpp:194:23: note: previous declaration is here
  CHAI_HOST_DEVICE T* getActiveBasePointer() const;
                      ^
In file included from /usr/workspace/taller1/CARE_TESTING_CORONA/CARE/src/care/RAJAPlugin.cpp:12:
In file included from /usr/workspace/taller1/CARE_TESTING_CORONA/CARE/src/care/util.h:12:
In file included from /usr/workspace/taller1/CARE_TESTING_CORONA/CARE/src/care/care.h:21:
In file included from /usr/workspace/taller1/CARE_TESTING_CORONA/chailib/include/chai/ManagedArray.hpp:529:
/usr/workspace/taller1/CARE_TESTING_CORONA/chailib/include/chai/ManagedArray.inl:491:18: error: __host__ function 'getActivePointer' cannot overload __host__ __device__ function 'getActivePointer'
ManagedArray<T>::getActivePointer() const
