### PR TITLE
Improvements to managed_ptr

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -63,6 +63,7 @@ Any questions? Contact chai-dev@llnl.gov
 
   getting_started
   tutorial
+  user_guide
 
 .. toctree::
   :maxdepth: 2

--- a/docs/sphinx/user_guide.rst
+++ b/docs/sphinx/user_guide.rst
@@ -1,0 +1,189 @@
+.. Copyright (c) 2016, Lawrence Livermore National Security, LLC. All
+ rights reserved.
+ 
+ Produced at the Lawrence Livermore National Laboratory
+ 
+ This file is part of CHAI.
+ 
+ LLNL-CODE-705877
+ 
+ For details, see https:://github.com/LLNL/CHAI
+ Please also see the NOTICE and LICENSE files.
+ 
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+ 
+ - Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ 
+ - Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+ 
+ - Neither the name of the LLNS/LLNL nor the names of its contributors
+   may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+
+.. _user_guide:
+
+**********
+User Guide
+**********
+
+-----------------------------------
+A Portable Pattern for Polymorphism
+-----------------------------------
+
+CHAI provides a data structure to help handle cases where it is desirable to call virtual functions on the device. If you only call virtual functions on the host, this pattern is unnecessary. But for those who do want to use virtual functions on the device without a painstaking amount of refactoring, we begin with a short, albeit admittedly contrived example.
+
+.. code-block:: cpp
+
+   class MyBaseClass {
+      public:
+         MyBaseClass() {}
+         virtual ~MyBaseClass() {}
+         virtual int getValue() const = 0;
+   };
+
+   class MyDerivedClass : public MyBaseClass {
+      public:
+         MyDerivedClass(const int value) : MyBaseClass(), m_value(value) {}
+         virtual ~MyDerivedClass() {}
+         virtual int getValue() const { return m_value; }
+
+      private:
+         int m_value;
+   };
+
+   int main(int argc, char** argv) {
+      MyBaseClass* myBaseClass = new MyDerivedClass(0);
+      myBaseClass->getValue();
+      return 0;
+   }
+
+It is perfectly fine to call `myBaseClass->getValue()` in host code, since myBaseClass was created on the host. However, what if you want to call this virtual function on the device?
+
+.. code-block:: cpp
+
+   __global__ void callVirtualFunction(MyBaseClass* myBaseClass) {
+      myBaseClass->getValue();
+   }
+
+   int main(int argc, char** argv) {
+      MyBaseClass* myBaseClass = new MyDerivedClass(0);
+      callVirtualFunction<<<1, 1>>>(myBaseClass);
+      return 0;
+   }
+
+At best, calling this code will result in a crash. At worst, it will access garbage and happily continue while giving incorrect results. It is illegal to access host pointers on the device and produces undefined behavior. So what is our next attempt? Why not pass the argument by value rather than by a pointer?
+
+.. code-block:: cpp
+
+   __global__ void callVirtualFunction(MyBaseClass myBaseClass) {
+      myBaseClass.getValue();
+   }
+
+   int main(int argc, char** argv) {
+      MyBaseClass* myBaseClass = new MyDerivedClass(0);
+      callVirtualFunction<<<1, 1>>>(*myBaseClass); // This will not compile
+      return 0;
+   }
+
+At first glance, this may seem like it would work, but there is a flaw - copy constructors are not virtual. You could cast to MyDerivedClass and then pass that by value, but if there are tons of classes in this heirarchy, how do you know which one to cast it to? You could try dynamic_cast dozens of times, but that is not performant or sustainable. You could also write a virtual clone method, but that is also not sustainable. You could refactor to use the curiously recurring template pattern, but that would likely require a large development effort. Also, there is a limitation on the size of the arguments passed to a global kernel, so if you have a very large class, this is simply impossible. So we make another attempt.
+
+.. code-block:: cpp
+
+   __global__ void callVirtualFunction(MyBaseClass* myBaseClass) {
+      myBaseClass->getValue();
+   }
+
+   int main(int argc, char** argv) {
+      MyBaseClass* myBaseClass = new MyDerivedClass(0);
+      MyBaseClass* d_myBaseClass;
+      cudaMalloc(&d_myBaseClass, sizeof(MyBaseClass));
+      cudaMemcpy(d_myBaseClass, myBaseClass, sizeof(MyBaseClass), cudaMemcpyHostToDevice);
+      callVirtualFunction<<<1, 1>>>(d_myBaseClass);
+      return 0;
+   }
+
+We are getting nearer, but there is still a flaw. The bits of myBaseClass contain the virtual function table that allows virtual function lookups on the host, but that virtual function table is not valid for lookups on the device since it contains pointers to host functions. It will not work any better to cast to MyDerivedClass and copy the bits. The only option is to call the constructor on the device and keep that device pointer around.
+
+.. code-block:: cpp
+
+   __global__ void make_on_device(MyBaseClass** myBaseClass, int argument) {
+      *myBaseClass = new MyDerivedClass(argument);
+   }
+
+   __global__ void callVirtualFunction(MyBaseClass* myBaseClass) {
+      myBaseClass->getValue();
+   }
+
+   int main(int argc, char** argv) {
+      MyBaseClass** d_temp;
+      cudaMalloc(&d_temp, sizeof(MyBaseClass*));
+      make_on_device<<<1, 1>>>(d_temp, 0);
+
+      MyBaseClass** temp = (MyBaseClass**) malloc(sizeof(MyBaseClass*));
+      cudaMemcpy(temp, d_temp, sizeof(MyBaseClass*), cudaMemcpyDeviceToHost);
+      MyBaseClass d_myBaseClass = *temp;
+
+      callVirtualFunction<<<1, 1>>>(d_myBaseClass);
+
+      free(temp);
+      cudaFree(d_temp);
+
+      // Still need to call delete on the device
+      return 0;
+   }
+
+OK, this is finally correct, but super tedious. So we took care of the details for you.
+
+.. code-block:: cpp
+
+   __global__ void callVirtualFunction(chai::managed_ptr<MyBaseClass> myBaseClass) {
+      myBaseClass->getValue();
+   }
+
+   int main(int argc, char** argv) {
+      chai::managed_ptr<MyBaseClass> myBaseClass = chai::make_managed<MyDerivedClass>(0);
+      callVirtualFunction<<<1, 1>>>(myBaseClass);
+      myBaseClass.free();
+
+      return 0;
+   }
+
+OK, so we didn't do all the work for you, but we definitely gave you a leg up. What's left for you to do? You just need to make sure the functions accessed on the device have the __device__ specifier (including constructors and destructors). You also need to make sure the destructors are virtual so the object gets cleaned up properly on the device.
+
+.. code-block:: cpp
+
+   class MyBaseClass {
+      public:
+         CARE_HOST_DEVICE MyBaseClass() {}
+         CARE_HOST_DEVICE virtual ~MyBaseClass() {}
+         CARE_HOST_DEVICE virtual int getValue() const = 0;
+   };
+
+   class MyDerivedClass : public MyBaseClass {
+      public:
+         CARE_HOST_DEVICE MyDerivedClass(const int value) : MyBaseClass(), m_value(value) {}
+         CARE_HOST_DEVICE virtual ~MyDerivedClass() {}
+         CARE_HOST_DEVICE virtual int getValue() const { return m_value; }
+
+      private:
+         int m_value;
+   };

