### PR TITLE
make tests and benchmarks workable for both cuda and hip

### DIFF
--- a/benchmarks/chai_managed_ptr_benchmarks.cpp
+++ b/benchmarks/chai_managed_ptr_benchmarks.cpp
@@ -9,6 +9,7 @@
 #include "benchmark/benchmark.h"
 
 #include "chai/config.hpp"
+#include "chai/ArrayManager.hpp"
 #include "chai/managed_ptr.hpp"
 
 #include "../src/util/forall.hpp"
@@ -135,7 +136,7 @@ static void benchmark_use_managed_ptr_cpu(benchmark::State& state)
   }
 
 #ifdef CHAI_GPUCC
-  gpuDeviceSynchronize();
+  chai::synchronize();
 #endif
 
   while (state.KeepRunning()) {
@@ -146,7 +147,7 @@ static void benchmark_use_managed_ptr_cpu(benchmark::State& state)
   object.free();
 
 #ifdef CHAI_GPUCC
-  gpuDeviceSynchronize();
+  chai::synchronize();
 #endif
 }
 
@@ -209,7 +210,7 @@ static void benchmark_pass_copy_to_gpu(benchmark::State& state)
 
   while (state.KeepRunning()) {
     copy_kernel<<<1, 1>>>(helper);
-    gpuDeviceSynchronize();
+    chai::synchronize();
   }
 }
 
@@ -225,10 +226,10 @@ static void benchmark_copy_to_gpu(benchmark::State& state)
 
   while (state.KeepRunning()) {
     ClassWithSize<N>* gpuPointer;
-    gpuMalloc(&gpuPointer, sizeof(ClassWithSize<N>));
-    gpuMemcpy(gpuPointer, cpuPointer, sizeof(ClassWithSize<N>), gpuMemcpyHostToDevice);
-    gpuFree(gpuPointer);
-    gpuDeviceSynchronize();
+    chai::gpuMalloc((void**)(&gpuPointer), sizeof(ClassWithSize<N>));
+    chai::gpuMemcpy(gpuPointer, cpuPointer, sizeof(ClassWithSize<N>), gpuMemcpyHostToDevice);
+    chai::gpuFree(gpuPointer);
+    chai::synchronize();
   }
 
   delete cpuPointer;
@@ -258,11 +259,11 @@ static void benchmark_placement_new_on_gpu(benchmark::State& state)
 {
   while (state.KeepRunning()) {
     ClassWithSize<N>* address;
-    gpuMalloc(&address, sizeof(ClassWithSize<N>));
+    chai::gpuMalloc((void**)(&address), sizeof(ClassWithSize<N>));
     placement_new_kernel<<<1, 1>>>(address);
     placement_delete_kernel<<<1, 1>>>(address);
-    gpuFree(address);
-    gpuDeviceSynchronize();
+    chai::gpuFree(address);
+    chai::synchronize();
   }
 }
 
@@ -290,11 +291,11 @@ static void benchmark_new_on_gpu(benchmark::State& state)
 {
   while (state.KeepRunning()) {
     ClassWithSize<N>** buffer;
-    gpuMalloc(&buffer, sizeof(ClassWithSize<N>*));
+    chai::gpuMalloc((void**)(&buffer), sizeof(ClassWithSize<N>*));
     create_kernel<<<1, 1>>>(buffer);
     delete_kernel<<<1, 1>>>(buffer);
-    gpuFree(buffer);
-    gpuDeviceSynchronize();
+    chai::gpuFree(buffer);
+    chai::synchronize();
   }
 }
 
@@ -317,15 +318,15 @@ static void benchmark_new_on_gpu_and_copy_to_host(benchmark::State& state)
 {
   while (state.KeepRunning()) {
     ClassWithSize<N>** gpuBuffer;
-    gpuMalloc(&gpuBuffer, sizeof(ClassWithSize<N>*));
+    chai::gpuMalloc((void**)(&gpuBuffer), sizeof(ClassWithSize<N>*));
     create_kernel<<<1, 1>>>(gpuBuffer);
     ClassWithSize<N>** cpuBuffer = (ClassWithSize<N>**) malloc(sizeof(ClassWithSize<N>*));
-    gpuMemcpy(cpuBuffer, gpuBuffer, sizeof(ClassWithSize<N>*), gpuMemcpyDeviceToHost);
-    gpuFree(gpuBuffer);
+    chai::gpuMemcpy(cpuBuffer, gpuBuffer, sizeof(ClassWithSize<N>*), gpuMemcpyDeviceToHost);
+    chai::gpuFree(gpuBuffer);
     ClassWithSize<N>* gpuPointer = cpuBuffer[0];
     free(cpuBuffer);
     delete_kernel_2<<<1, 1>>>(gpuPointer);
-    gpuDeviceSynchronize();
+    chai::synchronize();
   }
 }
 
