### PR TITLE
surround gpu functions by CHAI_GPUCC

### DIFF
--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -66,6 +66,8 @@ inline void gpuErrorCheck(hipError_t code, const char *file, int line, bool abor
 
 #endif
 
+#if defined(CHAI_GPUCC)
+
 // wrapper for hip/cuda synchronize
 inline void synchronize() {
 #if defined (CHAI_ENABLE_HIP) &&!defined(__HIP_DEVICE_COMPILE__)
@@ -110,6 +112,8 @@ CHAI_HOST inline void  gpuMemcpy(void* dst, const void* src, size_t count, gpuMe
    CHAI_GPU_ERROR_CHECK(cudaMemcpy(dst, src, count, kind));
 #endif
 }
+
+#endif //#if defined(CHAI_GPUCC)
 
 /*!
  * \brief Singleton that manages caching and movement of ManagedArray objects.

--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -66,8 +66,6 @@ inline void gpuErrorCheck(hipError_t code, const char *file, int line, bool abor
 
 #endif
 
-#if defined(CHAI_GPUCC)
-
 // wrapper for hip/cuda synchronize
 inline void synchronize() {
 #if defined (CHAI_ENABLE_HIP) &&!defined(__HIP_DEVICE_COMPILE__)
@@ -76,6 +74,8 @@ inline void synchronize() {
    CHAI_GPU_ERROR_CHECK(cudaDeviceSynchronize());
 #endif
 }
+
+#if defined(CHAI_GPUCC)
 
 // wrapper for hip/cuda free
 CHAI_HOST inline void gpuFree(void* buffer) {


### PR DESCRIPTION
Previously, when compiling cpu-only builds, I would get compiler warnings with functions like gpuMalloc(void** devPtr, size_t size) because the arguments devPtrffer and size are unused for non-gpu builds.

We avoid this by surrounding gpu functions by CHAI_GPUCC . These functions should not get called anyway for non-gpu builds