### PR TITLE
Add cdata method

### DIFF
--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -173,7 +173,8 @@ public:
    */
   CHAI_HOST void registerTouch(ExecutionSpace space);
 
-  CHAI_HOST void move(ExecutionSpace space=NONE) const;
+  CHAI_HOST void move(ExecutionSpace space=NONE,
+                      bool registerTouch=!std::is_const<T>::value) const;
 
   CHAI_HOST_DEVICE ManagedArray<T> slice(size_t begin, size_t elems=(size_t)-1) const;
 
@@ -206,6 +207,15 @@ public:
    * \return Raw pointer to data in the current execution space
    */
   CHAI_HOST_DEVICE T* data() const;
+
+  /*!
+   * \brief Move data to the current execution space (actually determined
+   *        by where the code is executing) and return a raw pointer. Do
+   *        not mark data as touched since a pointer to const is returned.
+   *
+   * \return Raw pointer to data in the current execution space
+   */
+  CHAI_HOST_DEVICE const T* cdata() const;
 
   /*!
    * \brief Return the raw pointer to the data in the given execution

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -386,7 +386,7 @@ CHAI_HOST_DEVICE void ManagedArray<T>::decr(size_t i) const {
 template <typename T>
 CHAI_INLINE
 CHAI_HOST
-void ManagedArray<T>::move(ExecutionSpace space) const
+void ManagedArray<T>::move(ExecutionSpace space, bool registerTouch) const
 {
   if (m_pointer_record != &ArrayManager::s_null_record) {
      ExecutionSpace prev_space = m_pointer_record->m_last_space;
@@ -408,7 +408,7 @@ void ManagedArray<T>::move(ExecutionSpace space) const
     if (m_pointer_record->m_last_space == PINNED) {
     } else 
 #endif
-     if (!std::is_const<T>::value) {
+     if (registerTouch) {
        CHAI_LOG(Debug, "T is non-const, registering touch of pointer" << m_active_pointer);
        m_resource_manager->registerTouch(m_pointer_record, space);
      }
@@ -487,6 +487,29 @@ T* ManagedArray<T>::data() const {
      }
 
      move(CPU);
+  }
+
+  if (m_elems == 0 && !m_is_slice) {
+     return nullptr;
+  }
+
+  return m_active_pointer;
+#else
+  return m_active_pointer;
+#endif
+}
+
+template<typename T>
+CHAI_INLINE
+CHAI_HOST_DEVICE
+const T* ManagedArray<T>::cdata() const {
+#if !defined(CHAI_DEVICE_COMPILE)
+  if (m_active_pointer) {
+     if (m_pointer_record == nullptr || m_pointer_record == &ArrayManager::s_null_record) {
+        CHAI_LOG(Warning, "nullptr pointer_record associated with non-nullptr active_pointer")
+     }
+
+     move(CPU, false);
   }
 
   if (m_elems == 0 && !m_is_slice) {

--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -119,6 +119,12 @@ CHAI_HOST_DEVICE T* ManagedArray<T>::data() const
 }
 
 template <typename T>
+CHAI_HOST_DEVICE T* ManagedArray<T>::cdata() const
+{
+   return m_active_pointer;
+}
+
+template <typename T>
 T* ManagedArray<T>::data(ExecutionSpace /*space*/, bool /*do_move*/) const
 {
   return m_active_pointer;
@@ -265,7 +271,7 @@ CHAI_INLINE CHAI_HOST void ManagedArray<T>::registerTouch(ExecutionSpace)
 }
 
 template <typename T>
-CHAI_INLINE CHAI_HOST void ManagedArray<T>::move(ExecutionSpace) const
+CHAI_INLINE CHAI_HOST void ManagedArray<T>::move(ExecutionSpace, bool) const
 {
 }
 

--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -119,7 +119,7 @@ CHAI_HOST_DEVICE T* ManagedArray<T>::data() const
 }
 
 template <typename T>
-CHAI_HOST_DEVICE T* ManagedArray<T>::cdata() const
+CHAI_HOST_DEVICE const T* ManagedArray<T>::cdata() const
 {
    return m_active_pointer;
 }


### PR DESCRIPTION
For ManagedArray<T>, the data method always returns T*, and if T is not const the ManagedArray is always marked as touched. This pull request adds a cdata method that always returns const T* and never marks the ManagedArray as touched.

An alternative would be to make data a template function so that it could be used like `myArray.data<const int>`(). The implementation below is greatly simplified, but gives the general idea:
template <typename U>
U* data() { move(space, std::is_const<U>::value); return m_active_pointer; }

If you have better ideas, I will be happy to hear them.