@@ -348,7 +349,7 @@ static void benchmark_create_on_stack_on_gpu(benchmark::State& state)
 {
   while (state.KeepRunning()) {
     create_on_stack_kernel<N><<<1, 1>>>();
-    gpuDeviceSynchronize();
+    chai::synchronize();
   }
 }
 
@@ -379,19 +380,19 @@ void benchmark_use_managed_ptr_gpu(benchmark::State& state)
 
   int numValues = 100;
   int* values;
-  gpuMalloc(&values, numValues * sizeof(int));
+  chai::gpuMalloc((void**)(&values), numValues * sizeof(int));
   fill<<<1, 100>>>(numValues, values);
 
-  gpuDeviceSynchronize();
+  chai::synchronize();
 
   while (state.KeepRunning()) {
     square<<<1, 1>>>(object, numValues, values);
-    gpuDeviceSynchronize();
+    chai::synchronize();
   }
 
-  gpuFree(values);
+  chai::gpuFree(values);
   object.free();
-  gpuDeviceSynchronize();
+  chai::synchronize();
 }
 
 BENCHMARK(benchmark_use_managed_ptr_gpu);
@@ -409,19 +410,19 @@ void benchmark_curiously_recurring_template_pattern_gpu(benchmark::State& state)
 
   int numValues = 100;
   int* values;
-  gpuMalloc(&values, numValues * sizeof(int));
+  chai::gpuMalloc((void**)(&values), numValues * sizeof(int));
   fill<<<1, 100>>>(numValues, values);
 
-  gpuDeviceSynchronize();
+  chai::synchronize();
 
   while (state.KeepRunning()) {
     square<<<1, 1>>>(object, numValues, values);
-    gpuDeviceSynchronize();
+    chai::synchronize();
   }
 
-  gpuFree(values);
+  chai::gpuFree(values);
   delete derivedCRTP;
-  gpuDeviceSynchronize();
+  chai::synchronize();
 }
 
 BENCHMARK(benchmark_curiously_recurring_template_pattern_gpu);
@@ -438,19 +439,19 @@ void benchmark_no_inheritance_gpu(benchmark::State& state)
 
   int numValues = 100;
   int* values;
-  gpuMalloc(&values, numValues * sizeof(int));
+  chai::gpuMalloc((void**)(&values), numValues * sizeof(int));
   fill<<<1, 100>>>(numValues, values);
 
-  gpuDeviceSynchronize();
+  chai::synchronize();
 
   while (state.KeepRunning()) {
     square<<<1, 1>>>(object, numValues, values);
-    gpuDeviceSynchronize();
+    chai::synchronize();
   }
 
-  gpuFree(values);
+  chai::gpuFree(values);
   delete noInheritance;
-  gpuDeviceSynchronize();
+  chai::synchronize();
 }
 
 BENCHMARK(benchmark_no_inheritance_gpu);
@@ -471,19 +472,19 @@ void benchmark_bulk_use_managed_ptr_gpu(benchmark::State& state)
   chai::managed_ptr<Base> object = chai::make_managed<Derived>(2);
 
   int* values;
-  gpuMalloc(&values, N * sizeof(int));
+  chai::gpuMalloc((void**)(&values), N * sizeof(int));
   fill<<<(N+255)/256, 256>>>(N, values);
 
-  gpuDeviceSynchronize();
+  chai::synchronize();
 
   while (state.KeepRunning()) {
     square<<<(N+255)/256, 256>>>(N, values, object);
-    gpuDeviceSynchronize();
+    chai::synchronize();
   }
 
-  gpuFree(values);
+  chai::gpuFree(values);
   object.free();
-  gpuDeviceSynchronize();
+  chai::synchronize();
 }
 
 BENCHMARK_TEMPLATE(benchmark_bulk_use_managed_ptr_gpu, 1);
@@ -519,19 +520,19 @@ void benchmark_bulk_curiously_recurring_template_pattern_gpu(benchmark::State& s
   auto object = *derivedCRTP;
 
   int* values;
-  gpuMalloc(&values, N * sizeof(int));
+  chai::gpuMalloc((void**)(&values), N * sizeof(int));
   fill<<<(N+255)/256, 256>>>(N, values);
 
-  gpuDeviceSynchronize();
+  chai::synchronize();
 
   while (state.KeepRunning()) {
     square<<<(N+255)/256, 256>>>(N, values, object);
-    gpuDeviceSynchronize();
+    chai::synchronize();
   }
 
-  gpuFree(values);
+  chai::gpuFree(values);
   delete derivedCRTP;
-  gpuDeviceSynchronize();
+  chai::synchronize();
 }
 
 BENCHMARK_TEMPLATE(benchmark_bulk_curiously_recurring_template_pattern_gpu, 1);
