### PR TITLE
Multi project integration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,7 +70,6 @@ stages:
 .build_blueos_3_ppc64le_ib_p9_script:
   extends: .build_blueos_3_ppc64le_ib_script
 
-
 # This is where jobs are included.
 include:
   - local: .gitlab/quartz-templates.yml

--- a/.gitlab/butte-jobs.yml
+++ b/.gitlab/butte-jobs.yml
@@ -44,7 +44,7 @@ clang_4_0_0 (build and test on butte):
     SPEC: "%clang@4.0.0"
   extends: .build_and_test_on_butte_advanced
 
-clang_9_0_0_libcpp (build and test on butte):
+clang_9_0_0 (build and test on butte):
   variables:
     SPEC: "%clang@9.0.0"
   extends: .build_and_test_on_butte_advanced

--- a/.gitlab/lassen-jobs.yml
+++ b/.gitlab/lassen-jobs.yml
@@ -44,9 +44,9 @@ clang_4_0_0 (build and test on lassen):
     SPEC: "%clang@4.0.0"
   extends: .build_and_test_on_lassen_advanced
 
-clang_9_0_0_libcpp (build and test on lassen):
+clang_9_0_0 (build and test on lassen):
   variables:
-    SPEC: "%clang@9.0.0 +libcpp"
+    SPEC: "%clang@9.0.0"
   extends: .build_and_test_on_lassen
 
 clang_coral_2018_08_08 (build and test on lassen):

--- a/.gitlab/lassen-jobs.yml
+++ b/.gitlab/lassen-jobs.yml
@@ -49,19 +49,9 @@ clang_9_0_0 (build and test on lassen):
     SPEC: "%clang@9.0.0"
   extends: .build_and_test_on_lassen
 
-clang_coral_2018_08_08 (build and test on lassen):
-  variables:
-    SPEC: "%clang@coral2018.08.08"
-  extends: .build_and_test_on_lassen
-
 nvcc_gcc_4_9_3 (build and test on lassen):
   variables:
     SPEC: "%gcc@4.9.3+cuda"
-  extends: .build_and_test_on_lassen
-
-nvcc_clang_coral_2018_08_08 (build and test on lassen):
-  variables:
-    SPEC: "%clang@coral2018.08.08+cuda"
   extends: .build_and_test_on_lassen
 
 nvcc_xl-beta-2019.06.20 (build and test on lassen):

--- a/docs/sphinx/developer_guide.rst
+++ b/docs/sphinx/developer_guide.rst
@@ -4,4 +4,93 @@
 Developer Guide
 ===============
 
-Coming soon!
+Generating CHAI host-config files
+===================================
+
+.. note::
+This mechanism will generate a cmake configuration file that reproduces the configuration `Spack <https://github.com/spack/spack>` would have generated in the same context. It will contain all the information necessary to build CHAI with the described toolchain.
+
+In particular, the host config file will setup:
+* flags corresponding with the target required (Release, Debug).
+* compilers path, and other toolkits (cuda if required), etc.
+* paths to installed dependencies.
+
+This provides an easy way to build CHAI based on `Spack <https://github.com/spack/spack>` itself driven by `Uberenv <https://github.com/LLNL/uberenv>`_.
+
+Uberenv role
+------------
+
+Uberenv helps by doing the following:
+
+* Pulls a blessed version of Spack locally
+* If you are on a known operating system (like TOSS3), we have defined compilers and system packages so you don't have to rebuild the world (CMake typically in CHAI).
+* Overrides CHAI Spack packages with the local one if it exists. (see ``scripts/uberenv/packages``).
+* Covers both dependencies and project build in one command.
+
+Uberenv will create a directory ``uberenv_libs`` containing a Spack instance with the required CHAI dependencies installed. It then generates a host-config file (``<config_dependent_name>.cmake``) at the root of CHAI repository.
+
+Using Uberenv to generate the host-config file
+----------------------------------------------
+
+.. code-block:: bash
+
+  $ python scripts/uberenv/uberenv.py
+
+.. note::
+  On LC machines, it is good practice to do the build step in parallel on a compute node. Here is an example command: ``srun -ppdebug -N1 --exclusive python scripts/uberenv/uberenv.py``
+
+Unless otherwise specified Spack will default to a compiler. It is recommended to specify which compiler to use: add the compiler spec to the ``--spec`` Uberenv command line option.
+
+On blessed systems, compiler specs can be found in the Spack compiler files in our repository: ``scripts/uberenv/spack_configs/<System type>/compilers.yaml``.
+
+Some examples uberenv options:
+
+* ``--spec=%clang@4.0.0``
+* ``--spec=%clang@4.0.0+cuda``
+* ``--prefix=<Path to uberenv build directory (defaults to ./uberenv_libs)>``
+
+It is also possible to use the CI script outside of CI:
+
+.. code-block:: bash
+
+  $ SPEC="%clang@9.0.0 +cuda" scripts/gitlab/build_and_test.sh --deps-only
+
+Building dependencies can take a long time. If you already have a Spack instance you would like to reuse (in supplement of the local one managed by Uberenv), you can do so changing the uberenv command as follow:
+
+.. code-block:: bash
+
+  $ python scripts/uberenv/uberenv.py --upstream=<path_to_my_spack>/opt/spack
+
+Using host-config files to build CHAI
+-------------------------------------
+
+When a host-config file exists for the desired machine and toolchain, it can easily be used in the CMake build process:
+
+.. code-block:: bash
+
+  $ mkdir build && cd build
+  $ cmake -C  <path_to>/lassen-blueos_3_ppc64le_ib_p9-clang@9.0.0.cmake ..
+  $ cmake --build -j .
+  $ ctest --output-on-failure -T test
+
+It is also possible to use the CI script outside of CI:
+
+.. code-block:: bash
+
+  $ HOST_CONFIG=<path_to>/<host-config>.cmake scripts/gitlab/build_and_test.sh
+
+Testing new dependencies versions
+---------------------------------
+
+CHAI depends on Umpire, and optionally RAJA. Testing with newer versions of both is made straightforward with Uberenv and Spack:
+
+* ``$ python scripts/uberenv/uberenv.py --spec=%clang@9.0.0 ^umpire@develop``
+* ``$ python scripts/uberenv/uberenv.py --spec=%clang@9.0.0+raja ^raja@develop``
+
+Those commands will install respectively `umpire@develop` and `raja@develop` locally, and generate host-config files with the corresponding paths.
+
+Again, the CI script can be used directly to install, build and test in one command:
+
+.. code-block:: bash
+
+  $ SPEC="%clang@9.0.0 ^umpire@develop" scripts/gitlab/build_and_test.sh

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -41,7 +41,7 @@ then
         prefix_opt="--prefix=${prefix}"
     fi
 
