### PR TITLE
Fix thin version and make data and getPointer methods available on const objects

### DIFF
--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -216,7 +216,7 @@ public:
    *
    * @return A copy of the pointer in the given execution space
    */
-  CHAI_HOST T* data(ExecutionSpace space, bool do_move = true);
+  CHAI_HOST T* data(ExecutionSpace space, bool do_move = true) const;
 
   /*!
    * \brief Deprecated! Use the data method instead!
@@ -228,7 +228,7 @@ public:
    *
    * @return A copy of the pointer in the given execution space
    */
-  CHAI_HOST T* getPointer(ExecutionSpace space, bool do_move = true);
+  CHAI_HOST T* getPointer(ExecutionSpace space, bool do_move = true) const;
 
   /*!
    * \brief

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -500,7 +500,7 @@ T* ManagedArray<T>::data() const {
 }
 
 template<typename T>
-T* ManagedArray<T>::data(ExecutionSpace space, bool do_move) {
+T* ManagedArray<T>::data(ExecutionSpace space, bool do_move) const {
    if (m_pointer_record == nullptr || m_pointer_record == &ArrayManager::s_null_record) {
       return nullptr;
    }
@@ -521,7 +521,7 @@ T* ManagedArray<T>::data(ExecutionSpace space, bool do_move) {
 }
 
 template<typename T>
-T* ManagedArray<T>::getPointer(ExecutionSpace space, bool do_move) {
+T* ManagedArray<T>::getPointer(ExecutionSpace space, bool do_move) const {
    return data(space, do_move);
 }
 

--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -99,13 +99,19 @@ T* ManagedArray<T>::getActivePointer() const
 }
 
 template <typename T>
-T* ManagedArray<T>::data(ExecutionSpace /*space*/, bool)
+CHAI_HOST_DEVICE T* ManagedArray<T>::data() const
+{
+   return m_active_pointer;
+}
+
+template <typename T>
+T* ManagedArray<T>::data(ExecutionSpace /*space*/, bool /*do_move*/) const
 {
   return m_active_pointer;
 }
 
 template <typename T>
-T* ManagedArray<T>::getPointer(ExecutionSpace space, bool do_move)
+T* ManagedArray<T>::getPointer(ExecutionSpace space, bool do_move) const
 {
   return data(space, do_move);
 }


### PR DESCRIPTION
This pull request does two things:
1. Fixes the thin version by adding the data() method to it
2. Makes the data and getPointer methods available for use on const objects