@@ -567,19 +568,19 @@ void benchmark_bulk_no_inheritance_gpu(benchmark::State& state)
   auto object = *noInheritance;
 
   int* values;
-  gpuMalloc(&values, N * sizeof(int));
+  chai::gpuMalloc((void**)(&values), N * sizeof(int));
   fill<<<(N+255)/256, 256>>>(N, values);
 
-  gpuDeviceSynchronize();
+  chai::synchronize();
 
   while (state.KeepRunning()) {
     square<<<(N+255)/256, 256>>>(N, values, object);
-    gpuDeviceSynchronize();
+    chai::synchronize();
   }
 
-  gpuFree(values);
+  chai::gpuFree(values);
   delete noInheritance;
-  gpuDeviceSynchronize();
+  chai::synchronize();
 }
 
 BENCHMARK_TEMPLATE(benchmark_bulk_no_inheritance_gpu, 1);
@@ -613,7 +614,7 @@ static void benchmark_bulk_polymorphism_cpu(benchmark::State& state)
   }
 
 #ifdef CHAI_GPUCC
-  gpuDeviceSynchronize();
+  chai::synchronize();
 #endif
 
   while (state.KeepRunning()) {
@@ -627,7 +628,7 @@ static void benchmark_bulk_polymorphism_cpu(benchmark::State& state)
   delete object;
 
 #ifdef CHAI_GPUCC
-  gpuDeviceSynchronize();
+  chai::synchronize();
 #endif
 }
 
@@ -660,7 +661,7 @@ static void benchmark_bulk_use_managed_ptr_cpu(benchmark::State& state)
   }
 
 #ifdef CHAI_GPUCC
-  gpuDeviceSynchronize();
+  chai::synchronize();
 #endif
 
   while (state.KeepRunning()) {
@@ -674,7 +675,7 @@ static void benchmark_bulk_use_managed_ptr_cpu(benchmark::State& state)
   object.free();
 
 #ifdef CHAI_GPUCC
-  gpuDeviceSynchronize();
+  chai::synchronize();
 #endif
 }
 

--- a/benchmarks/chai_managed_ptr_benchmarks.cpp
+++ b/benchmarks/chai_managed_ptr_benchmarks.cpp
@@ -134,8 +134,8 @@ static void benchmark_use_managed_ptr_cpu(benchmark::State& state)
      values[i] = i * i;
   }
 
-#ifdef __CUDACC__
-  cudaDeviceSynchronize();
+#ifdef CHAI_GPUCC
+  gpuDeviceSynchronize();
 #endif
 
   while (state.KeepRunning()) {
@@ -145,8 +145,8 @@ static void benchmark_use_managed_ptr_cpu(benchmark::State& state)
   free(values);
   object.free();
 
-#ifdef __CUDACC__
-  cudaDeviceSynchronize();
+#ifdef CHAI_GPUCC
+  gpuDeviceSynchronize();
 #endif
 }
 
@@ -209,7 +209,7 @@ static void benchmark_pass_copy_to_gpu(benchmark::State& state)
 
   while (state.KeepRunning()) {
     copy_kernel<<<1, 1>>>(helper);
-    cudaDeviceSynchronize();
+    gpuDeviceSynchronize();
   }
 }
 
@@ -225,10 +225,10 @@ static void benchmark_copy_to_gpu(benchmark::State& state)
 
   while (state.KeepRunning()) {
     ClassWithSize<N>* gpuPointer;
-    cudaMalloc(&gpuPointer, sizeof(ClassWithSize<N>));
-    cudaMemcpy(gpuPointer, cpuPointer, sizeof(ClassWithSize<N>), cudaMemcpyHostToDevice);
-    cudaFree(gpuPointer);
-    cudaDeviceSynchronize();
+    gpuMalloc(&gpuPointer, sizeof(ClassWithSize<N>));
+    gpuMemcpy(gpuPointer, cpuPointer, sizeof(ClassWithSize<N>), gpuMemcpyHostToDevice);
+    gpuFree(gpuPointer);
+    gpuDeviceSynchronize();
   }
 
   delete cpuPointer;
@@ -258,11 +258,11 @@ static void benchmark_placement_new_on_gpu(benchmark::State& state)
 {
   while (state.KeepRunning()) {
     ClassWithSize<N>* address;
-    cudaMalloc(&address, sizeof(ClassWithSize<N>));
+    gpuMalloc(&address, sizeof(ClassWithSize<N>));
     placement_new_kernel<<<1, 1>>>(address);
     placement_delete_kernel<<<1, 1>>>(address);
-    cudaFree(address);
-    cudaDeviceSynchronize();
+    gpuFree(address);
+    gpuDeviceSynchronize();
   }
 }
 
