### PR TITLE
Add support for GPU simulation mode in the RAJA plugin

### DIFF
--- a/src/chai/ArrayManager.cpp
+++ b/src/chai/ArrayManager.cpp
@@ -158,6 +158,12 @@ void * ArrayManager::frontOfAllocation(void * pointer) {
 
 void ArrayManager::setExecutionSpace(ExecutionSpace space)
 {
+#if defined(CHAI_ENABLE_GPU_SIMULATION_MODE)
+   if (isGPUSimMode()) {
+      space = chai::GPU;
+   }
+#endif
+
   CHAI_LOG(Debug, "Setting execution space to " << space);
 
   if (chai::GPU == space) {

--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -425,7 +425,7 @@ public:
   /*!
    * \brief Return true if GPU simulation mode is on, false otherwise.
    */
-  bool getGPUSimMode() { return m_gpu_sim_mode; }
+  bool isGPUSimMode() { return m_gpu_sim_mode; }
 #endif
 
   /*!

--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -416,6 +416,18 @@ public:
    */
   bool syncIfNeeded();
 
+#if defined(CHAI_ENABLE_GPU_SIMULATION_MODE)
+  /*!
+   * \brief Turn the GPU simulation mode on or off.
+   */
+  void setGPUSimMode(bool gpuSimMode) { m_gpu_sim_mode = gpuSimMode; }
+
+  /*!
+   * \brief Return true if GPU simulation mode is on, false otherwise.
+   */
+  bool getGPUSimMode() { return m_gpu_sim_mode; }
+#endif
+
   /*!
    * \brief Evicts the data in the given space.
    *
@@ -523,6 +535,14 @@ private:
    * GPU context
    */
   bool m_synced_since_last_kernel = false;
+
+#if defined(CHAI_ENABLE_GPU_SIMULATION_MODE)
+  /*!
+   * Used by the RAJA plugin to determine whether the execution space should be
+   * CPU or GPU.
+   */
+  bool m_gpu_sim_mode = false;
+#endif
 };
 
 }  // end of namespace chai

--- a/src/chai/RajaExecutionSpacePlugin.cpp
+++ b/src/chai/RajaExecutionSpacePlugin.cpp
@@ -12,14 +12,17 @@
 
 namespace chai {
 
-RajaExecutionSpacePlugin::RajaExecutionSpacePlugin() :
-  m_arraymanager(chai::ArrayManager::getInstance())
+RajaExecutionSpacePlugin::RajaExecutionSpacePlugin()
 {
 }
 
 void
 RajaExecutionSpacePlugin::preCapture(const RAJA::util::PluginContext& p)
 {
+  if (!m_arraymanager) {
+    m_arraymanager = chai::ArrayManager::getInstance();
+  }
+
   switch (p.platform) {
     case RAJA::Platform::host:
       m_arraymanager->setExecutionSpace(chai::CPU); break;

--- a/src/chai/RajaExecutionSpacePlugin.cpp
+++ b/src/chai/RajaExecutionSpacePlugin.cpp
@@ -12,38 +12,23 @@
 
 namespace chai {
 
-RajaExecutionSpacePlugin::RajaExecutionSpacePlugin()
+RajaExecutionSpacePlugin::RajaExecutionSpacePlugin() :
+  m_arraymanager(chai::ArrayManager::getInstance())
 {
 }
 
 void
 RajaExecutionSpacePlugin::preCapture(const RAJA::util::PluginContext& p)
 {
-  if (!m_arraymanager) {
-    m_arraymanager = chai::ArrayManager::getInstance();
-  }
-
   switch (p.platform) {
     case RAJA::Platform::host:
-#if defined(CHAI_ENABLE_GPU_SIMULATION_MODE)
-      if (m_arraymanager->isGPUSimMode()) {
-         m_arraymanager->setExecutionSpace(chai::GPU);
-      }
-      else {
-         m_arraymanager->setExecutionSpace(chai::CPU);
-      }
-#else
-      m_arraymanager->setExecutionSpace(chai::CPU);
-#endif
-      break;
+      m_arraymanager->setExecutionSpace(chai::CPU); break;
 #if defined(CHAI_ENABLE_CUDA)
     case RAJA::Platform::cuda:
-      m_arraymanager->setExecutionSpace(chai::GPU);
-      break;
+      m_arraymanager->setExecutionSpace(chai::GPU); break;
 #endif
     default:
       m_arraymanager->setExecutionSpace(chai::NONE);
-      break;
   }
 }
 

--- a/src/chai/RajaExecutionSpacePlugin.cpp
+++ b/src/chai/RajaExecutionSpacePlugin.cpp
@@ -23,7 +23,7 @@ RajaExecutionSpacePlugin::preCapture(const RAJA::util::PluginContext& p)
   switch (p.platform) {
     case RAJA::Platform::host:
 #if defined(CHAI_ENABLE_GPU_SIMULATION_MODE)
-      if (m_arraymanager->getGPUSimMode()) {
+      if (m_arraymanager->isGPUSimMode()) {
          m_arraymanager->setExecutionSpace(chai::GPU);
       }
       else {

--- a/src/chai/RajaExecutionSpacePlugin.cpp
+++ b/src/chai/RajaExecutionSpacePlugin.cpp
@@ -22,13 +22,25 @@ RajaExecutionSpacePlugin::preCapture(const RAJA::util::PluginContext& p)
 {
   switch (p.platform) {
     case RAJA::Platform::host:
-      m_arraymanager->setExecutionSpace(chai::CPU); break;
+#if defined(CHAI_ENABLE_GPU_SIMULATION_MODE)
+      if (m_arraymanager->getGPUSimMode()) {
+         m_arraymanager->setExecutionSpace(chai::GPU);
+      }
+      else {
+         m_arraymanager->setExecutionSpace(chai::CPU);
+      }
+#else
+      m_arraymanager->setExecutionSpace(chai::CPU);
+#endif
+      break;
 #if defined(CHAI_ENABLE_CUDA)
     case RAJA::Platform::cuda:
-      m_arraymanager->setExecutionSpace(chai::GPU); break;
+      m_arraymanager->setExecutionSpace(chai::GPU);
+      break;
 #endif
     default:
       m_arraymanager->setExecutionSpace(chai::NONE);
+      break;
   }
 }
 


### PR DESCRIPTION
Since RAJA currently does not have any notion of a GPU simulation mode, the "GPU kernels" will always run on the host and that is the platform that will be passed to the RAJA plugin. This pull request provides the capability for telling CHAI when GPU simulation mode is on or off. When it is off and the CAMP platform is "host", the execution space is set to chai::CPU. However, when it is on and the CAMP platform is "host", the execution space is set to chai::GPU. This works because the chai::GPU space is actually backed with host memory when configured with -DENABLE_GPU_SIMULATION_MODE=ON.