### PR TITLE
fixes for ENABLE_IMPLICIT_CONVERSIONS=Off

### DIFF
--- a/src/chai/managed_ptr.hpp
+++ b/src/chai/managed_ptr.hpp
@@ -664,7 +664,7 @@ namespace chai {
       ///
       template <typename T>
       CHAI_HOST_DEVICE T* getRawPointers(ManagedArray<T> arg) {
-         return (T*) arg;
+         return arg.getActivePointer();
       }
 
       ///

--- a/src/chai/managed_ptr.hpp
+++ b/src/chai/managed_ptr.hpp
@@ -664,7 +664,7 @@ namespace chai {
       ///
       template <typename T>
       CHAI_HOST_DEVICE T* getRawPointers(ManagedArray<T> arg) {
-         return arg.getActivePointer();
+         return arg.data();
       }
 
       ///

--- a/tests/unit/array_manager_unit_tests.cpp
+++ b/tests/unit/array_manager_unit_tests.cpp
@@ -18,6 +18,8 @@ TEST(ArrayManager, Constructor)
 
 #ifndef CHAI_DISABLE_RM
 
+#if defined(CHAI_ENABLE_IMPLICIT_CONVERSIONS)
+
 TEST(ArrayManager, getPointerMap)
 {
   chai::ArrayManager* rm = chai::ArrayManager::getInstance();
@@ -73,6 +75,7 @@ TEST(ArrayManager, getPointerMap)
   ASSERT_EQ(rm->getTotalSize(),
             (sizeOfArray1 * sizeof(int)) + (sizeOfArray2 * sizeof(double)));
 }
+#endif
 
 /*!
  * \brief Tests to see if callbacks can be turned on or off

--- a/tests/unit/array_manager_unit_tests.cpp
+++ b/tests/unit/array_manager_unit_tests.cpp
@@ -18,8 +18,6 @@ TEST(ArrayManager, Constructor)
 
 #ifndef CHAI_DISABLE_RM
 
-#if defined(CHAI_ENABLE_IMPLICIT_CONVERSIONS)
-
 TEST(ArrayManager, getPointerMap)
 {
   chai::ArrayManager* rm = chai::ArrayManager::getInstance();
@@ -35,8 +33,8 @@ TEST(ArrayManager, getPointerMap)
   ASSERT_EQ(map1.size(), 1);
 
   // Check some of the entries in the pointer record
-  ASSERT_TRUE(map1.find(array1) != map1.end());
-  const chai::PointerRecord* record1Temp = map1[array1];
+  ASSERT_TRUE(map1.find(array1.data()) != map1.end());
+  const chai::PointerRecord* record1Temp = map1[array1.data()];
   ASSERT_EQ(record1Temp->m_size, sizeOfArray1 * sizeof(int));
   ASSERT_EQ(record1Temp->m_last_space, chai::CPU);
 
@@ -55,14 +53,14 @@ TEST(ArrayManager, getPointerMap)
   ASSERT_EQ(map2.size(), 2);
 
   // Check that the entries in the first record are not changed
-  ASSERT_TRUE(map2.find(array1) != map2.end());
-  const chai::PointerRecord* record1 = map1[array1];
+  ASSERT_TRUE(map2.find(array1.data()) != map2.end());
+  const chai::PointerRecord* record1 = map1[array1.data()];
   ASSERT_EQ(record1->m_size, sizeOfArray1 * sizeof(int));
   ASSERT_EQ(record1->m_last_space, chai::CPU);
 
   // Check some of the entries in the pointer record
-  ASSERT_TRUE(map2.find(array2) != map2.end());
-  const chai::PointerRecord* record2 = map2[array2];
+  ASSERT_TRUE(map2.find(array2.data()) != map2.end());
+  const chai::PointerRecord* record2 = map2[array2.data()];
   ASSERT_EQ(record2->m_size, sizeOfArray2 * sizeof(double));
   ASSERT_EQ(record2->m_last_space, chai::CPU);
 
@@ -75,7 +73,6 @@ TEST(ArrayManager, getPointerMap)
   ASSERT_EQ(rm->getTotalSize(),
             (sizeOfArray1 * sizeof(int)) + (sizeOfArray2 * sizeof(double)));
 }
-#endif
 
 /*!
  * \brief Tests to see if callbacks can be turned on or off


### PR DESCRIPTION
In the future, ale3d plans to use chai with ENABLE_IMPLICIT_CONVERSIONS off. Having this option on (as is the case by default) has been the source of a bunch of gpu-related bugs in ale3d. When an int* is converted to a managed array implicitly without passing an array length, errors occur as data is copied to/from the gpu.