@@ -290,11 +290,11 @@ static void benchmark_new_on_gpu(benchmark::State& state)
 {
   while (state.KeepRunning()) {
     ClassWithSize<N>** buffer;
-    cudaMalloc(&buffer, sizeof(ClassWithSize<N>*));
+    gpuMalloc(&buffer, sizeof(ClassWithSize<N>*));
     create_kernel<<<1, 1>>>(buffer);
     delete_kernel<<<1, 1>>>(buffer);
-    cudaFree(buffer);
-    cudaDeviceSynchronize();
+    gpuFree(buffer);
+    gpuDeviceSynchronize();
   }
 }
 
@@ -317,15 +317,15 @@ static void benchmark_new_on_gpu_and_copy_to_host(benchmark::State& state)
 {
   while (state.KeepRunning()) {
     ClassWithSize<N>** gpuBuffer;
-    cudaMalloc(&gpuBuffer, sizeof(ClassWithSize<N>*));
+    gpuMalloc(&gpuBuffer, sizeof(ClassWithSize<N>*));
     create_kernel<<<1, 1>>>(gpuBuffer);
     ClassWithSize<N>** cpuBuffer = (ClassWithSize<N>**) malloc(sizeof(ClassWithSize<N>*));
-    cudaMemcpy(cpuBuffer, gpuBuffer, sizeof(ClassWithSize<N>*), cudaMemcpyDeviceToHost);
-    cudaFree(gpuBuffer);
+    gpuMemcpy(cpuBuffer, gpuBuffer, sizeof(ClassWithSize<N>*), gpuMemcpyDeviceToHost);
+    gpuFree(gpuBuffer);
     ClassWithSize<N>* gpuPointer = cpuBuffer[0];
     free(cpuBuffer);
     delete_kernel_2<<<1, 1>>>(gpuPointer);
-    cudaDeviceSynchronize();
+    gpuDeviceSynchronize();
   }
 }
 
@@ -348,7 +348,7 @@ static void benchmark_create_on_stack_on_gpu(benchmark::State& state)
 {
   while (state.KeepRunning()) {
     create_on_stack_kernel<N><<<1, 1>>>();
-    cudaDeviceSynchronize();
+    gpuDeviceSynchronize();
   }
 }
 
@@ -379,19 +379,19 @@ void benchmark_use_managed_ptr_gpu(benchmark::State& state)
 
   int numValues = 100;
   int* values;
-  cudaMalloc(&values, numValues * sizeof(int));
+  gpuMalloc(&values, numValues * sizeof(int));
   fill<<<1, 100>>>(numValues, values);
 
-  cudaDeviceSynchronize();
+  gpuDeviceSynchronize();
 
   while (state.KeepRunning()) {
     square<<<1, 1>>>(object, numValues, values);
-    cudaDeviceSynchronize();
+    gpuDeviceSynchronize();
   }
 
-  cudaFree(values);
+  gpuFree(values);
   object.free();
-  cudaDeviceSynchronize();
+  gpuDeviceSynchronize();
 }
 
 BENCHMARK(benchmark_use_managed_ptr_gpu);
@@ -409,19 +409,19 @@ void benchmark_curiously_recurring_template_pattern_gpu(benchmark::State& state)
 
   int numValues = 100;
   int* values;
-  cudaMalloc(&values, numValues * sizeof(int));
+  gpuMalloc(&values, numValues * sizeof(int));
   fill<<<1, 100>>>(numValues, values);
 
-  cudaDeviceSynchronize();
+  gpuDeviceSynchronize();
 
   while (state.KeepRunning()) {
     square<<<1, 1>>>(object, numValues, values);
-    cudaDeviceSynchronize();
+    gpuDeviceSynchronize();
   }
 
-  cudaFree(values);
+  gpuFree(values);
   delete derivedCRTP;
-  cudaDeviceSynchronize();
+  gpuDeviceSynchronize();
 }
 
 BENCHMARK(benchmark_curiously_recurring_template_pattern_gpu);
@@ -438,19 +438,19 @@ void benchmark_no_inheritance_gpu(benchmark::State& state)
 
   int numValues = 100;
   int* values;
-  cudaMalloc(&values, numValues * sizeof(int));
+  gpuMalloc(&values, numValues * sizeof(int));
   fill<<<1, 100>>>(numValues, values);
 
-  cudaDeviceSynchronize();
+  gpuDeviceSynchronize();
 
   while (state.KeepRunning()) {
     square<<<1, 1>>>(object, numValues, values);
-    cudaDeviceSynchronize();
+    gpuDeviceSynchronize();
   }
 
-  cudaFree(values);
+  gpuFree(values);
   delete noInheritance;
-  cudaDeviceSynchronize();
+  gpuDeviceSynchronize();
 }
 
 BENCHMARK(benchmark_no_inheritance_gpu);