--- a/docs/sphinx/user_guide.rst
+++ b/docs/sphinx/user_guide.rst
@@ -62,9 +62,9 @@ CHAI provides a data structure to help handle cases where it is desirable to cal
 
    class MyDerivedClass : public MyBaseClass {
       public:
-         MyDerivedClass(const int value) : MyBaseClass(), m_value(value) {}
-         virtual ~MyDerivedClass() {}
-         virtual int getValue() const { return m_value; }
+         MyDerivedClass(int value) : MyBaseClass(), m_value(value) {}
+         ~MyDerivedClass() {}
+         int getValue() const { return m_value; }
 
       private:
          int m_value;
@@ -73,10 +73,11 @@ CHAI provides a data structure to help handle cases where it is desirable to cal
    int main(int argc, char** argv) {
       MyBaseClass* myBaseClass = new MyDerivedClass(0);
       myBaseClass->getValue();
+      delete myBaseClass;
       return 0;
    }
 
-It is perfectly fine to call `myBaseClass->getValue()` in host code, since myBaseClass was created on the host. However, what if you want to call this virtual function on the device?
+It is perfectly fine to call `myBaseClass->getValue()` in host code, since `myBaseClass` was created on the host. However, what if you want to call this virtual function on the device?
 
 .. code-block:: cpp
 
@@ -87,6 +88,7 @@ It is perfectly fine to call `myBaseClass->getValue()` in host code, since myBas
    int main(int argc, char** argv) {
       MyBaseClass* myBaseClass = new MyDerivedClass(0);
       callVirtualFunction<<<1, 1>>>(myBaseClass);
+      delete myBaseClass;
       return 0;
    }
 
@@ -101,10 +103,11 @@ At best, calling this code will result in a crash. At worst, it will access garb
    int main(int argc, char** argv) {
       MyBaseClass* myBaseClass = new MyDerivedClass(0);
       callVirtualFunction<<<1, 1>>>(*myBaseClass); // This will not compile
+      delete myBaseClass;
       return 0;
    }
 
-At first glance, this may seem like it would work, but there is a flaw - copy constructors are not virtual. You could cast to MyDerivedClass and then pass that by value, but if there are tons of classes in this heirarchy, how do you know which one to cast it to? You could try dynamic_cast dozens of times, but that is not performant or sustainable. You could also write a virtual clone method, but that is also not sustainable. You could refactor to use the curiously recurring template pattern, but that would likely require a large development effort. Also, there is a limitation on the size of the arguments passed to a global kernel, so if you have a very large class, this is simply impossible. So we make another attempt.
+At first glance, this may seem like it would work, but this is not supported by nvidia: "It is not allowed to pass as an argument to a `__global__` function an object of a class with virtual functions" (https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#virtual-functions). Also: "It is not allowed to pass as an argument to a `__global__` function an object of a class derived from virtual base classes" (https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#virtual-base-classes). You could refactor to use the curiously recurring template pattern, but that would likely require a large development effort and also limits the programming patterns you can use. Also, there is a limitation on the size of the arguments passed to a global kernel, so if you have a very large class this is simply impossible. So we make another attempt.
 
 .. code-block:: cpp
 
@@ -117,16 +120,25 @@ At first glance, this may seem like it would work, but there is a flaw - copy co
       MyBaseClass* d_myBaseClass;
       cudaMalloc(&d_myBaseClass, sizeof(MyBaseClass));
       cudaMemcpy(d_myBaseClass, myBaseClass, sizeof(MyBaseClass), cudaMemcpyHostToDevice);
+
       callVirtualFunction<<<1, 1>>>(d_myBaseClass);
+
+      cudaFree(d_myBaseClass);
+      delete myBaseClass;
+
       return 0;
    }
 
-We are getting nearer, but there is still a flaw. The bits of myBaseClass contain the virtual function table that allows virtual function lookups on the host, but that virtual function table is not valid for lookups on the device since it contains pointers to host functions. It will not work any better to cast to MyDerivedClass and copy the bits. The only option is to call the constructor on the device and keep that device pointer around.
+We are getting nearer, but there is still a flaw. The bits of `myBaseClass` contain the virtual function table that allows virtual function lookups on the host, but that virtual function table is not valid for lookups on the device since it contains pointers to host functions. It will not work any better to cast to `MyDerivedClass` and copy the bits. The only option is to call the constructor on the device and keep that device pointer around.
 
 .. code-block:: cpp
 
    __global__ void make_on_device(MyBaseClass** myBaseClass, int argument) {
       *myBaseClass = new MyDerivedClass(argument);
+   }
+
+   __global__ void destroy_on_device(MyBaseClass* myBaseClass) {
+      delete myBaseClass;
    }
 
    __global__ void callVirtualFunction(MyBaseClass* myBaseClass) {
@@ -145,13 +157,13 @@ We are getting nearer, but there is still a flaw. The bits of myBaseClass contai
       callVirtualFunction<<<1, 1>>>(d_myBaseClass);
 
       free(temp);
+      destroy_on_device<<<1, 1>>>(d_myBaseClass);
       cudaFree(d_temp);
 
-      // Still need to call delete on the device
       return 0;
    }
 
-OK, this is finally correct, but super tedious. So we took care of the details for you.
+OK, this is finally correct, but super tedious. So we took care of all the boilerplate and underlying details for you. The final result is at least recognizable when compared to the original code. The added benefit is that you can use a `chai::managed_ptr` on the host AND the device.
 
 .. code-block:: cpp
 
@@ -161,13 +173,13 @@ OK, this is finally correct, but super tedious. So we took care of the details f
 
    int main(int argc, char** argv) {
       chai::managed_ptr<MyBaseClass> myBaseClass = chai::make_managed<MyDerivedClass>(0);
-      callVirtualFunction<<<1, 1>>>(myBaseClass);
+      myBaseClass->getValue(); // Accessible on the host
+      callVirtualFunction<<<1, 1>>>(myBaseClass); // Accessible on the device
       myBaseClass.free();
-
       return 0;
    }
 
-OK, so we didn't do all the work for you, but we definitely gave you a leg up. What's left for you to do? You just need to make sure the functions accessed on the device have the __device__ specifier (including constructors and destructors). You also need to make sure the destructors are virtual so the object gets cleaned up properly on the device.
+OK, so we didn't do all the work for you, but we definitely gave you a leg up. What's left for you to do? You just need to make sure the functions accessed on the device have the `__device__` specifier (including constructors and destructors). We use the `CHAI_HOST_DEVICE` macro in this example, which actually annotates the functions as `__host__ __device__` so we can call the virtual method on both the host and the device. You also need to make sure the destructors of all base classes are virtual so the object gets cleaned up properly on the device.
 
 .. code-block:: cpp
 
@@ -180,10 +192,78 @@ OK, so we didn't do all the work for you, but we definitely gave you a leg up. W
 
    class MyDerivedClass : public MyBaseClass {
       public:
-         CARE_HOST_DEVICE MyDerivedClass(const int value) : MyBaseClass(), m_value(value) {}
-         CARE_HOST_DEVICE virtual ~MyDerivedClass() {}
-         CARE_HOST_DEVICE virtual int getValue() const { return m_value; }
+         CARE_HOST_DEVICE MyDerivedClass(int value) : MyBaseClass(), m_value(value) {}
+         CARE_HOST_DEVICE ~MyDerivedClass() {}
+         CARE_HOST_DEVICE int getValue() const { return m_value; }
 
       private:
          int m_value;
    };
+
+Now you may rightfully ask, what happens when this class contains raw pointers? There is a convenient solution for this case and we demonstrate with a more interesting example.
+
+.. code-block:: cpp
+
+   class MyBaseClass {
+      public:
+         CARE_HOST_DEVICE MyBaseClass() {}
+         CARE_HOST_DEVICE virtual ~MyBaseClass() {}
+         CARE_HOST_DEVICE virtual int getScalarValue() const = 0;
+         CARE_HOST_DEVICE virtual int getArrayValue(int index) const = 0;
+   };
+
+   class MyDerivedClass : public MyBaseClass {
+      public:
+         CARE_HOST_DEVICE MyDerivedClass(int scalarValue, int* arrayValue)
+            : MyBaseClass(), m_scalarValue(scalarValue), m_arrayValue(arrayValue) {}
+         CARE_HOST_DEVICE ~MyDerivedClass() {}
+         CARE_HOST_DEVICE int getScalarValue() const { return m_scalarValue; }
+         CARE_HOST_DEVICE int getArrayValue() const { return m_arrayValue; }
+
+      private:
+         int m_scalarValue;
+         int* m_arrayValue;
+   };
+
+   __global__ void callVirtualFunction(chai::managed_ptr<MyBaseClass> myBaseClass) {
+      int i = blockIdx.x*blockDim.x + threadIdx.x;
+      myBaseClass->getScalarValue();
+      myBaseClass->getArrayValue(i);
+   }
+
+   int main(int argc, char** argv) {
+      chai::ManagedArray<int> arrayValue(10);
+      chai::managed_ptr<MyBaseClass> myBaseClass
+         = chai::make_managed<MyDerivedClass>(0, chai::unpack(arrayValue));
+      callVirtualFunction<<<1, 10>>>(myBaseClass);
+      myBaseClass.free();
+      arrayValue.free();
+      return 0;
+   }
+
+The respective host and device pointers contained in the `chai::ManagedArray` can be extracted and passed to the host and device instance of `MyDerivedClass` using `chai::unpack`. Of course, if you never dereference `m_arrayValue` on the device, you could simply pass a raw pointer to `chai::make_managed`. If the class contains a `chai::ManagedArray`, a `chai::ManagedArray` can simply be passed to the constructor. The same rules apply for passing a `chai::managed_ptr`, calling `chai::unpack` on a `chai::managed_ptr`, or passing a raw pointer and not accessing it on the device.
+
+More complicated rules apply for keeping the data in sync between the host and device instances of an object, but it is possible to do so to a limited extent. It is also possible to control the lifetimes of objects passed to `chai::make_managed`.
+
+.. code-block:: cpp
+   int main(int argc, char** argv) {
+      chai::ManagedArray<int> arrayValue(10);
+
+      chai::managed_ptr<MyBaseClass> myBaseClass
+         = chai::make_managed<MyDerivedClass>(0, chai::unpack(arrayValue));
+      myBaseClass.set_callback([=] (chai::Action action, chai::ExecutionSpace space, void*) mutable {
+         if (action == chai::ACTION_MOVE) {
+            (void) chai::ManagedArray<int> temp(arrayValue); // Copy constructor triggers movement
+         }
+         else if (action == chai::ACTION_FREE && space == chai::NONE) {
+            temp.free();
+         }
+
+         return false;
+      });
+
+      callVirtualFunction<<<1, 10>>>(myBaseClass);
+      myBaseClass.free();
+      // arrayValue.free(); // Not needed anymore
+      return 0;
+   }

--- a/src/chai/managed_ptr.hpp
+++ b/src/chai/managed_ptr.hpp
@@ -612,7 +612,9 @@ namespace chai {
    ///
    /// @author Alan Dayton
    ///
-   /// A wrapper used for unpacking the internal pointers in the correct space
+   /// A wrapper used by the make_managed family of functions to indicate when
+   /// the internal pointers contained by a ManagedArray should be extracted.
+   /// It is not intended to be used directly, but rather created by unpack.
    ///
    template <typename T>
    class ManagedArrayUnpacker {
@@ -648,7 +650,9 @@ namespace chai {
    ///
    /// @author Alan Dayton
    ///
-   /// A wrapper used for unpacking the internal pointers in the correct space
+   /// A wrapper used by the make_managed family of functions to indicate when
+   /// the internal pointers contained by a managed_ptr should be extracted.
+   /// It is not intended to be used directly, but rather created by unpack.
    ///
    template <typename T>
    class managed_ptr_unpacker {
@@ -817,7 +821,8 @@ namespace chai {
    ///
    /// @param[in] arg The ManagedArray to unpack
    ///
-   /// @return A wrapper used for unpacking the internal pointers in the correct space
+   /// @return A wrapper used by make_managed for unpacking the internal pointers
+   ///         in the correct space
    ///
    template <typename T>
    CHAI_HOST ManagedArrayUnpacker<T> unpack(const ManagedArray<T>& arg) {
@@ -832,7 +837,8 @@ namespace chai {
    ///
    /// @param[in] arg The managed_ptr to unpack
    ///
-   /// @return A wrapper used for unpacking the internal pointers in the correct space
+   /// @return A wrapper used by make_managed for unpacking the internal pointers
+   ///         in the correct space
    ///
    template <typename T>
    CHAI_HOST managed_ptr_unpacker<T> unpack(const managed_ptr<T>& arg) {

--- a/src/chai/managed_ptr.hpp
+++ b/src/chai/managed_ptr.hpp
@@ -59,8 +59,8 @@ namespace chai {
    ///    used in both contexts with a single API.
    /// The make_managed and make_managed_from_factory functions call new on both the
    ///    host and device so that polymorphism is valid in both contexts. Simply copying
-   ///    an object to the device will not copy the vtable, so new must be called on
-   ///    the device.
+   ///    the bits of an object to the device will not copy the vtable, so new must be
+   ///    called on the device.
    ///
    /// Usage Requirements:
    ///    Methods that can be called on the host and/or device must be declared
@@ -71,27 +71,30 @@ namespace chai {
    ///       is updated and vice versa. If you wish to keep both instances in sync,
    ///       you must explicitly modify the object in both the host context and the
    ///       device context.
-   ///    Raw array members of T need to be initialized correctly with a host or
-   ///       device array. If a ManagedArray is passed to the make_managed or
-   ///       make_managed_from_factory methods in place of a raw array, it will be
-   ///       cast to the appropriate host or device pointer when passed to T's
-   ///       constructor on the host and on the device. If it is desired that these
-   ///       host and device pointers be kept in sync, define a callback that maintains
-   ///       a copy of the ManagedArray and upon the ACTION_MOVE event calls the copy
-   ///       constructor of that ManagedArray.
-   ///    If a raw array is passed to make_managed, accessing that member will be
+   ///    C-style array members of T need to be initialized correctly with a host or
+   ///       device C-style array. If a ManagedArray is passed to the make_managed or
+   ///       make_managed_from_factory methods in place of a C-style array, wrap it in
+   ///       a call to chai::unpack to extract the C-style arrays contained within the
+   ///       ManagedArray. This will pass the extracted host C-style array to the host
+   ///       constructor and the extracted device C-style array to the device
+   ///       constructor. If it is desired that these host and device C-style arrays be
+   ///       kept in sync like the normal behavior of ManagedArray, define a callback
+   ///       that maintains a copy of the ManagedArray and upon the ACTION_MOVE event
+   ///       calls the copy constructor of that ManagedArray.
+   ///    If a C-style array is passed to make_managed, accessing that member will be
    ///       valid only in the correct context. To prevent the accidental use of that
    ///       member in the wrong context, any methods that access it should be __host__
-   ///       only or __device__ only. Special care should be taken when passing raw
+   ///       only or __device__ only. Special care should be taken when passing C-style
    ///       arrays as arguments to member functions.
-   ///    The same restrictions for raw array members also apply to raw pointer members.
-   ///       A managed_ptr can be passed to the make_managed or make_managed_from_factory
-   ///       methods in place of a raw pointer, and the host constructor of T will
-   ///       be given the extracted host pointer, and likewise the device constructor
-   ///       of T will be given the extracted device pointer. If it is desired that these
-   ///       host and device pointers be kept in sync, define a callback that maintains
-   ///       a copy of the managed_ptr and upon the ACTION_MOVE event calls the copy
-   ///       constructor of that managed_ptr.
+   ///    The same restrictions for C-style array members also apply to raw pointer
+   ///       members. If a managed_ptr is passed to the make_managed or
+   ///       make_managed_from_factory methods in place of a raw pointer, wrap it in
+   ///       a call to chai::unpack to extract the raw pointers contained within the
+   ///       managed_ptr. This will pass the extracted host pointer to the host
+   ///       constructor and the extracted device pointer to the device constructor.
+   ///       If it is desired that these host and device pointers be kept in sync,
+   ///       define a callback that maintains a copy of the managed_ptr and upon the
+   ///       ACTION_MOVE event call the copy constructor of that managed_ptr.
    ///    Again, if a raw pointer is passed to make_managed, accessing that member will
    ///       only be valid in the correct context. Take care when passing raw pointers
    ///       as arguments to member functions.
@@ -101,10 +104,10 @@ namespace chai {
    ///       every kernel, call ArrayManager::getInstance()->enableDeviceSynchronize().
    ///       Alternatively, call cudaDeviceSynchronize() after any call to make_managed,
    ///       make_managed_from_factory, or managed_ptr::free, and check the return code
-   ///       for errors. If your code crashes in the constructor/destructor of T, then it
-   ///       is recommended to turn on this synchronization. For example, the constructor
-   ///       of T might run out of per-thread stack space on the GPU. If that happens,
-   ///       you can increase the device limit of per-thread stack space.
+   ///       for errors. If your code crashes in the constructor/destructor of T, then
+   ///       it is recommended to turn on this synchronization. For example, the
+   ///       constructor of T might run out of per-thread stack space on the GPU. If
+   ///       that happens, you can increase the device limit of per-thread stack space.
    ///
    template <typename T>
    class managed_ptr {
@@ -491,12 +494,14 @@ namespace chai {
                         switch (execSpace) {
                            case CPU:
                               delete pointer;
+                              m_cpu_pointer = nullptr;
                               break;
 #if defined(CHAI_GPUCC)
                            case GPU:
                            {
                               if (pointer) {
                                  detail::destroy_on_device<<<1, 1>>>(temp);
+                                 m_gpu_pointer = nullptr;
 
 #ifndef CHAI_DISABLE_RM
                                  if (ArrayManager::getInstance()->deviceSynchronize()) {
@@ -523,12 +528,14 @@ namespace chai {
                      switch (execSpace) {
                         case CPU:
                            delete pointer;
+                           m_cpu_pointer = nullptr;
                            break;
 #if defined(CHAI_GPUCC)
                         case GPU:
                         {
                            if (pointer) {
                               detail::destroy_on_device<<<1, 1>>>(pointer);
+                              m_gpu_pointer = nullptr;
 
 #ifndef CHAI_DISABLE_RM
                               if (ArrayManager::getInstance()->deviceSynchronize()) {
@@ -547,6 +554,7 @@ namespace chai {
                }
 
                delete m_pointer_record;
+               m_pointer_record = nullptr;
             }
          }
 
@@ -601,7 +609,80 @@ namespace chai {
          }
    };
 
+   ///
+   /// @author Alan Dayton
+   ///
+   /// A wrapper used for unpacking the internal pointers in the correct space
+   ///
+   template <typename T>
+   class ManagedArrayUnpacker {
+      public:
+         CHAI_HOST ManagedArrayUnpacker() = delete;
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Constructor
+         ///
+         /// @param[in] arg The ManagedArray to unpack
+         ///
+         /// @return a new instance of ManagedArrayUnpacker
+         ///
+         explicit CHAI_HOST ManagedArrayUnpacker(const ManagedArray<T>& arg)
+            : m_array{arg}
+         {}
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Unpacks the data
+         ///
+         /// @return the unpacked data
+         ///
+         CHAI_HOST_DEVICE T* data() const { return m_array.data(); }
+
+      private:
+         ManagedArray<T> m_array = nullptr; //!< The ManagedArray to unpack
+   };
+
+   ///
+   /// @author Alan Dayton
+   ///
+   /// A wrapper used for unpacking the internal pointers in the correct space
+   ///
+   template <typename T>
+   class managed_ptr_unpacker {
+      public:
+         CHAI_HOST managed_ptr_unpacker() = delete;
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Constructor
+         ///
+         /// @param[in] arg The managed_ptr to unpack
+         ///
+         /// @return a new instance of managed_ptr_unpacker
+         ///
+         explicit CHAI_HOST managed_ptr_unpacker(const managed_ptr<T>& arg)
+            : m_managed_ptr{arg}
+         {}
+
+         ///
+         /// @author Alan Dayton
+         ///
+         /// Unpacks the data
+         ///
+         /// @return the unpacked data
+         ///
+         CHAI_HOST_DEVICE T* get() const { return m_managed_ptr.get(); }
+
+      private:
+         managed_ptr<T> m_managed_ptr = nullptr; //!< The managed_ptr to unpack
+   };
+
    namespace detail {
+
       ///
       /// @author Alan Dayton
       ///
@@ -612,7 +693,7 @@ namespace chai {
       /// @return arg
       ///
       template <typename T>
-      CHAI_HOST_DEVICE T getRawPointers(T arg) {
+      CHAI_HOST_DEVICE T processArguments(const T& arg) {
          return arg;
       }
 
@@ -626,7 +707,7 @@ namespace chai {
       /// @return arg cast to a raw pointer
       ///
       template <typename T>
-      CHAI_HOST_DEVICE T* getRawPointers(ManagedArray<T> arg) {
+      CHAI_HOST_DEVICE T* processArguments(const ManagedArrayUnpacker<T>& arg) {
          return arg.data();
       }
 
@@ -643,156 +724,11 @@ namespace chai {
       /// @return a raw pointer acquired from arg
       ///
       template <typename T>
-      CHAI_HOST_DEVICE T* getRawPointers(managed_ptr<T> arg) {
+      CHAI_HOST_DEVICE T* processArguments(const managed_ptr_unpacker<T>& arg) {
          return arg.get();
       }
 
-      ///
-      /// @author Alan Dayton
-      ///
-      /// Creates a new object on the host and returns a pointer to it.
-      /// This implementation of new_on_host is called when no arguments need to be
-      ///    converted to raw pointers.
-      ///
-      /// @param[in] args The arguments to T's constructor
-      ///
-      /// @return a pointer to the new object on the host
-      ///
-      template <typename T,
-                typename... Args,
-                typename std::enable_if<std::is_constructible<T, Args...>::value, int>::type = 0>
-      CHAI_HOST T* new_on_host(Args&&... args) {
-         return new T(args...);
-      }
-
-      ///
-      /// @author Alan Dayton
-      ///
-      /// Creates a new object on the host and returns a pointer to it.
-      /// This implementation of new_on_host is called when arguments do need to be
-      ///    converted to raw pointers.
-      ///
-      /// @param[in] args The arguments to T's constructor
-      ///
-      /// @return a pointer to the new object on the host
-      ///
-      template <typename T,
-                typename... Args,
-                typename std::enable_if<!std::is_constructible<T, Args...>::value, int>::type = 0>
-      CHAI_HOST T* new_on_host(Args&&... args) {
-         return new T(getRawPointers(args)...);
-      }
-
-      ///
-      /// @author Alan Dayton
-      ///
-      /// Creates a new T on the host.
-      /// Sets the execution space to the CPU so that ManagedArrays and managed_ptrs
-      ///    are moved to the host as necessary.
-      ///
-      /// @param[in]  args The arguments to T's constructor
-      ///
-      /// @return The host pointer to the new T
-      ///
-      template <typename T,
-                typename... Args>
-      CHAI_HOST T* make_on_host(Args&&... args) {
-#ifndef CHAI_DISABLE_RM
-         // Get the ArrayManager and save the current execution space
-         chai::ArrayManager* arrayManager = chai::ArrayManager::getInstance();
-         ExecutionSpace currentSpace = arrayManager->getExecutionSpace();
-
-         // Set the execution space so that ManagedArrays and managed_ptrs
-         // are handled properly
-         arrayManager->setExecutionSpace(CPU);
-#endif
-
-         // Create on the host
-         T* cpuPointer = detail::new_on_host<T>(args...);
-
-#ifndef CHAI_DISABLE_RM
-         // Set the execution space back to the previous value
-         arrayManager->setExecutionSpace(currentSpace);
-#endif
-
-         // Return the CPU pointer
-         return cpuPointer;
-      }
-
-      ///
-      /// @author Alan Dayton
-      ///
-      /// Calls a factory method to create a new object on the host.
-      /// Sets the execution space to the CPU so that ManagedArrays and managed_ptrs
-      ///    are moved to the host as necessary.
-      ///
-      /// @param[in]  f    The factory method
-      /// @param[in]  args The arguments to the factory method
-      ///
-      /// @return The host pointer to the new object
-      ///
-      template <typename T,
-                typename F,
-                typename... Args>
-      CHAI_HOST T* make_on_host_from_factory(F f, Args&&... args) {
-#ifndef CHAI_DISABLE_RM
-         // Get the ArrayManager and save the current execution space
-         chai::ArrayManager* arrayManager = chai::ArrayManager::getInstance();
-         ExecutionSpace currentSpace = arrayManager->getExecutionSpace();
-
-         // Set the execution space so that ManagedArrays and managed_ptrs
-         // are handled properly
-         arrayManager->setExecutionSpace(CPU);
-#endif
-
-         // Create the object on the device
-         T* cpuPointer = f(args...);
-
-#ifndef CHAI_DISABLE_RM
-         // Set the execution space back to the previous value
-         arrayManager->setExecutionSpace(currentSpace);
-#endif
-
-         // Return the GPU pointer
-         return cpuPointer;
-      }
-
 #if defined(CHAI_GPUCC)
-      ///
-      /// @author Alan Dayton
-      ///
-      /// Creates a new object on the device and returns a pointer to it.
-      /// This implementation of new_on_device is called when no arguments need to be
-      ///    converted to raw pointers.
-      ///
-      /// @param[in] args The arguments to T's constructor
-      ///
-      /// @return a pointer to the new object on the device
-      ///
-      template <typename T,
-                typename... Args,
-                typename std::enable_if<std::is_constructible<T, Args...>::value, int>::type = 0>
-      CHAI_DEVICE void new_on_device(T** gpuPointer, Args&&... args) {
-         *gpuPointer = new T(args...);
-      }
-
-      ///
-      /// @author Alan Dayton
-      ///
-      /// Creates a new object on the device and returns a pointer to it.
-      /// This implementation of new_on_device is called when arguments do need to be
-      ///    converted to raw pointers.
-      ///
-      /// @param[in] args The arguments to T's constructor
-      ///
-      /// @return a pointer to the new object on the device
-      ///
-      template <typename T,
-                typename... Args,
-                typename std::enable_if<!std::is_constructible<T, Args...>::value, int>::type = 0>
-      CHAI_DEVICE void new_on_device(T** gpuPointer, Args&&... args) {
-         *gpuPointer = new T(getRawPointers(args)...);
-      }
 
       ///
       /// @author Alan Dayton
@@ -809,7 +745,7 @@ namespace chai {
                 typename... Args>
       __global__ void make_on_device(T** gpuPointer, Args... args)
       {
-         new_on_device(gpuPointer, args...);
+         *gpuPointer = new T(processArguments(args)...);
       }
 
       ///
@@ -830,7 +766,7 @@ namespace chai {
                 typename... Args>
       __global__ void make_on_device_from_factory(T** gpuPointer, F f, Args... args)
       {
-         *gpuPointer = f(args...);
+         *gpuPointer = f(processArguments(args)...);
       }
 
       ///
@@ -843,121 +779,7 @@ namespace chai {
       template <typename T>
       __global__ void destroy_on_device(T* gpuPointer)
       {
-         if (gpuPointer) {
-            delete gpuPointer;
-         }
-      }
-
-      ///
-      /// @author Alan Dayton
-      ///
-      /// Creates a new T on the device.
-      ///
-      /// @param[in]  args The arguments to T's constructor
-      ///
-      /// @return The device pointer to the new T
-      ///
-      template <typename T,
-                typename... Args>
-      CHAI_HOST T* make_on_device(Args... args) {
-#ifndef CHAI_DISABLE_RM
-         // Get the ArrayManager and save the current execution space
-         chai::ArrayManager* arrayManager = chai::ArrayManager::getInstance();
-         ExecutionSpace currentSpace = arrayManager->getExecutionSpace();
-
-         // Set the execution space so that ManagedArrays and managed_ptrs
-         // are handled properly
-         arrayManager->setExecutionSpace(GPU);
-#endif
-
-         // Allocate space on the GPU to hold the pointer to the new object
-         T** gpuBuffer;
-         gpuMalloc((void**)(&gpuBuffer), sizeof(T*));
-
-         // Create the object on the device
-         make_on_device<<<1, 1>>>(gpuBuffer, args...);
-
-#ifndef CHAI_DISABLE_RM
-         if (ArrayManager::getInstance()->deviceSynchronize()) {
-            synchronize();
-         }
-#endif
-
-         // Allocate space on the CPU for the pointer and copy the pointer to the CPU
-         T** cpuBuffer = (T**) malloc(sizeof(T*));
-         gpuMemcpy(cpuBuffer, gpuBuffer, sizeof(T*), gpuMemcpyDeviceToHost);
-
-         // Get the GPU pointer
-         T* gpuPointer = cpuBuffer[0];
-
-         // Free the host and device buffers
-         free(cpuBuffer);
-         gpuFree(gpuBuffer);
-
-#ifndef CHAI_DISABLE_RM
-         // Set the execution space back to the previous value
-         arrayManager->setExecutionSpace(currentSpace);
-#endif
-
-         // Return the GPU pointer
-         return gpuPointer;
-      }
-
-      ///
-      /// @author Alan Dayton
-      ///
-      /// Calls a factory method to create a new object on the device.
-      ///
-      /// @param[in]  f    The factory method
-      /// @param[in]  args The arguments to the factory method
-      ///
-      /// @return The device pointer to the new object
-      ///
-      template <typename T,
-                typename F,
-                typename... Args>
-      CHAI_HOST T* make_on_device_from_factory(F f, Args&&... args) {
-#ifndef CHAI_DISABLE_RM
-         // Get the ArrayManager and save the current execution space
-         chai::ArrayManager* arrayManager = chai::ArrayManager::getInstance();
-         ExecutionSpace currentSpace = arrayManager->getExecutionSpace();
-
-         // Set the execution space so that chai::ManagedArrays and
-         // chai::managed_ptrs are handled properly
-         arrayManager->setExecutionSpace(GPU);
-#endif
-
-         // Allocate space on the GPU to hold the pointer to the new object
-         T** gpuBuffer;
-         gpuMalloc((void**)(&gpuBuffer), sizeof(T*));
-
-         // Create the object on the device
-         make_on_device_from_factory<T><<<1, 1>>>(gpuBuffer, f, args...);
-
-#ifndef CHAI_DISABLE_RM
-         if (ArrayManager::getInstance()->deviceSynchronize()) {
-            synchronize();
-         }
-#endif
-
-         // Allocate space on the CPU for the pointer and copy the pointer to the CPU
-         T** cpuBuffer = (T**) malloc(sizeof(T*));
-         gpuMemcpy(cpuBuffer, gpuBuffer, sizeof(T*), gpuMemcpyDeviceToHost);
-
-         // Get the GPU pointer
-         T* gpuPointer = cpuBuffer[0];
-
-         // Free the host and device buffers
-         free(cpuBuffer);
-         gpuFree(gpuBuffer);
-
-#ifndef CHAI_DISABLE_RM
-         // Set the execution space back to the previous value
-         arrayManager->setExecutionSpace(currentSpace);
-#endif
-
-         // Return the GPU pointer
-         return gpuPointer;
+         delete gpuPointer;
       }
 
 #endif
@@ -990,6 +812,250 @@ namespace chai {
    ///
    /// @author Alan Dayton
    ///
+   /// Unpacks the pointers contained in the ManagedArray and passes them to the
+   /// corresponding spaces.
+   ///
+   /// @param[in] arg The ManagedArray to unpack
+   ///
+   /// @return A wrapper used for unpacking the internal pointers in the correct space
+   ///
+   template <typename T>
+   CHAI_HOST ManagedArrayUnpacker<T> unpack(const ManagedArray<T>& arg) {
+      return ManagedArrayUnpacker<T>(arg);
+   }
+
+   ///
+   /// @author Alan Dayton
+   ///
+   /// Unpacks the pointers contained in the managed_ptr and passes them to the
+   /// corresponding spaces.
+   ///
+   /// @param[in] arg The managed_ptr to unpack
+   ///
+   /// @return A wrapper used for unpacking the internal pointers in the correct space
+   ///
+   template <typename T>
+   CHAI_HOST managed_ptr_unpacker<T> unpack(const managed_ptr<T>& arg) {
+      return managed_ptr_unpacker<T>(arg);
+   }
+
+   ///
+   /// @author Alan Dayton
+   ///
+   /// Creates a new T on the host.
+   /// Sets the execution space to the CPU so that ManagedArrays and managed_ptrs
+   ///    are moved to the host as necessary.
+   ///
+   /// @param[in]  args The arguments to T's constructor
+   ///
+   /// @return The host pointer to the new T
+   ///
+   template <typename T,
+             typename... Args>
+   CHAI_HOST T* make_on_host(Args&&... args) {
+#ifndef CHAI_DISABLE_RM
+      // Get the ArrayManager and save the current execution space
+      chai::ArrayManager* arrayManager = chai::ArrayManager::getInstance();
+      ExecutionSpace currentSpace = arrayManager->getExecutionSpace();
+
+      // Set the execution space so that ManagedArrays and managed_ptrs
+      // are handled properly
+      arrayManager->setExecutionSpace(CPU);
+#endif
+
+      // Create on the host
+      T* cpuPointer = new T(detail::processArguments(args)...);
+
+#ifndef CHAI_DISABLE_RM
+      // Set the execution space back to the previous value
+      arrayManager->setExecutionSpace(currentSpace);
+#endif
+
+      // Return the CPU pointer
+      return cpuPointer;
+   }
+
+   ///
+   /// @author Alan Dayton
+   ///
+   /// Calls a factory method to create a new object on the host.
+   /// Sets the execution space to the CPU so that ManagedArrays and managed_ptrs
+   ///    are moved to the host as necessary.
+   ///
+   /// @param[in]  f    The factory method
+   /// @param[in]  args The arguments to the factory method
+   ///
+   /// @return The host pointer to the new object
+   ///
+   template <typename T,
+             typename F,
+             typename... Args>
+   CHAI_HOST T* make_on_host_from_factory(F f, Args&&... args) {
+#ifndef CHAI_DISABLE_RM
+      // Get the ArrayManager and save the current execution space
+      chai::ArrayManager* arrayManager = chai::ArrayManager::getInstance();
+      ExecutionSpace currentSpace = arrayManager->getExecutionSpace();
+
+      // Set the execution space so that ManagedArrays and managed_ptrs
+      // are handled properly
+      arrayManager->setExecutionSpace(CPU);
+#endif
+
+      // Create the object on the device
+      T* cpuPointer = f(args...);
+
+#ifndef CHAI_DISABLE_RM
+      // Set the execution space back to the previous value
+      arrayManager->setExecutionSpace(currentSpace);
+#endif
+
+      // Return the GPU pointer
+      return cpuPointer;
+   }
+
+   ///
+   /// @author Alan Dayton
+   ///
+   /// Destroys the host pointer.
+   ///
+   /// @param[out] cpuPointer The host pointer to clean up
+   ///
+   template <typename T>
+   CHAI_HOST void destroy_on_host(T* cpuPointer) {
+      delete cpuPointer;
+   }
+
+#if defined(CHAI_GPUCC)
+
+   ///
+   /// @author Alan Dayton
+   ///
+   /// Creates a new T on the device.
+   ///
+   /// @param[in]  args The arguments to T's constructor
+   ///
+   /// @return The device pointer to the new T
+   ///
+   template <typename T,
+             typename... Args>
+   CHAI_HOST T* make_on_device(Args... args) {
+#ifndef CHAI_DISABLE_RM
+      // Get the ArrayManager and save the current execution space
+      chai::ArrayManager* arrayManager = chai::ArrayManager::getInstance();
+      ExecutionSpace currentSpace = arrayManager->getExecutionSpace();
+
+      // Set the execution space so that ManagedArrays and managed_ptrs
+      // are handled properly
+      arrayManager->setExecutionSpace(GPU);
+#endif
+
+      // Allocate space on the GPU to hold the pointer to the new object
+      T** gpuBuffer;
+      gpuMalloc((void**)(&gpuBuffer), sizeof(T*));
+
+      // Create the object on the device
+      make_on_device<<<1, 1>>>(gpuBuffer, args...);
+
+#ifndef CHAI_DISABLE_RM
+      if (ArrayManager::getInstance()->deviceSynchronize()) {
+         synchronize();
+      }
+#endif
+
+      // Allocate space on the CPU for the pointer and copy the pointer to the CPU
+      T** cpuBuffer = (T**) malloc(sizeof(T*));
+      gpuMemcpy(cpuBuffer, gpuBuffer, sizeof(T*), gpuMemcpyDeviceToHost);
+
+      // Get the GPU pointer
+      T* gpuPointer = cpuBuffer[0];
+
+      // Free the host and device buffers
+      free(cpuBuffer);
+      gpuFree(gpuBuffer);
+
+#ifndef CHAI_DISABLE_RM
+      // Set the execution space back to the previous value
+      arrayManager->setExecutionSpace(currentSpace);
+#endif
+
+      // Return the GPU pointer
+      return gpuPointer;
+   }
+
+   ///
+   /// @author Alan Dayton
+   ///
+   /// Calls a factory method to create a new object on the device.
+   ///
+   /// @param[in]  f    The factory method
+   /// @param[in]  args The arguments to the factory method
+   ///
+   /// @return The device pointer to the new object
+   ///
+   template <typename T,
+             typename F,
+             typename... Args>
+   CHAI_HOST T* make_on_device_from_factory(F f, Args&&... args) {
+#ifndef CHAI_DISABLE_RM
+      // Get the ArrayManager and save the current execution space
+      chai::ArrayManager* arrayManager = chai::ArrayManager::getInstance();
+      ExecutionSpace currentSpace = arrayManager->getExecutionSpace();
+
+      // Set the execution space so that chai::ManagedArrays and
+      // chai::managed_ptrs are handled properly
+      arrayManager->setExecutionSpace(GPU);
+#endif
+
+      // Allocate space on the GPU to hold the pointer to the new object
+      T** gpuBuffer;
+      gpuMalloc((void**)(&gpuBuffer), sizeof(T*));
+
+      // Create the object on the device
+      make_on_device_from_factory<T><<<1, 1>>>(gpuBuffer, f, args...);
+
+#ifndef CHAI_DISABLE_RM
+      if (ArrayManager::getInstance()->deviceSynchronize()) {
+         synchronize();
+      }
+#endif
+
+      // Allocate space on the CPU for the pointer and copy the pointer to the CPU
+      T** cpuBuffer = (T**) malloc(sizeof(T*));
+      gpuMemcpy(cpuBuffer, gpuBuffer, sizeof(T*), gpuMemcpyDeviceToHost);
+
+      // Get the GPU pointer
+      T* gpuPointer = cpuBuffer[0];
+
+      // Free the host and device buffers
+      free(cpuBuffer);
+      gpuFree(gpuBuffer);
+
+#ifndef CHAI_DISABLE_RM
+      // Set the execution space back to the previous value
+      arrayManager->setExecutionSpace(currentSpace);
+#endif
+
+      // Return the GPU pointer
+      return gpuPointer;
+   }
+
+   ///
+   /// @author Alan Dayton
+   ///
+   /// Destroys the device pointer.
+   ///
+   /// @param[out] gpuPointer The device pointer to clean up
+   ///
+   template <typename T>
+   CHAI_HOST void destroy_on_device(T* gpuPointer) {
+      detail::destroy_on_device<<<1, 1>>>(gpuPointer);
+   }
+
+#endif
+
+   ///
+   /// @author Alan Dayton
+   ///
    /// Makes a managed_ptr<T>.
    /// Factory function to create managed_ptrs.
    ///
@@ -1000,11 +1066,11 @@ namespace chai {
    CHAI_HOST managed_ptr<T> make_managed(Args... args) {
 #if defined(CHAI_GPUCC)
       // Construct on the GPU first to take advantage of asynchrony
-      T* gpuPointer = detail::make_on_device<T>(args...);
+      T* gpuPointer = make_on_device<T>(args...);
 #endif
 
       // Construct on the CPU
-      T* cpuPointer = detail::make_on_host<T>(args...);
+      T* cpuPointer = make_on_host<T>(args...);
 
       // Construct and return the managed_ptr
 #if defined(CHAI_GPUCC)
@@ -1040,11 +1106,11 @@ namespace chai {
 
 #if defined(CHAI_GPUCC)
       // Construct on the GPU first to take advantage of asynchrony
-      T* gpuPointer = detail::make_on_device_from_factory<R>(f, args...);
+      T* gpuPointer = make_on_device_from_factory<R>(f, args...);
 #endif
 
       // Construct on the CPU
-      T* cpuPointer = detail::make_on_host_from_factory<R>(f, args...);
+      T* cpuPointer = make_on_host_from_factory<R>(f, args...);
 
       // Construct and return the managed_ptr
 #if defined(CHAI_GPUCC)

--- a/src/chai/managed_ptr.hpp
+++ b/src/chai/managed_ptr.hpp
@@ -954,7 +954,7 @@ namespace chai {
       gpuMalloc((void**)(&gpuBuffer), sizeof(T*));
 
       // Create the object on the device
-      make_on_device<<<1, 1>>>(gpuBuffer, args...);
+      detail::make_on_device<<<1, 1>>>(gpuBuffer, args...);
 
 #ifndef CHAI_DISABLE_RM
       if (ArrayManager::getInstance()->deviceSynchronize()) {
@@ -1011,7 +1011,7 @@ namespace chai {
       gpuMalloc((void**)(&gpuBuffer), sizeof(T*));
 
       // Create the object on the device
-      make_on_device_from_factory<T><<<1, 1>>>(gpuBuffer, f, args...);
+      detail::make_on_device_from_factory<T><<<1, 1>>>(gpuBuffer, f, args...);
 
 #ifndef CHAI_DISABLE_RM
       if (ArrayManager::getInstance()->deviceSynchronize()) {

--- a/tests/integration/managed_ptr_tests.cpp
+++ b/tests/integration/managed_ptr_tests.cpp
@@ -160,7 +160,7 @@ TEST(managed_ptr, class_with_raw_array)
     array[i] = expectedValue;
   });
 
-  auto rawArrayClass = chai::make_managed<RawArrayClass>(array);
+  auto rawArrayClass = chai::make_managed<RawArrayClass>(chai::unpack(array));
 
   ASSERT_EQ(rawArrayClass->getValue(0), expectedValue);
 
@@ -181,7 +181,9 @@ TEST(managed_ptr, class_with_multiple_raw_arrays)
      array2[i] = expectedValue2;
   });
 
-  auto multipleRawArrayClass = chai::make_managed<MultipleRawArrayClass>(array1, array2);
+  auto multipleRawArrayClass = chai::make_managed<MultipleRawArrayClass>(
+                                 chai::unpack(array1),
+                                 chai::unpack(array2));
 
   ASSERT_EQ(multipleRawArrayClass->getValue(0, 0), expectedValue1);
   ASSERT_EQ(multipleRawArrayClass->getValue(1, 0), expectedValue2);
@@ -219,8 +221,9 @@ TEST(managed_ptr, class_with_raw_ptr)
      array[i] = expectedValue;
   });
 
-  auto rawArrayClass = chai::make_managed<RawArrayClass>(array);
-  auto rawPointerClass = chai::make_managed<RawPointerClass>(rawArrayClass);
+  auto rawArrayClass = chai::make_managed<RawArrayClass>(chai::unpack(array));
+  auto rawPointerClass = chai::make_managed<RawPointerClass>(
+                           chai::unpack(rawArrayClass));
 
   ASSERT_EQ((*rawPointerClass).getValue(0), expectedValue);
 
@@ -452,7 +455,7 @@ GPU_TEST(managed_ptr, gpu_class_with_raw_array)
      array[i] = expectedValue;
   });
 
-  auto rawArrayClass = chai::make_managed<RawArrayClass>(array);
+  auto rawArrayClass = chai::make_managed<RawArrayClass>(chai::unpack(array));
   chai::ManagedArray<int> results(1, chai::GPU);
 
   forall(gpu(), 0, 1, [=] __device__ (int i) {
@@ -482,7 +485,7 @@ GPU_TEST(managed_ptr, gpu_class_with_raw_array_and_callback)
 #else
   auto cpuPointer = new RawArrayClass(array.data());
 #endif
-  auto gpuPointer = chai::detail::make_on_device<RawArrayClass>(array);
+  auto gpuPointer = chai::make_on_device<RawArrayClass>(chai::unpack(array));
 
   auto callback = [=] (chai::Action action, chai::ExecutionSpace space, void*) mutable -> bool {
      switch (action) {
@@ -553,8 +556,9 @@ GPU_TEST(managed_ptr, gpu_class_with_raw_ptr)
      array[0] = expectedValue;
   });
 
-  auto rawArrayClass = chai::make_managed<RawArrayClass>(array);
-  auto rawPointerClass = chai::make_managed<RawPointerClass>(rawArrayClass);
+  auto rawArrayClass = chai::make_managed<RawArrayClass>(chai::unpack(array));
+  auto rawPointerClass = chai::make_managed<RawPointerClass>(
+                           chai::unpack(rawArrayClass));
 
   chai::ManagedArray<int> results(1, chai::GPU);
 
@@ -793,7 +797,7 @@ TEST(managed_ptr, class_with_raw_array_of_pointers)
   chai::ManagedArray<int> array(1, chai::CPU);
   array[0] = expectedValue;
 
-  auto rawArrayClass = chai::make_managed<RawArrayClass>(array);
+  auto rawArrayClass = chai::make_managed<RawArrayClass>(chai::unpack(array));
   chai::managed_ptr<RawArrayClass> arrayOfPointers[1] = {rawArrayClass};
 
   auto rawArrayOfPointersClass = chai::make_managed<RawArrayOfPointersClass>(arrayOfPointers);

--- a/tests/unit/managed_ptr_unit_tests.cpp
+++ b/tests/unit/managed_ptr_unit_tests.cpp
@@ -552,7 +552,7 @@ GPU_TEST(managed_ptr, gpu_nullptr_constructor)
 
 GPU_TEST(managed_ptr, gpu_gpu_pointer_constructor)
 {
-  TestDerived* gpuPointer = chai::detail::make_on_device<TestDerived>(3);
+  TestDerived* gpuPointer = chai::make_on_device<TestDerived>(3);
   chai::managed_ptr<TestDerived> derived({chai::GPU}, {gpuPointer});
 
   EXPECT_EQ(derived.get(), nullptr);
@@ -656,7 +656,7 @@ GPU_TEST(managed_ptr, gpu_new_and_delete_on_device_2)
 
 GPU_TEST(managed_ptr, simple_gpu_cpu_and_gpu_pointer_constructor)
 {
-  Simple* gpuPointer = chai::detail::make_on_device<Simple>(3);
+  Simple* gpuPointer = chai::make_on_device<Simple>(3);
   Simple* cpuPointer = new Simple(4);
 
   chai::managed_ptr<Simple> simple({chai::GPU, chai::CPU}, {gpuPointer, cpuPointer});
@@ -680,7 +680,7 @@ GPU_TEST(managed_ptr, simple_gpu_cpu_and_gpu_pointer_constructor)
 
 GPU_TEST(managed_ptr, gpu_cpu_and_gpu_pointer_constructor)
 {
-  TestDerived* gpuPointer = chai::detail::make_on_device<TestDerived>(3);
+  TestDerived* gpuPointer = chai::make_on_device<TestDerived>(3);
   TestDerived* cpuPointer = new TestDerived(4);
 
   chai::managed_ptr<TestDerived> derived({chai::GPU, chai::CPU}, {gpuPointer, cpuPointer});


### PR DESCRIPTION
Adds chai::unpack so that the user can specify when they want a ManagedArray or a managed_ptr to be unpacked when calling chai::make_managed. If chai::unpack is used, the host pointer will be extracted and passed to the host constructor of the object and the device pointer will be extracted and passed to the device constructor of the object. The current behavior of automatically detecting when to do this falls down in the case where some ManagedArrays/managed_ptrs should be unpacked and others should not be, particularly when implicit conversions are disabled.