### PR TITLE
Add CMP0025 policy to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@
 ##############################################################################
 cmake_policy(SET CMP0057 NEW)
 cmake_policy(SET CMP0048 NEW)
+cmake_policy(SET CMP0025 NEW)
 
 project(Chai LANGUAGES CXX VERSION 2.3.0)
 


### PR DESCRIPTION
This one-line PR adds CMake policy [CMP0025](https://cmake.org/cmake/help/latest/policy/CMP0025.html) to the top-level `CMakeList.txt`.

We observed a rather obscure error when trying to build CHAI on OSX with upstream LLVM/Clang (from homebrew) instead of AppleClang (system default):
```
-- The CXX compiler identification is Clang 12.0.1
-- Check for working CXX compiler: /usr/local/opt/llvm/bin/clang++
-- Check for working CXX compiler: /usr/local/opt/llvm/bin/clang++ - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- BLT Version: 0.3.6
-- CMake Version: 3.17.0
-- CMake Executable: /usr/local/Cellar/cmake/3.17.0_1/bin/cmake
-- Found Git: /usr/local/bin/git (found version "2.26.0") 
-- Git Support is ON
-- Git Executable: /usr/local/bin/git
-- Git Version: 2.26.0
-- MPI Support is Off
-- OpenMP Support is OFF
-- CUDA Support is OFF
-- HIP Support is Off
-- HCC Support is OFF
-- Sphinx support is OFF
-- Valgrind support is ON
-- Failed to locate Valgrind executable (missing: VALGRIND_EXECUTABLE) 
-- AStyle support is ON
-- Failed to locate AStyle executable (missing: ASTYLE_EXECUTABLE) 
-- ClangFormat support is ON
-- Failed to locate ClangFormat executable (missing: CLANGFORMAT_EXECUTABLE) 
-- Uncrustify support is ON
-- Failed to locate Uncrustify executable (missing: UNCRUSTIFY_EXECUTABLE) 
-- Cppcheck support is ON
-- Failed to locate Cppcheck executable (missing: CPPCHECK_EXECUTABLE) 
-- ClangQuery support is ON
-- Failed to locate ClangQuery executable (missing: CLANGQUERY_EXECUTABLE) 
-- C Compiler family is Clang
-- Adding optional BLT definitions and compiler flags
-- Standard C++11 selected
-- Enabling all compiler warnings on all targets.
-- Fortran support disabled.
-- CMAKE_C_FLAGS flags are:    -Wall -Wextra 
-- CMAKE_CXX_FLAGS flags are:       -Wall -Wextra     -Wall -Wextra 
-- CMAKE_EXE_LINKER_FLAGS flags are:  
-- The C compiler identification is Clang 12.0.1
-- Check for working C compiler: /usr/local/opt/llvm/bin/clang
-- Check for working C compiler: /usr/local/opt/llvm/bin/clang - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Using CMake version 3.17.0
-- Setting C standard to 99
-- Checking for std::filesystem
-- Performing Test UMPIRE_ENABLE_FILESYSTEM
-- Performing Test UMPIRE_ENABLE_FILESYSTEM - Failed
-- std::filesystem NOT found, using POSIX
-- Performing Test UMPIRE_HAS_ASAN
-- Performing Test UMPIRE_HAS_ASAN - Success
-- Umpire may be built with ASAN support
-- CHAI: using external RAJA via find_package /usr/local/GEOSX/GEOSX_TPL/raja/share/raja/cmake
-- Configuring done
CMake Error in src/tpl/umpire/src/umpire/CMakeLists.txt:
  No known features for CXX compiler

  "Clang"

  version 12.0.1.

CMake Generate step failed.  Build files cannot be regenerated correctly.
```

A quick search revealed that this problem in similar circumstances was fixed by adding this CMake policy: https://github.com/google/cctz/issues/134

I don't have a very good explanation of what's going on. Umpire [does set](https://github.com/LLNL/Umpire/blob/447f4640eff7b8f39d3c59404f3b03629b90c021/CMakeLists.txt#L8) CMP0025 to `NEW`, but that happens in the middle of CHAI configuration, after CXX compiler has been identified. Even though the compiler family is correctly identified as `Clang`, something inside CMake gets mixed up and it probably thinks it's working with AppleClang... or something.

In any case, I've confirmed that adding the policy fixes the problem in our (GEOSX) CI build.
The issue was originally reported here: https://github.com/GEOSX/thirdPartyLibs/issues/157