@@ -471,19 +471,19 @@ void benchmark_bulk_use_managed_ptr_gpu(benchmark::State& state)
   chai::managed_ptr<Base> object = chai::make_managed<Derived>(2);
 
   int* values;
-  cudaMalloc(&values, N * sizeof(int));
+  gpuMalloc(&values, N * sizeof(int));
   fill<<<(N+255)/256, 256>>>(N, values);
 
-  cudaDeviceSynchronize();
+  gpuDeviceSynchronize();
 
   while (state.KeepRunning()) {
     square<<<(N+255)/256, 256>>>(N, values, object);
-    cudaDeviceSynchronize();
+    gpuDeviceSynchronize();
   }
 
-  cudaFree(values);
+  gpuFree(values);
   object.free();
-  cudaDeviceSynchronize();
+  gpuDeviceSynchronize();
 }
 
 BENCHMARK_TEMPLATE(benchmark_bulk_use_managed_ptr_gpu, 1);
@@ -519,19 +519,19 @@ void benchmark_bulk_curiously_recurring_template_pattern_gpu(benchmark::State& s
   auto object = *derivedCRTP;
 
   int* values;
-  cudaMalloc(&values, N * sizeof(int));
+  gpuMalloc(&values, N * sizeof(int));
   fill<<<(N+255)/256, 256>>>(N, values);
 
-  cudaDeviceSynchronize();
+  gpuDeviceSynchronize();
 
   while (state.KeepRunning()) {
     square<<<(N+255)/256, 256>>>(N, values, object);
-    cudaDeviceSynchronize();
+    gpuDeviceSynchronize();
   }
 
-  cudaFree(values);
+  gpuFree(values);
   delete derivedCRTP;
-  cudaDeviceSynchronize();
+  gpuDeviceSynchronize();
 }
 
 BENCHMARK_TEMPLATE(benchmark_bulk_curiously_recurring_template_pattern_gpu, 1);
@@ -567,19 +567,19 @@ void benchmark_bulk_no_inheritance_gpu(benchmark::State& state)
   auto object = *noInheritance;
 
   int* values;
-  cudaMalloc(&values, N * sizeof(int));
+  gpuMalloc(&values, N * sizeof(int));
   fill<<<(N+255)/256, 256>>>(N, values);
 
-  cudaDeviceSynchronize();
+  gpuDeviceSynchronize();
 
   while (state.KeepRunning()) {
     square<<<(N+255)/256, 256>>>(N, values, object);
-    cudaDeviceSynchronize();
+    gpuDeviceSynchronize();
   }
 
-  cudaFree(values);
+  gpuFree(values);
   delete noInheritance;
-  cudaDeviceSynchronize();
+  gpuDeviceSynchronize();
 }
 
 BENCHMARK_TEMPLATE(benchmark_bulk_no_inheritance_gpu, 1);
@@ -612,8 +612,8 @@ static void benchmark_bulk_polymorphism_cpu(benchmark::State& state)
      values[i] = i * i;
   }
 
-#ifdef __CUDACC__
-  cudaDeviceSynchronize();
+#ifdef CHAI_GPUCC
+  gpuDeviceSynchronize();
 #endif
 
   while (state.KeepRunning()) {
@@ -626,8 +626,8 @@ static void benchmark_bulk_polymorphism_cpu(benchmark::State& state)
   free(values);
   delete object;
 
-#ifdef __CUDACC__
-  cudaDeviceSynchronize();
+#ifdef CHAI_GPUCC
+  gpuDeviceSynchronize();
 #endif
 }
 
@@ -659,8 +659,8 @@ static void benchmark_bulk_use_managed_ptr_cpu(benchmark::State& state)
      values[i] = i * i;
   }
 
-#ifdef __CUDACC__
-  cudaDeviceSynchronize();
+#ifdef CHAI_GPUCC
+  gpuDeviceSynchronize();
 #endif
 
   while (state.KeepRunning()) {
@@ -673,8 +673,8 @@ static void benchmark_bulk_use_managed_ptr_cpu(benchmark::State& state)
   free(values);
   object.free();
 
-#ifdef __CUDACC__
-  cudaDeviceSynchronize();
+#ifdef CHAI_GPUCC
+  gpuDeviceSynchronize();
 #endif
 }
 

--- a/tests/integration/managed_ptr_tests.cpp
+++ b/tests/integration/managed_ptr_tests.cpp
@@ -326,7 +326,7 @@ TEST(managed_ptr, managed_array_of_managed_ptr)
   delete[] expectedValues;
 }
 