-    python scripts/uberenv/uberenv.py --spec=${spec} ${prefix_opt}
+    python scripts/uberenv/uberenv.py --spec="${spec}" ${prefix_opt}
 
 fi
 

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -19,6 +19,9 @@ build_root=${BUILD_ROOT:-""}
 hostconfig=${HOST_CONFIG:-""}
 spec=${SPEC:-""}
 
+raja_version=${UPDATE_RAJA:-""}
+umpire_version=${UPDATE_UMPIRE:-""}
+
 # Dependencies
 if [[ "${option}" != "--build-only" && "${option}" != "--test-only" ]]
 then
@@ -32,11 +35,29 @@ then
         exit 1
     fi
 
+    extra_variants=""
+    extra_deps=""
+
+    if [[ -n ${raja_version} ]]
+    then
+        extra_variants="${extra_variants} +raja"
+        extra_deps="${extra_deps} ^raja@${raja_version}"
+    fi
+
+    if [[ -n ${umpire_version} ]]
+    then
+        extra_variants="${extra_variants} +umpire"
+        extra_deps="${extra_deps} ^umpire@${umpire_version}"
+    fi
+
+    [[ -n ${extra_variants} ]] && spec="${spec} ${extra_variants}"
+    [[ -n ${extra_deps} ]] && spec="${spec} ${extra_deps}"
+
     prefix_opt=""
 
     if [[ -d /dev/shm ]]
     then
-        prefix="/dev/shm/${hostname}/${spec}"
+        prefix="/dev/shm/${hostname}/${spec// /_}"
         mkdir -p ${prefix}
         prefix_opt="--prefix=${prefix}"
     fi

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -46,7 +46,6 @@ then
 
     if [[ -n ${umpire_version} ]]
     then
-        extra_variants="${extra_variants} +umpire"
         extra_deps="${extra_deps} ^umpire@${umpire_version}"
     fi
 

--- a/scripts/uberenv/packages/chai/package.py
+++ b/scripts/uberenv/packages/chai/package.py
@@ -68,6 +68,8 @@ class Chai(CMakePackage, CudaPackage):
 
     variant('shared', default=True, description='Build Shared Libs')
     variant('raja', default=False, description='Build plugin for RAJA')
+    variant('tests', default='basic', values=('none', 'basic', 'benchmarks'),
+            multi=False, description='Tests to run')
 
     depends_on('cmake@3.8:', type='build')
     depends_on('umpire')
@@ -238,6 +240,9 @@ class Chai(CMakePackage, CudaPackage):
 
         umpire_conf_path = spec['umpire'].prefix + "/share/umpire/cmake"
         cfg.write(cmake_cache_entry("umpire_DIR",umpire_conf_path))
+
+        cfg.write(cmake_cache_option("ENABLE_BENCHMARKS", 'tests=benchmarks' in spec))
+        cfg.write(cmake_cache_option("ENABLE_TESTS", not 'tests=none' in spec))
 
         #######################
         # Close and save

--- a/scripts/uberenv/packages/chai/package.py
+++ b/scripts/uberenv/packages/chai/package.py
@@ -58,7 +58,7 @@ class Chai(CMakePackage, CudaPackage):
     git      = "https://github.com/LLNL/CHAI.git"
 
     version('develop', branch='develop', submodules='True')
-    version('main', branch='main', submodules='True')
+    version('master', branch='main', submodules='True')
     version('2.1.1', tag='v2.1.1', submodules='True')
     version('2.1.0', tag='v2.1.0', submodules='True')
     version('2.0.0', tag='v2.0.0', submodules='True')

--- a/scripts/uberenv/packages/chai/package.py
+++ b/scripts/uberenv/packages/chai/package.py
@@ -238,8 +238,6 @@ class Chai(CMakePackage, CudaPackage):
 
         umpire_conf_path = spec['umpire'].prefix + "/share/umpire/cmake"
         cfg.write(cmake_cache_entry("umpire_DIR",umpire_conf_path))
-        camp_conf_path = spec['umpire'].prefix + "/lib/cmake/camp"
-        cfg.write(cmake_cache_entry("camp_DIR", camp_conf_path))
 
         #######################
         # Close and save

--- a/scripts/uberenv/packages/chai/package.py
+++ b/scripts/uberenv/packages/chai/package.py
@@ -219,6 +219,17 @@ class Chai(CMakePackage, CudaPackage):
         else:
             cfg.write(cmake_cache_option("ENABLE_CUDA", False))
 
