### PR TITLE
Fix hip build with resource manager disabled

### DIFF
--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -101,13 +101,13 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(T* data,
 }
 
 template <typename T>
-T* ManagedArray<T>::getActiveBasePointer() const
+CHAI_HOST_DEVICE T* ManagedArray<T>::getActiveBasePointer() const
 {
   return m_active_base_pointer;
 }
 
 template <typename T>
-T* ManagedArray<T>::getActivePointer() const
+CHAI_HOST_DEVICE T* ManagedArray<T>::getActivePointer() const
 {
   return m_active_pointer;
 }


### PR DESCRIPTION
HIP requires that both function declarations and definitions must have the same `__host__` and/or `__device__` specifiers.