-#ifdef __CUDACC__
+#ifdef CHAI_GPUCC
 
 template <typename T>
 __global__ void deviceNew(T** arr) {
@@ -348,21 +348,21 @@ GPU_TEST(managed_ptr, make_on_device)
   hostArray[0] = nullptr;
 
   int** deviceArray = nullptr;
-  cudaMalloc(&deviceArray, sizeof(int*));
+  gpuMalloc(&deviceArray, sizeof(int*));
 
   int** deviceArray2 = nullptr;
-  cudaMalloc(&deviceArray2, sizeof(int*));
+  gpuMalloc(&deviceArray2, sizeof(int*));
 
   deviceNew<<<1, 1>>>(deviceArray);
 
-  cudaMemcpy(hostArray, deviceArray, sizeof(int*), cudaMemcpyDeviceToHost);
-  cudaMemcpy(deviceArray2, hostArray, sizeof(int*), cudaMemcpyHostToDevice);
+  gpuMemcpy(hostArray, deviceArray, sizeof(int*), gpuMemcpyDeviceToHost);
+  gpuMemcpy(deviceArray2, hostArray, sizeof(int*), gpuMemcpyHostToDevice);
   ASSERT_NE(hostArray[0], nullptr);
 
   deviceDelete<<<1, 1>>>(deviceArray2);
   free(hostArray);
-  cudaFree(deviceArray);
-  cudaFree(deviceArray2);
+  gpuFree(deviceArray);
+  gpuFree(deviceArray2);
 }
 
 GPU_TEST(managed_ptr, gpu_new_and_delete_on_device)
@@ -373,16 +373,16 @@ GPU_TEST(managed_ptr, gpu_new_and_delete_on_device)
 
   // Initialize device side memory to hold a pointer
   RawArrayClass** gpuPointerHolder = nullptr;
-  cudaMalloc(&gpuPointerHolder, sizeof(RawArrayClass*));
+  gpuMalloc(&gpuPointerHolder, sizeof(RawArrayClass*));
 
   // Create on the device
   chai::detail::make_on_device<<<1, 1>>>(gpuPointerHolder);
 
   // Copy to the host side memory
-  cudaMemcpy(cpuPointerHolder, gpuPointerHolder, sizeof(RawArrayClass*), cudaMemcpyDeviceToHost);
+  gpuMemcpy(cpuPointerHolder, gpuPointerHolder, sizeof(RawArrayClass*), gpuMemcpyDeviceToHost);
 
   // Free device side memory
-  cudaFree(gpuPointerHolder);
+  gpuFree(gpuPointerHolder);
 
   // Save the pointer
   ASSERT_NE(cpuPointerHolder[0], nullptr);
@@ -402,16 +402,16 @@ GPU_TEST(managed_ptr, gpu_build_managed_ptr)
 
   // Initialize device side memory to hold a pointer
   RawArrayClass** gpuPointerHolder = nullptr;
-  cudaMalloc(&gpuPointerHolder, sizeof(RawArrayClass*));
+  gpuMalloc(&gpuPointerHolder, sizeof(RawArrayClass*));
 
   // Create on the device
   chai::detail::make_on_device<<<1, 1>>>(gpuPointerHolder);
 
   // Copy to the host side memory
-  cudaMemcpy(cpuPointerHolder, gpuPointerHolder, sizeof(RawArrayClass*), cudaMemcpyDeviceToHost);
+  gpuMemcpy(cpuPointerHolder, gpuPointerHolder, sizeof(RawArrayClass*), gpuMemcpyDeviceToHost);
 
   // Free device side memory
-  cudaFree(gpuPointerHolder);
+  gpuFree(gpuPointerHolder);
 
   // Save the pointer
   ASSERT_NE(cpuPointerHolder[0], nullptr);

--- a/tests/integration/managed_ptr_tests.cpp
+++ b/tests/integration/managed_ptr_tests.cpp
@@ -12,6 +12,7 @@
   static void gpu_test_##X##Y()
 
 #include "chai/config.hpp"
+#include "chai/ArrayManager.hpp"
 #include "chai/ManagedArray.hpp"
 #include "chai/managed_ptr.hpp"
 
@@ -348,21 +349,21 @@ GPU_TEST(managed_ptr, make_on_device)
   hostArray[0] = nullptr;
 
   int** deviceArray = nullptr;
-  gpuMalloc(&deviceArray, sizeof(int*));
+  chai::gpuMalloc((void**)(&deviceArray), sizeof(int*));
 
   int** deviceArray2 = nullptr;
-  gpuMalloc(&deviceArray2, sizeof(int*));
+  chai::gpuMalloc((void**)(&deviceArray2), sizeof(int*));
 
   deviceNew<<<1, 1>>>(deviceArray);
 
-  gpuMemcpy(hostArray, deviceArray, sizeof(int*), gpuMemcpyDeviceToHost);
-  gpuMemcpy(deviceArray2, hostArray, sizeof(int*), gpuMemcpyHostToDevice);
+  chai::gpuMemcpy(hostArray, deviceArray, sizeof(int*), gpuMemcpyDeviceToHost);
+  chai::gpuMemcpy(deviceArray2, hostArray, sizeof(int*), gpuMemcpyHostToDevice);
   ASSERT_NE(hostArray[0], nullptr);
 
   deviceDelete<<<1, 1>>>(deviceArray2);
   free(hostArray);