+        if "+raja" in spec:
+            cfg.write("#------------------{0}\n".format("-" * 60))
+            cfg.write("# RAJA\n")
+            cfg.write("#------------------{0}\n\n".format("-" * 60))
+
+            cfg.write(cmake_cache_option("ENABLE_RAJA_PLUGIN", True))
+            raja_dir = spec['raja'].prefix
+            cfg.write(cmake_cache_entry("RAJA_DIR", raja_dir))
+        else:
+            cfg.write(cmake_cache_option("ENABLE_RAJA_PLUGIN", False))
+
         # shared vs static libs
         cfg.write(cmake_cache_option("BUILD_SHARED_LIBS","+shared" in spec))
 

--- a/scripts/uberenv/packages/chai/package.py
+++ b/scripts/uberenv/packages/chai/package.py
@@ -74,7 +74,7 @@ class Chai(CMakePackage, CudaPackage):
     depends_on('cmake@3.9:', type='build', when="+cuda")
     depends_on('umpire+cuda', when="+cuda")
 
-    phases = ['hostconfig', 'cmake', 'build','install']
+    phases = ['hostconfig', 'cmake', 'build', 'install']
 
     def _get_sys_type(self, spec):
         sys_type = str(spec.architecture)

--- a/scripts/uberenv/packages/chai/package.py
+++ b/scripts/uberenv/packages/chai/package.py
@@ -67,12 +67,15 @@ class Chai(CMakePackage, CudaPackage):
     version('1.0', tag='v1.0', submodules='True')
 
     variant('shared', default=True, description='Build Shared Libs')
+    variant('raja', default=False, description='Build plugin for RAJA')
 
     depends_on('cmake@3.8:', type='build')
     depends_on('umpire')
+    depends_on('raja', when="+raja")
 
     depends_on('cmake@3.9:', type='build', when="+cuda")
     depends_on('umpire+cuda', when="+cuda")
+    depends_on('raja+cuda', when="+raja+cuda")
 
     phases = ['hostconfig', 'cmake', 'build', 'install']
 

--- a/scripts/uberenv/packages/raja/package.py
+++ b/scripts/uberenv/packages/raja/package.py
@@ -56,7 +56,7 @@ class Raja(CMakePackage, CudaPackage):
     git      = "https://github.com/LLNL/RAJA.git"
 
     version('develop', branch='develop', submodules='True')
-    version('main',  branch='main',  submodules='True')
+    version('master',  branch='main',  submodules='True')
     version('0.11.0', tag='v0.11.0', submodules="True")
     version('0.10.1', tag='v0.10.1', submodules="True")
     version('0.10.0', tag='v0.10.0', submodules="True")

