### PR TITLE
CHAI_LOG only active with CHAI_DEBUG regardless of RM being enabled

### DIFF
--- a/src/chai/ChaiMacros.hpp
+++ b/src/chai/ChaiMacros.hpp
@@ -70,23 +70,21 @@
 
 #define CHAI_UNUSED_ARG(X)
 
+#if defined(CHAI_DEBUG)
 #if !defined(CHAI_DISABLE_RM)
 
 #define CHAI_LOG(level, msg) \
   UMPIRE_LOG(level, msg);
-
 #else
-
-#if defined(CHAI_DEBUG)
 
 #define CHAI_LOG(level, msg) \
   std::cerr << "[" << __FILE__ << "] " << msg << std::endl;
 
+#endif // !CHAI_DISABLE_RM
 #else
 
 #define CHAI_LOG(level, msg)
 
-#endif
-#endif
+#endif // CHAI_DEBUG
 
 #endif  // CHAI_ChaiMacros_HPP


### PR DESCRIPTION
Not sure if this was intentional or not, but CHAI_LOG has been incurring overhead for non debug builds. This has shown up in some of CARE's stress testing kernel launch overhead (can double the cost of a kernel capture and launch). This PR changes CHAI_LOG to only do something when CHAI_DEBUG is defined. 