-  gpuFree(deviceArray);
-  gpuFree(deviceArray2);
+  chai::gpuFree(deviceArray);
+  chai::gpuFree(deviceArray2);
 }
 
 GPU_TEST(managed_ptr, gpu_new_and_delete_on_device)
@@ -373,16 +374,16 @@ GPU_TEST(managed_ptr, gpu_new_and_delete_on_device)
 
   // Initialize device side memory to hold a pointer
   RawArrayClass** gpuPointerHolder = nullptr;
-  gpuMalloc(&gpuPointerHolder, sizeof(RawArrayClass*));
+  chai::gpuMalloc((void**)(&gpuPointerHolder), sizeof(RawArrayClass*));
 
   // Create on the device
   chai::detail::make_on_device<<<1, 1>>>(gpuPointerHolder);
 
   // Copy to the host side memory
-  gpuMemcpy(cpuPointerHolder, gpuPointerHolder, sizeof(RawArrayClass*), gpuMemcpyDeviceToHost);
+  chai::gpuMemcpy(cpuPointerHolder, gpuPointerHolder, sizeof(RawArrayClass*), gpuMemcpyDeviceToHost);
 
   // Free device side memory
-  gpuFree(gpuPointerHolder);
+  chai::gpuFree(gpuPointerHolder);
 
   // Save the pointer
   ASSERT_NE(cpuPointerHolder[0], nullptr);
@@ -402,16 +403,16 @@ GPU_TEST(managed_ptr, gpu_build_managed_ptr)
 
   // Initialize device side memory to hold a pointer
   RawArrayClass** gpuPointerHolder = nullptr;
-  gpuMalloc(&gpuPointerHolder, sizeof(RawArrayClass*));
+  chai::gpuMalloc((void**)(&gpuPointerHolder), sizeof(RawArrayClass*));
 
   // Create on the device
   chai::detail::make_on_device<<<1, 1>>>(gpuPointerHolder);
 
   // Copy to the host side memory
-  gpuMemcpy(cpuPointerHolder, gpuPointerHolder, sizeof(RawArrayClass*), gpuMemcpyDeviceToHost);
+  chai::gpuMemcpy(cpuPointerHolder, gpuPointerHolder, sizeof(RawArrayClass*), gpuMemcpyDeviceToHost);
 
   // Free device side memory
-  gpuFree(gpuPointerHolder);
+  chai::gpuFree(gpuPointerHolder);
 
   // Save the pointer
   ASSERT_NE(cpuPointerHolder[0], nullptr);

--- a/tests/integration/raja-chai-nested.cpp
+++ b/tests/integration/raja-chai-nested.cpp
@@ -27,6 +27,7 @@ using namespace std;
 
 #include "gtest/gtest.h"
 
+// TODO: add hip policy for these tests.
 #if defined(RAJA_ENABLE_CUDA)
 #define PARALLEL_RAJA_DEVICE __device__
 #elif defined(RAJA_ENABLE_OPENMP)

--- a/tests/integration/raja-chai-tests.cpp
+++ b/tests/integration/raja-chai-tests.cpp
@@ -16,6 +16,7 @@
 
 #include "gtest/gtest.h"
 
+// TODO: add hip policy for these tests.
 #define CUDA_TEST(X, Y)                 \
   static void cuda_test_##X##_##Y();    \
   TEST(X, Y) { cuda_test_##X##_##Y(); } \

--- a/tests/unit/managed_ptr_unit_tests.cpp
+++ b/tests/unit/managed_ptr_unit_tests.cpp
@@ -464,7 +464,7 @@ TEST(managed_ptr, reinterpret_pointer_cast)
   derived.free();
 }
 
