### PR TITLE
Fix: libcpp and ci

### DIFF
--- a/.gitlab/butte-jobs.yml
+++ b/.gitlab/butte-jobs.yml
@@ -44,7 +44,7 @@ clang_4_0_0 (build and test on butte):
     SPEC: "%clang@4.0.0"
   extends: .build_and_test_on_butte_advanced
 
-clang_9_0_0_libcpp (build and test on butte):
+clang_9_0_0 (build and test on butte):
   variables:
     SPEC: "%clang@9.0.0"
   extends: .build_and_test_on_butte_advanced

--- a/.gitlab/lassen-jobs.yml
+++ b/.gitlab/lassen-jobs.yml
@@ -44,9 +44,9 @@ clang_4_0_0 (build and test on lassen):
     SPEC: "%clang@4.0.0"
   extends: .build_and_test_on_lassen_advanced
 
-clang_9_0_0_libcpp (build and test on lassen):
+clang_9_0_0 (build and test on lassen):
   variables:
-    SPEC: "%clang@9.0.0 +libcpp"
+    SPEC: "%clang@9.0.0"
   extends: .build_and_test_on_lassen
 
 clang_coral_2018_08_08 (build and test on lassen):

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -41,7 +41,7 @@ then
         prefix_opt="--prefix=${prefix}"
     fi
 
-    python scripts/uberenv/uberenv.py --spec=${spec} ${prefix_opt}
+    python scripts/uberenv/uberenv.py --spec="${spec}" ${prefix_opt}
 
 fi
 

--- a/scripts/uberenv/packages/chai/package.py
+++ b/scripts/uberenv/packages/chai/package.py
@@ -66,6 +66,8 @@ class Chai(CMakePackage, CudaPackage):
     version('1.1.0', tag='v1.1.0', submodules='True')
     version('1.0', tag='v1.0', submodules='True')
 
+    variant('shared', default=True, description='Build Shared Libs')
+
     depends_on('cmake@3.8:', type='build')
     depends_on('umpire')
 
@@ -217,6 +219,8 @@ class Chai(CMakePackage, CudaPackage):
         else:
             cfg.write(cmake_cache_option("ENABLE_CUDA", False))
 
+        # shared vs static libs
+        cfg.write(cmake_cache_option("BUILD_SHARED_LIBS","+shared" in spec))
 
         umpire_conf_path = spec['umpire'].prefix + "/share/umpire/cmake"
         cfg.write(cmake_cache_entry("umpire_DIR",umpire_conf_path))

--- a/scripts/uberenv/packages/chai/package.py
+++ b/scripts/uberenv/packages/chai/package.py
@@ -74,7 +74,7 @@ class Chai(CMakePackage, CudaPackage):
     depends_on('cmake@3.9:', type='build', when="+cuda")
     depends_on('umpire+cuda', when="+cuda")
 
-    phases = ['hostconfig', 'cmake', 'build','install']
+    phases = ['hostconfig', 'cmake', 'build', 'install']
 
     def _get_sys_type(self, spec):
         sys_type = str(spec.architecture)


### PR DESCRIPTION
A minor fix to remove libcpp mentions in CI and fix the capture of the spec string in the CI jobs.

The two are related, since fixing the spec string (to allow whitespaces) uncovered the fact that there is no libcpp variant in CHAI package.

Decision was that there is not need for libcpp variant in CHAI at the moment.

EDIT: Also add a shared variant to CHAI package.