--- a/scripts/uberenv/packages/raja/package.py
+++ b/scripts/uberenv/packages/raja/package.py
@@ -1,0 +1,277 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+import socket
+import os
+
+from os import environ as env
+from os.path import join as pjoin
+
+def cmake_cache_entry(name, value, comment=""):
+    """Generate a string for a cmake cache variable"""
+
+    return 'set(%s "%s" CACHE PATH "%s")\n\n' % (name,value,comment)
+
+
+def cmake_cache_string(name, string, comment=""):
+    """Generate a string for a cmake cache variable"""
+
+    return 'set(%s "%s" CACHE STRING "%s")\n\n' % (name,string,comment)
+
+
+def cmake_cache_option(name, boolean_value, comment=""):
+    """Generate a string for a cmake configuration option"""
+
+    value = "ON" if boolean_value else "OFF"
+    return 'set(%s %s CACHE BOOL "%s")\n\n' % (name,value,comment)
+
+
+def get_spec_path(spec, package_name, path_replacements = {}, use_bin = False) :
+    """Extracts the prefix path for the given spack package
+       path_replacements is a dictionary with string replacements for the path.
+    """
+
+    if not use_bin:
+        path = spec[package_name].prefix
+    else:
+        path = spec[package_name].prefix.bin
+
+    path = os.path.realpath(path)
+
+    for key in path_replacements:
+        path = path.replace(key, path_replacements[key])
+
+    return path
+
+
+class Raja(CMakePackage, CudaPackage):
+    """RAJA Parallel Framework."""
+
+    homepage = "http://software.llnl.gov/RAJA/"
+    git      = "https://github.com/LLNL/RAJA.git"
+
+    version('develop', branch='develop', submodules='True')
+    version('main',  branch='main',  submodules='True')
+    version('0.11.0', tag='v0.11.0', submodules="True")
+    version('0.10.1', tag='v0.10.1', submodules="True")
+    version('0.10.0', tag='v0.10.0', submodules="True")
+    version('0.9.0', tag='v0.9.0', submodules="True")
+    version('0.8.0', tag='v0.8.0', submodules="True")
+    version('0.7.0', tag='v0.7.0', submodules="True")
+    version('0.6.0', tag='v0.6.0', submodules="True")
+    version('0.5.3', tag='v0.5.3', submodules="True")
+    version('0.5.2', tag='v0.5.2', submodules="True")
+    version('0.5.1', tag='v0.5.1', submodules="True")
+    version('0.5.0', tag='v0.5.0', submodules="True")
+    version('0.4.1', tag='v0.4.1', submodules="True")
+    version('0.4.0', tag='v0.4.0', submodules="True")
+
+    variant('openmp', default=True, description='Build OpenMP backend')
+    variant('shared', default=True, description='Build Shared Libs')
+
+    depends_on('cmake@3.8:', type='build')
+    depends_on('cmake@3.9:', when='+cuda', type='build')
+
+    phases = ['hostconfig', 'cmake', 'build', 'install']
+
+    def _get_sys_type(self, spec):
+        sys_type = str(spec.architecture)
+        # if on llnl systems, we can use the SYS_TYPE
+        if "SYS_TYPE" in env:
+            sys_type = env["SYS_TYPE"]
+        return sys_type
+
+    def _get_host_config_path(self, spec):
+        var=''
+        if '+cuda' in spec:
+            var= '-'.join([var,'cuda'])
+
+        host_config_path = "hc-%s-%s-%s%s-%s.cmake" % (socket.gethostname().rstrip('1234567890'),
+                                               self._get_sys_type(spec),
+                                               spec.compiler,
+                                               var,
+                                               spec.dag_hash())
+        dest_dir = self.stage.source_path
+        host_config_path = os.path.abspath(pjoin(dest_dir, host_config_path))
+        return host_config_path
+
+    def hostconfig(self, spec, prefix, py_site_pkgs_dir=None):
+        """
+        This method creates a 'host-config' file that specifies
+        all of the options used to configure and build Umpire.
+
+        For more details about 'host-config' files see:
+            http://software.llnl.gov/conduit/building.html
+
+        Note:
+          The `py_site_pkgs_dir` arg exists to allow a package that
+          subclasses this package provide a specific site packages
+          dir when calling this function. `py_site_pkgs_dir` should
+          be an absolute path or `None`.
+
+          This is necessary because the spack `site_packages_dir`
+          var will not exist in the base class. For more details
+          on this issue see: https://github.com/spack/spack/issues/6261
+        """
+
+        #######################
+        # Compiler Info
+        #######################
+        c_compiler = env["SPACK_CC"]
+        cpp_compiler = env["SPACK_CXX"]
+
+        # Even though we don't have fortran code in our project we sometimes
+        # use the Fortran compiler to determine which libstdc++ to use
+        f_compiler = ""
+        if "SPACK_FC" in env.keys():
+            # even if this is set, it may not exist
+            # do one more sanity check
+            if os.path.isfile(env["SPACK_FC"]):
+                f_compiler = env["SPACK_FC"]
+
+        #######################################################################
+        # By directly fetching the names of the actual compilers we appear
+        # to doing something evil here, but this is necessary to create a
+        # 'host config' file that works outside of the spack install env.
+        #######################################################################
+
+        sys_type = self._get_sys_type(spec)
+
+        ##############################################
+        # Find and record what CMake is used
+        ##############################################
+
+        cmake_exe = spec['cmake'].command.path
+        cmake_exe = os.path.realpath(cmake_exe)
+
+        host_config_path = self._get_host_config_path(spec)
+        cfg = open(host_config_path, "w")
+        cfg.write("###################\n".format("#" * 60))
+        cfg.write("# Generated host-config - Edit at own risk!\n")
+        cfg.write("###################\n".format("#" * 60))
+        cfg.write("# Copyright (c) 2020, Lawrence Livermore National Security, LLC and\n")
+        cfg.write("# other Umpire Project Developers. See the top-level LICENSE file for\n")
+        cfg.write("# details.\n")
+        cfg.write("#\n")
+        cfg.write("# SPDX-License-Identifier: (BSD-3-Clause) \n")
+        cfg.write("###################\n\n".format("#" * 60))
+
+        cfg.write("#------------------\n".format("-" * 60))
+        cfg.write("# SYS_TYPE: {0}\n".format(sys_type))
+        cfg.write("# Compiler Spec: {0}\n".format(spec.compiler))
+        cfg.write("# CMake executable path: %s\n" % cmake_exe)
+        cfg.write("#------------------\n\n".format("-" * 60))
+
+        cfg.write(cmake_cache_string("CMAKE_BUILD_TYPE", spec.variants['build_type'].value))
+
+        #######################
+        # Compiler Settings
+        #######################
+
+        cfg.write("#------------------\n".format("-" * 60))
+        cfg.write("# Compilers\n")
+        cfg.write("#------------------\n\n".format("-" * 60))
+        cfg.write(cmake_cache_entry("CMAKE_C_COMPILER", c_compiler))
+        cfg.write(cmake_cache_entry("CMAKE_CXX_COMPILER", cpp_compiler))
+
+        # use global spack compiler flags
+        cflags = ' '.join(spec.compiler_flags['cflags'])
+        if cflags:
+            cfg.write(cmake_cache_entry("CMAKE_C_FLAGS", cflags))
+
+        cxxflags = ' '.join(spec.compiler_flags['cxxflags'])
+        if cxxflags:
+            cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS", cxxflags))
+
+        # TODO (bernede1@llnl.gov): Is this useful for RAJA?
+        if ("gfortran" in f_compiler) and ("clang" in cpp_compiler):
+            libdir = pjoin(os.path.dirname(
+                           os.path.dirname(f_compiler)), "lib")
+            flags = ""
+            for _libpath in [libdir, libdir + "64"]:
+                if os.path.exists(_libpath):
+                    flags += " -Wl,-rpath,{0}".format(_libpath)
+            description = ("Adds a missing libstdc++ rpath")
+            if flags:
+                cfg.write(cmake_cache_string("BLT_EXE_LINKER_FLAGS", flags,
+                                            description))
+
+        if "toss_3_x86_64_ib" in sys_type:
+            release_flags = "-O3 -msse4.2 -funroll-loops -finline-functions"
+            cfg.write(cmake_cache_string("CMAKE_CXX_FLAGS_RELEASE", release_flags))
+            reldebinf_flags = "-O3 -g -msse4.2 -funroll-loops -finline-functions"
+            cfg.write(cmake_cache_string("CMAKE_CXX_FLAGS_RELWITHDEBINFO", reldebinf_flags))
+            debug_flags = "-O0 -g"
+            cfg.write(cmake_cache_string("CMAKE_CXX_FLAGS_DEBUG", debug_flags))
+
+        if "blueos_3_ppc64le_ib" in sys_type:
+            release_flags = "-O3"
+            cfg.write(cmake_cache_string("CMAKE_CXX_FLAGS_RELEASE", release_flags))
+            reldebinf_flags = "-O3 -g"
+            cfg.write(cmake_cache_string("CMAKE_CXX_FLAGS_RELWITHDEBINFO", reldebinf_flags))
+            debug_flags = "-O0 -g"
+            cfg.write(cmake_cache_string("CMAKE_CXX_FLAGS_DEBUG", debug_flags))
+
+        if "+cuda" in spec:
+            cfg.write("#------------------{0}\n".format("-" * 60))
+            cfg.write("# Cuda\n")
+            cfg.write("#------------------{0}\n\n".format("-" * 60))
+
+            cfg.write(cmake_cache_option("ENABLE_CUDA", True))
+
+            cudatoolkitdir = spec['cuda'].prefix
+            cfg.write(cmake_cache_entry("CUDA_TOOLKIT_ROOT_DIR",
+                                        cudatoolkitdir))
+            cudacompiler = "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc"
+            cfg.write(cmake_cache_entry("CMAKE_CUDA_COMPILER",
+                                        cudacompiler))
+
+            if not spec.satisfies('cuda_arch=none'):
+                cuda_arch = spec.variants['cuda_arch'].value
+                flag = '-arch sm_{0}'.format(cuda_arch[0])
+                cfg.write(cmake_cache_string("CMAKE_CUDA_FLAGS", flag))
+
+        else:
+            cfg.write(cmake_cache_option("ENABLE_CUDA", False))
+
+        cfg.write("#------------------{0}\n".format("-" * 60))
+        cfg.write("# Other\n")
+        cfg.write("#------------------{0}\n\n".format("-" * 60))
+
+        cfg.write(cmake_cache_string("RAJA_RANGE_ALIGN", "4"))
+        cfg.write(cmake_cache_string("RAJA_RANGE_MIN_LENGTH", "32"))
+        cfg.write(cmake_cache_string("RAJA_DATA_ALIGN", "64"))
+
+        cfg.write(cmake_cache_option("RAJA_HOST_CONFIG_LOADED", True))
+
+        # shared vs static libs
+        cfg.write(cmake_cache_option("BUILD_SHARED_LIBS","+shared" in spec))
+        cfg.write(cmake_cache_option("ENABLE_OPENMP","+openmp" in spec))
+
+        # Work around spack adding -march=ppc64le to SPACK_TARGET_ARGS which
+        # is used by the spack compiler wrapper.  This can go away when BLT
+        # removes -Werror from GTest flags
+        if self.spec.satisfies('%clang target=ppc64le:'):
+            cfg.write(cmake_cache_option("ENABLE_TESTS",False))
+
+        #######################
+        # Close and save
+        #######################
+        cfg.write("\n")
+        cfg.close()
+
+        print("OUT: host-config file {0}".format(host_config_path))
+
+    def cmake_args(self):
+        spec = self.spec
+        host_config_path = self._get_host_config_path(spec)
+
+        options = []
+        options.extend(['-C', host_config_path])
+
+        return options