-#ifdef __CUDACC__
+#ifdef CHAI_GPUCC
 
 GPU_TEST(managed_ptr, gpu_default_constructor)
 {
@@ -603,16 +603,16 @@ GPU_TEST(managed_ptr, gpu_new_and_delete_on_device)
 
   // Initialize device side memory to hold a pointer
   Simple** gpuPointerHolder = nullptr;
-  cudaMalloc(&gpuPointerHolder, sizeof(Simple*));
+  gpuMalloc(&gpuPointerHolder, sizeof(Simple*));
 
   // Create on the device
   chai::detail::make_on_device<<<1, 1>>>(gpuPointerHolder);
 
   // Copy to the host side memory
-  cudaMemcpy(cpuPointerHolder, gpuPointerHolder, sizeof(Simple*), cudaMemcpyDeviceToHost);
+  gpuMemcpy(cpuPointerHolder, gpuPointerHolder, sizeof(Simple*), gpuMemcpyDeviceToHost);
 
   // Free device side memory
-  cudaFree(gpuPointerHolder);
+  gpuFree(gpuPointerHolder);
 
   // Save the pointer
   ASSERT_NE(cpuPointerHolder[0], nullptr);
@@ -632,16 +632,16 @@ GPU_TEST(managed_ptr, gpu_new_and_delete_on_device_2)
 
   // Initialize device side memory to hold a pointer
   Simple** gpuPointerHolder = nullptr;
-  cudaMalloc(&gpuPointerHolder, sizeof(Simple*));
+  gpuMalloc(&gpuPointerHolder, sizeof(Simple*));
 
   // Create on the device
   chai::detail::make_on_device<<<1, 1>>>(gpuPointerHolder);
 
   // Copy to the host side memory
-  cudaMemcpy(cpuPointerHolder, gpuPointerHolder, sizeof(Simple*), cudaMemcpyDeviceToHost);
+  gpuMemcpy(cpuPointerHolder, gpuPointerHolder, sizeof(Simple*), gpuMemcpyDeviceToHost);
 
   // Free device side memory
-  cudaFree(gpuPointerHolder);
+  gpuFree(gpuPointerHolder);
 
   // Save the pointer
   ASSERT_NE(cpuPointerHolder[0], nullptr);

--- a/tests/unit/managed_ptr_unit_tests.cpp
+++ b/tests/unit/managed_ptr_unit_tests.cpp
@@ -12,6 +12,7 @@
   static void gpu_test_##X_##Y()
 
 #include "chai/config.hpp"
+#include "chai/ArrayManager.hpp"
 #include "chai/ManagedArray.hpp"
 #include "chai/managed_ptr.hpp"
 
@@ -603,16 +604,16 @@ GPU_TEST(managed_ptr, gpu_new_and_delete_on_device)
 
   // Initialize device side memory to hold a pointer
   Simple** gpuPointerHolder = nullptr;
-  gpuMalloc(&gpuPointerHolder, sizeof(Simple*));
+  chai::gpuMalloc((void**)(&gpuPointerHolder), sizeof(Simple*));
 
   // Create on the device
   chai::detail::make_on_device<<<1, 1>>>(gpuPointerHolder);
 
   // Copy to the host side memory
-  gpuMemcpy(cpuPointerHolder, gpuPointerHolder, sizeof(Simple*), gpuMemcpyDeviceToHost);
+  chai::gpuMemcpy(cpuPointerHolder, gpuPointerHolder, sizeof(Simple*), gpuMemcpyDeviceToHost);
 
   // Free device side memory
-  gpuFree(gpuPointerHolder);
+  chai::gpuFree(gpuPointerHolder);
 
   // Save the pointer
   ASSERT_NE(cpuPointerHolder[0], nullptr);
@@ -632,16 +633,16 @@ GPU_TEST(managed_ptr, gpu_new_and_delete_on_device_2)
 
   // Initialize device side memory to hold a pointer
   Simple** gpuPointerHolder = nullptr;
-  gpuMalloc(&gpuPointerHolder, sizeof(Simple*));
+  chai::gpuMalloc((void**)(&gpuPointerHolder), sizeof(Simple*));
 
   // Create on the device
   chai::detail::make_on_device<<<1, 1>>>(gpuPointerHolder);
 
   // Copy to the host side memory
-  gpuMemcpy(cpuPointerHolder, gpuPointerHolder, sizeof(Simple*), gpuMemcpyDeviceToHost);
+  chai::gpuMemcpy(cpuPointerHolder, gpuPointerHolder, sizeof(Simple*), gpuMemcpyDeviceToHost);
 
   // Free device side memory
-  gpuFree(gpuPointerHolder);
+  chai::gpuFree(gpuPointerHolder);
 
   // Save the pointer
   ASSERT_NE(cpuPointerHolder[0], nullptr);


### PR DESCRIPTION
Replaced cuda specific guards like __CUDACC__ with CHAI_GPUCC (which is __CUDACC__ or __HIPCC__).

I used wrappers like chai::gpuMalloc instead of cuda-specific functions like cudaMalloc so that the code would things would compile for both architectures. Note that this has the added benefit (or side affect?) of adding error checking for these gpu calls:


`// wrapper for hip/cuda malloc`
`CHAI_HOST inline void gpuMalloc(void** devPtr, size_t size) {`
`#if defined (CHAI_ENABLE_HIP)`
`   CHAI_GPU_ERROR_CHECK(hipMalloc(devPtr, size));`
`#elif defined (CHAI_ENABLE_CUDA)`
`   CHAI_GPU_ERROR_CHECK(cudaMalloc(devPtr, size));`
`#endif`
`}`