--- a/scripts/uberenv/packages/raja/package.py
+++ b/scripts/uberenv/packages/raja/package.py
@@ -73,6 +73,8 @@ class Raja(CMakePackage, CudaPackage):
 
     variant('openmp', default=True, description='Build OpenMP backend')
     variant('shared', default=True, description='Build Shared Libs')
+    variant('tests', default='basic', values=('none', 'basic', 'benchmarks'),
+            multi=False, description='Tests to run')
 
     depends_on('cmake@3.8:', type='build')
     depends_on('cmake@3.9:', when='+cuda', type='build')
@@ -258,6 +260,11 @@ class Raja(CMakePackage, CudaPackage):
         # removes -Werror from GTest flags
         if self.spec.satisfies('%clang target=ppc64le:'):
             cfg.write(cmake_cache_option("ENABLE_TESTS",False))
+            if 'tests=benchmarks' in spec or not 'tests=none' in spec:
+                print("MSG: no testing supported on %clang target=ppc64le:")
+        else:
+            cfg.write(cmake_cache_option("ENABLE_BENCHMARKS", 'tests=benchmarks' in spec))
+            cfg.write(cmake_cache_option("ENABLE_TESTS", not 'tests=none' in spec))
 
         #######################
         # Close and save

--- a/scripts/uberenv/packages/umpire/camp_target_umpire_3.0.0.patch
+++ b/scripts/uberenv/packages/umpire/camp_target_umpire_3.0.0.patch
@@ -1,0 +1,18 @@
+diff --git a/umpire-config.cmake.in b/umpire-config.cmake.in
+index a98ad5fe..4e54e173 100644
+--- a/umpire-config.cmake.in
++++ b/umpire-config.cmake.in
+@@ -7,6 +7,13 @@
+ get_filename_component(UMPIRE_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+ set(UMPIRE_INCLUDE_DIRS "@CMAKE_INSTALL_PREFIX@/include")
+ 
++if (NOT TARGET camp)
++  if (NOT DEFINED camp_DIR)
++    set(camp_DIR @CMAKE_INSTALL_PREFIX@/lib/cmake/camp)
++  endif ()
++  find_package(camp REQUIRED)
++endif ()
++
+ set(Umpire_VERSION_MAJOR  @Umpire_VERSION_MAJOR@)
+ set(Umpire_VERSION_MINOR @Umpire_VERSION_MINOR@)
+ set(Umpire_VERSION_PATCH @Umpire_VERSION_PATCH@)

--- a/scripts/uberenv/packages/umpire/package.py
+++ b/scripts/uberenv/packages/umpire/package.py
@@ -58,6 +58,7 @@ class Umpire(CMakePackage, CudaPackage):
 
     version('develop', branch='develop', submodules='True')
     version('master', branch='master', submodules='True')
+    version('3.0.0', tag='v3.0.0', submodules='True')
     version('2.1.0', tag='v2.1.0', submodules='True')
     version('2.0.0', tag='v2.0.0', submodules='True')
     version('1.1.0', tag='v1.1.0', submodules='True')

--- a/scripts/uberenv/packages/umpire/package.py
+++ b/scripts/uberenv/packages/umpire/package.py
@@ -78,6 +78,8 @@ class Umpire(CMakePackage, CudaPackage):
     version('0.1.4', tag='v0.1.4', submodules='True')
     version('0.1.3', tag='v0.1.3', submodules='True')
 
+    patch('camp_target_umpire_3.0.0.patch', when='@3.0.0')
+
     variant('fortran', default=False, description='Build C/Fortran API')
     variant('c', default=True, description='Build C API')
     variant('numa', default=False, description='Enable NUMA support')

--- a/scripts/uberenv/packages/umpire/package.py
+++ b/scripts/uberenv/packages/umpire/package.py
@@ -57,7 +57,7 @@ class Umpire(CMakePackage, CudaPackage):
     git      = 'https://github.com/LLNL/Umpire.git'
 
     version('develop', branch='develop', submodules='True')
-    version('master', branch='master', submodules='True')
+    version('master', branch='main', submodules='True')
     version('3.0.0', tag='v3.0.0', submodules='True')
     version('2.1.0', tag='v2.1.0', submodules='True')
     version('2.0.0', tag='v2.0.0', submodules='True')
@@ -83,6 +83,7 @@ class Umpire(CMakePackage, CudaPackage):
     variant('fortran', default=False, description='Build C/Fortran API')
     variant('c', default=True, description='Build C API')
     variant('numa', default=False, description='Enable NUMA support')
+    variant('shared', default=True, description='Enable Shared libs')
     variant('openmp', default=False, description='Build with OpenMP support')
     variant('deviceconst', default=False,
             description='Enables support for constant device memory')

--- a/scripts/uberenv/packages/umpire/package.py
+++ b/scripts/uberenv/packages/umpire/package.py
@@ -1,0 +1,275 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack import *
+
+import socket
+import os
+
+from os import environ as env
+from os.path import join as pjoin
+
+def cmake_cache_entry(name, value, comment=""):
+    """Generate a string for a cmake cache variable"""
+
+    return 'set(%s "%s" CACHE PATH "%s")\n\n' % (name,value,comment)
+
+
+def cmake_cache_string(name, string, comment=""):
+    """Generate a string for a cmake cache variable"""
+
+    return 'set(%s "%s" CACHE STRING "%s")\n\n' % (name,string,comment)
+
+
+def cmake_cache_option(name, boolean_value, comment=""):
+    """Generate a string for a cmake configuration option"""
+
+    value = "ON" if boolean_value else "OFF"
+    return 'set(%s %s CACHE BOOL "%s")\n\n' % (name,value,comment)
+
+
+def get_spec_path(spec, package_name, path_replacements = {}, use_bin = False) :
+    """Extracts the prefix path for the given spack package
+       path_replacements is a dictionary with string replacements for the path.
+    """
+
+    if not use_bin:
+        path = spec[package_name].prefix
+    else:
+        path = spec[package_name].prefix.bin
+
+    path = os.path.realpath(path)
+
+    for key in path_replacements:
+        path = path.replace(key, path_replacements[key])
+
+    return path
+
+
+class Umpire(CMakePackage, CudaPackage):
+    """An application-focused API for memory management on NUMA & GPU
+    architectures"""
+
+    homepage = 'https://github.com/LLNL/Umpire'
+    git      = 'https://github.com/LLNL/Umpire.git'
+
+    version('develop', branch='develop', submodules='True')
+    version('master', branch='master', submodules='True')
+    version('2.1.0', tag='v2.1.0', submodules='True')
+    version('2.0.0', tag='v2.0.0', submodules='True')
+    version('1.1.0', tag='v1.1.0', submodules='True')
+    version('1.0.1', tag='v1.0.1', submodules='True')
+    version('1.0.0', tag='v1.0.0', submodules='True')
+    version('0.3.5', tag='v0.3.5', submodules='True')
+    version('0.3.4', tag='v0.3.4', submodules='True')
+    version('0.3.3', tag='v0.3.3', submodules='True')
+    version('0.3.2', tag='v0.3.2', submodules='True')
+    version('0.3.1', tag='v0.3.1', submodules='True')
+    version('0.3.0', tag='v0.3.0', submodules='True')
+    version('0.2.4', tag='v0.2.4', submodules='True')
+    version('0.2.3', tag='v0.2.3', submodules='True')
+    version('0.2.2', tag='v0.2.2', submodules='True')
+    version('0.2.1', tag='v0.2.1', submodules='True')
+    version('0.2.0', tag='v0.2.0', submodules='True')
+    version('0.1.4', tag='v0.1.4', submodules='True')
+    version('0.1.3', tag='v0.1.3', submodules='True')
+
+    variant('fortran', default=False, description='Build C/Fortran API')
+    variant('c', default=True, description='Build C API')
+    variant('numa', default=False, description='Enable NUMA support')
+    variant('openmp', default=False, description='Build with OpenMP support')
+    variant('deviceconst', default=False,
+            description='Enables support for constant device memory')
+
+    variant('libcpp', default=False, description='Uses libc++ instead of libstdc++')
+
+    depends_on('cmake@3.8:', type='build')
+    depends_on('cmake@3.9:', when='+cuda', type='build')
+
+    conflicts('+numa', when='@:0.3.2')
+    conflicts('~c', when='+fortran', msg='Fortran API requires C API')
+
+    phases = ['hostconfig', 'cmake', 'build', 'install']
+
+    def _get_sys_type(self, spec):
+        sys_type = str(spec.architecture)
+        # if on llnl systems, we can use the SYS_TYPE
+        if "SYS_TYPE" in env:
+            sys_type = env["SYS_TYPE"]
+        return sys_type
+
+    def _get_host_config_path(self, spec):
+        var=''
+        if '+cuda' in spec:
+            var= '-'.join([var,'cuda'])
+        if '+libcpp' in spec:
+            var='-'.join([var,'libcpp'])
+
+        host_config_path = "hc-%s-%s-%s%s-%s.cmake" % (socket.gethostname().rstrip('1234567890'),
+                                               self._get_sys_type(spec),
+                                               spec.compiler,
+                                               var,
+                                               spec.dag_hash())
+        dest_dir = self.stage.source_path
+        host_config_path = os.path.abspath(pjoin(dest_dir, host_config_path))
+        return host_config_path
+
+    def hostconfig(self, spec, prefix, py_site_pkgs_dir=None):
+        """
+        This method creates a 'host-config' file that specifies
+        all of the options used to configure and build Umpire.
+
+        For more details about 'host-config' files see:
+            http://software.llnl.gov/conduit/building.html
+
+        Note:
+          The `py_site_pkgs_dir` arg exists to allow a package that
+          subclasses this package provide a specific site packages
+          dir when calling this function. `py_site_pkgs_dir` should
+          be an absolute path or `None`.
+
+          This is necessary because the spack `site_packages_dir`
+          var will not exist in the base class. For more details
+          on this issue see: https://github.com/spack/spack/issues/6261
+        """
+
+        #######################
+        # Compiler Info
+        #######################
+        c_compiler = env["SPACK_CC"]
+        cpp_compiler = env["SPACK_CXX"]
+
+        # Even though we don't have fortran code in our project we sometimes
+        # use the Fortran compiler to determine which libstdc++ to use
+        f_compiler = ""
+        if "SPACK_FC" in env.keys():
+            # even if this is set, it may not exist
+            # do one more sanity check
+            if os.path.isfile(env["SPACK_FC"]):
+                f_compiler = env["SPACK_FC"]
+
+        #######################################################################
+        # By directly fetching the names of the actual compilers we appear
+        # to doing something evil here, but this is necessary to create a
+        # 'host config' file that works outside of the spack install env.
+        #######################################################################
+
+        sys_type = self._get_sys_type(spec)
+
+        ##############################################
+        # Find and record what CMake is used
+        ##############################################
+
+        cmake_exe = spec['cmake'].command.path
+        cmake_exe = os.path.realpath(cmake_exe)
+
+        host_config_path = self._get_host_config_path(spec)
+        cfg = open(host_config_path, "w")
+        cfg.write("###################\n".format("#" * 60))
+        cfg.write("# Generated host-config - Edit at own risk!\n")
+        cfg.write("###################\n".format("#" * 60))
+        cfg.write("# Copyright (c) 2020, Lawrence Livermore National Security, LLC and\n")
+        cfg.write("# other Umpire Project Developers. See the top-level LICENSE file for\n")
+        cfg.write("# details.\n")
+        cfg.write("#\n")
+        cfg.write("# SPDX-License-Identifier: (BSD-3-Clause) \n")
+        cfg.write("###################\n\n".format("#" * 60))
+
+        cfg.write("#------------------\n".format("-" * 60))
+        cfg.write("# SYS_TYPE: {0}\n".format(sys_type))
+        cfg.write("# Compiler Spec: {0}\n".format(spec.compiler))
+        cfg.write("# CMake executable path: %s\n" % cmake_exe)
+        cfg.write("#------------------\n\n".format("-" * 60))
+
+        #######################
+        # Compiler Settings
+        #######################
+
+        cfg.write("#------------------\n".format("-" * 60))
+        cfg.write("# Compilers\n")
+        cfg.write("#------------------\n\n".format("-" * 60))
+        cfg.write(cmake_cache_entry("CMAKE_C_COMPILER", c_compiler))
+        cfg.write(cmake_cache_entry("CMAKE_CXX_COMPILER", cpp_compiler))
+
+        # use global spack compiler flags
+        cflags = ' '.join(spec.compiler_flags['cflags'])
+        if "+libcpp" in spec:
+            cflags += ' '.join([cflags,"-DGTEST_HAS_CXXABI_H_=0"])
+        if cflags:
+            cfg.write(cmake_cache_entry("CMAKE_C_FLAGS", cflags))
+
+        cxxflags = ' '.join(spec.compiler_flags['cxxflags'])
+        if "+libcpp" in spec:
+            cxxflags += ' '.join([cxxflags,"-stdlib=libc++ -DGTEST_HAS_CXXABI_H_=0"])
+        if cxxflags:
+            cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS", cxxflags))
+
+        if ("gfortran" in f_compiler) and ("clang" in cpp_compiler):
+            libdir = pjoin(os.path.dirname(
+                           os.path.dirname(f_compiler)), "lib")
+            flags = ""
+            for _libpath in [libdir, libdir + "64"]:
+                if os.path.exists(_libpath):
+                    flags += " -Wl,-rpath,{0}".format(_libpath)
+            description = ("Adds a missing libstdc++ rpath")
+            if flags:
+                cfg.write(cmake_cache_entry("BLT_EXE_LINKER_FLAGS", flags,
+                                            description))
+
+        if "toss_3_x86_64_ib" in sys_type:
+            release_flags = "-O3 -finline-functions -axCORE-AVX2 -diag-disable cpu-dispatch"
+            cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS_RELEASE", release_flags))
+            reldebinf_flags = "-O3 -g -finline-functions -axCORE-AVX2 -diag-disable cpu-dispatch"
+            cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS_RELWITHDEBINFO", reldebinf_flags))
+            debug_flags = "-O0 -g"
+            cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS_DEBUG", debug_flags))
+
+        if "+cuda" in spec:
+            cfg.write("#------------------{0}\n".format("-" * 60))
+            cfg.write("# Cuda\n")
+            cfg.write("#------------------{0}\n\n".format("-" * 60))
+
+            cfg.write(cmake_cache_option("ENABLE_CUDA", True))
+
+            cudatoolkitdir = spec['cuda'].prefix
+            cfg.write(cmake_cache_entry("CUDA_TOOLKIT_ROOT_DIR",
+                                        cudatoolkitdir))
+            cudacompiler = "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc"
+            cfg.write(cmake_cache_entry("CMAKE_CUDA_COMPILER",
+                                        cudacompiler))
+
+            if not spec.satisfies('cuda_arch=none'):
+                cuda_arch = spec.variants['cuda_arch'].value
+                flag = '-arch sm_{0}'.format(cuda_arch[0])
+                cfg.write(cmake_cache_string("CMAKE_CUDA_FLAGS", flag))
+
+            if '+deviceconst' in spec:
+                cfg.write(cmake_cache_option("ENABLE_DEVICE_CONST", True))
+
+        else:
+            cfg.write(cmake_cache_option("ENABLE_CUDA", False))
+
+        cfg.write(cmake_cache_option("ENABLE_C", '+c' in spec))
+        cfg.write(cmake_cache_option("ENABLE_FORTRAN", '+fortran' in spec))
+        cfg.write(cmake_cache_option("ENABLE_NUMA", '+numa' in spec))
+        cfg.write(cmake_cache_option("ENABLE_OPENMP", '+openmp' in spec))
+
+        #######################
+        # Close and save
+        #######################
+        cfg.write("\n")
+        cfg.close()
+
+        print("OUT: host-config file {0}".format(host_config_path))
+
+    def cmake_args(self):
+        spec = self.spec
+        host_config_path = self._get_host_config_path(spec)
+
+        options = []
+        options.extend(['-C', host_config_path])
+
+        return options

--- a/scripts/uberenv/packages/umpire/package.py
+++ b/scripts/uberenv/packages/umpire/package.py
@@ -87,6 +87,8 @@ class Umpire(CMakePackage, CudaPackage):
     variant('openmp', default=False, description='Build with OpenMP support')
     variant('deviceconst', default=False,
             description='Enables support for constant device memory')
+    variant('tests', default='basic', values=('none', 'basic', 'benchmarks'),
+            multi=False, description='Tests to run')
 
     variant('libcpp', default=False, description='Uses libc++ instead of libstdc++')
 
@@ -267,6 +269,9 @@ class Umpire(CMakePackage, CudaPackage):
         cfg.write(cmake_cache_option("ENABLE_FORTRAN", '+fortran' in spec))
         cfg.write(cmake_cache_option("ENABLE_NUMA", '+numa' in spec))
         cfg.write(cmake_cache_option("ENABLE_OPENMP", '+openmp' in spec))
+
+        cfg.write(cmake_cache_option("ENABLE_BENCHMARKS", 'tests=benchmarks' in spec))
+        cfg.write(cmake_cache_option("ENABLE_TESTS", not 'tests=none' in spec))
 
         #######################
         # Close and save

--- a/scripts/uberenv/packages/umpire/package.py
+++ b/scripts/uberenv/packages/umpire/package.py
@@ -184,6 +184,8 @@ class Umpire(CMakePackage, CudaPackage):
         cfg.write("# CMake executable path: %s\n" % cmake_exe)
         cfg.write("#------------------\n\n".format("-" * 60))
 
+        cfg.write(cmake_cache_string("CMAKE_BUILD_TYPE", spec.variants['build_type'].value))
+
         #######################
         # Compiler Settings
         #######################
@@ -220,11 +222,16 @@ class Umpire(CMakePackage, CudaPackage):
                                             description))
 
         if "toss_3_x86_64_ib" in sys_type:
-            release_flags = "-O3 -finline-functions -axCORE-AVX2 -diag-disable cpu-dispatch"
-            cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS_RELEASE", release_flags))
-            reldebinf_flags = "-O3 -g -finline-functions -axCORE-AVX2 -diag-disable cpu-dispatch"
-            cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS_RELWITHDEBINFO", reldebinf_flags))
+            release_flags = "-O3"
+            reldebinf_flags = "-O3 -g"
             debug_flags = "-O0 -g"
+
+            if "intel" in str(spec.compiler):
+                release_flags = ' '.join([release_flags,'-finline-functions -axCORE-AVX2 -diag-disable cpu-dispatch'])
+                reldebinf_flags = ' '.join([reldebinf_flags,'-finline-functions -axCORE-AVX2 -diag-disable cpu-dispatch'])
+
+            cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS_RELEASE", release_flags))
+            cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS_RELWITHDEBINFO", reldebinf_flags))
             cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS_DEBUG", debug_flags))
 
         if "+cuda" in spec:


### PR DESCRIPTION
This PR introduces multi-project integration.

This is simply achieved by allowing Umpire and/or RAJA to be updated during CI via definition of a specific environment variable.
This has no impact on regular CI.

Also, we add copies of Umpire and RAJA packages locally, waiting for them to be published to the Spack repo.
