### PR TITLE
Add CHAI_ prefix and cmake dependent options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,41 +9,13 @@ cmake_policy(SET CMP0048 NEW)
 cmake_policy(SET CMP0025 NEW)
 
 include(CMakeDependentOption)
+include(CMakePackageConfigHelpers)
 
 project(Chai LANGUAGES CXX VERSION 2.4.0)
+cmake_minimum_required(VERSION 3.9)
 
-set(ENABLE_CUDA Off CACHE BOOL "Enable CUDA")
-set(ENABLE_HIP Off CACHE BOOL "Enable HIP")
-set(ENABLE_GPU_SIMULATION_MODE Off CACHE BOOL "Enable GPU Simulation Mode")
-set(ENABLE_OPENMP OFF CACHE BOOL "Enable OpenMP")
-set(ENABLE_MPI Off CACHE BOOL "Enable MPI (for umpire replay only)")
-option(ENABLE_IMPLICIT_CONVERSIONS "Enable implicit conversions to-from raw pointers" On)
-option(DISABLE_RM "Make ManagedArray a thin wrapper" Off)
-mark_as_advanced(DISABLE_RM)
-option(ENABLE_UM "Use CUDA unified (managed) memory" Off)
-option(ENABLE_PINNED "Use pinned host memory" Off)
-option(ENABLE_RAJA_PLUGIN "Build plugin to set RAJA execution spaces" Off)
-option(CHAI_ENABLE_GPU_ERROR_CHECKING "Enable GPU error checking" On)
-option(CHAI_ENABLE_MANAGED_PTR "Enable managed_ptr" On)
-option(CHAI_DEBUG "Enable Debug Logging.")
-set(ENABLE_RAJA_NESTED_TEST ON CACHE BOOL "Enable raja-chai-nested-tests, which fails to build on Debug CUDA builds.")
+include(cmake/SetupChaiOptions.cmake)
 
-set(ENABLE_TESTS On CACHE BOOL "")
-set(ENABLE_BENCHMARKS On CACHE BOOL "Enable benchmarks")
-set(ENABLE_EXAMPLES On CACHE BOOL "")
-set(ENABLE_REPRODUCERS Off CACHE BOOL "")
-set(ENABLE_DOCS Off CACHE BOOL "")
-
-# options for Umpire as TPL
-set(ENABLE_GMOCK On CACHE BOOL "")
-set(ENABLE_ASSERTS "Build Umpire with assert() enabled" On)
-set(ENABLE_GTEST_DEATH_TESTS ${ENABLE_ASSERTS} CACHE BOOL "")
-
-if (ENABLE_UM AND NOT ENABLE_CUDA)
-  message(FATAL_ERROR "Option ENABLE_UM requires ENABLE_CUDA")
-endif()
-
-set(ENABLE_COPY_HEADERS Off CACHE BOOL "")
 set(BLT_CXX_STD c++11 CACHE STRING "")
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")
@@ -51,11 +23,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")
   set( CMAKE_CXX_EXTENSIONS ON )
 endif()
 
-if (ENABLE_CUDA)
-  cmake_minimum_required(VERSION 3.9)
-else ()
-  cmake_minimum_required(VERSION 3.8)
-endif()
+message(STATUS "Using CMake version ${CMAKE_VERSION}")
 
 ################################
 # BLT
@@ -83,14 +51,26 @@ endif()
 #######################################
 # Options that depend on BLT Options
 #######################################
+cmake_dependent_option( CHAI_ENABLE_CUDA "Build CHAI with CUDA support" On
+                        "ENABLE_CUDA" Off )
+cmake_dependent_option( CHAI_ENABLE_HIP "Build CHAI with HIP" On
+                       "ENABLE_HIP" Off )
+cmake_dependent_option( CHAI_ENABLE_OPENMP "Build CHAI with OpenMP" On
+                       "ENABLE_OPENMP" Off )
+cmake_dependent_option( CHAI_ENABLE_MPI "Build CHAI with MPI" On
+                       "ENABLE_MPI" Off )
+
 cmake_dependent_option(CHAI_ENABLE_TESTS "Build CHAI tests" On
                        "ENABLE_TESTS" Off)
 cmake_dependent_option(CHAI_ENABLE_BENCHMARKS "Build CHAI benchmarks" On
                        "ENABLE_BENCHMARKS" Off)
 cmake_dependent_option(CHAI_ENABLE_EXAMPLES "Build CHAI examples" On
                        "ENABLE_EXAMPLES" Off )
+
 cmake_dependent_option(CHAI_ENABLE_DOCS "Build CHAI docs" On
                        "ENABLE_DOCS" Off)
+cmake_dependent_option( CHAI_ENABLE_GMOCK "Build CHAI with gmock" On
+                        "ENABLE_GMOCK" Off )
 cmake_dependent_option(CHAI_ENABLE_REPRODUCERS "Build CHAI reproducers" On
                        "ENABLE_REPRODUCERS" Off)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,46 +1,47 @@
-strategy:
-  matrix: 
-    gcc5: 
-      docker_target: gcc5
-    gcc6:
-      docker_target: gcc6
-    gcc7:
-      docker_target: gcc7
-    gcc8:
-      docker_target: gcc8
-    clang4:
-      docker_target: clang4
-    clang5:
-      docker_target: clang5
-    clang7:
-      docker_target: clang6
-    nvcc:
-      docker_target: nvcc
-
-variables:
-  DOCKER_BUILDKIT: '1'
-
-steps:
-- checkout: self
-  clean: boolean
-  submodules: recursive
-- pool:
-    vmImage: ubuntu-latest
-- task: Docker@1
-  inputs:
-    command: build
-    dockerFile: Dockerfile
-    arguments: '--target $(docker_target)'
-- script: |
-    CID=$(docker create llnl/chai:$(Build.BuildId))
-    echo ${CID}
-    docker cp ${CID}:/home/axom/workspace/build local-build
-    docker rm ${CID}
-  displayName: 'Copy test artifacts'
-  condition: ne( variables['docker_target'], 'nvcc')
-- task: PublishTestResults@2
-  inputs:
-    testResultsFormat: 'cTest'
-    testResultsFiles: '**/Test.xml'
-    testRunTitle: '$(docker_target) Tests'
-  condition: ne( variables['docker_target'], 'nvcc')
+jobs:
+- job: Docker
+  timeoutInMinutes: 360
+  strategy:
+    matrix: 
+      gcc5: 
+        docker_target: gcc5
+      gcc6:
+        docker_target: gcc6
+      gcc7:
+        docker_target: gcc7
+      gcc8:
+        docker_target: gcc8
+      clang4:
+        docker_target: clang4
+      clang5:
+        docker_target: clang5
+      clang7:
+        docker_target: clang6
+      nvcc:
+        docker_target: nvcc
+  pool:
+    vmImage: 'ubuntu-latest'
+  variables:
+    DOCKER_BUILDKIT: '1'
+  steps:
+  - checkout: self
+    clean: boolean
+    submodules: recursive
+  - task: Docker@1
+    inputs:
+      command: build
+      dockerFile: 'Dockerfile'
+      arguments: '--target $(docker_target)'
+  - script: |
+      CID=$(docker create llnl/chai:$(Build.BuildId))
+      echo ${CID}
+      docker cp ${CID}:/home/axom/workspace/build local-build
+      docker rm ${CID}
+    displayName: 'Copy test artifacts'
+    condition: ne( variables['docker_target'], 'nvcc')
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'cTest'
+      testResultsFiles: '**/Test.xml'
+      testRunTitle: '$(docker_target) Tests'
+    condition: ne( variables['docker_target'], 'nvcc')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,8 @@ steps:
 - checkout: self
   clean: boolean
   submodules: recursive
+- pool:
+    vmImage: ubuntu-latest
 - task: Docker@1
   inputs:
     command: build

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -8,13 +8,13 @@ set (chai_benchmark_depends
   chai
   gbenchmark)
 
-if (ENABLE_CUDA)
+if (CHAI_ENABLE_CUDA)
   set (chai_benchmark_depends
     ${chai_benchmark_depends}
     cuda)
 endif ()
 
-if (ENABLE_HIP)
+if (CHAI_ENABLE_HIP)
   set (chai_benchmark_depends
     ${chai_benchmark_depends}
     hip)

--- a/cmake/ChaiBasics.cmake
+++ b/cmake/ChaiBasics.cmake
@@ -6,7 +6,7 @@
 ##############################################################################
 set (CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda")
 
-if (ENABLE_HIP)
+if (CHAI_ENABLE_HIP)
   #bug in ROCm 2.4 is incorrectly warning about missing overrides
   set(HIP_HIPCC_FLAGS "${HIP_HIPCC_FLAGS} -Wno-inconsistent-missing-override")
 endif()

--- a/cmake/SetupChaiOptions.cmake
+++ b/cmake/SetupChaiOptions.cmake
@@ -1,0 +1,41 @@
+############################################################################
+# Copyright (c) 2016-20, Lawrence Livermore National Security, LLC and CHAI
+# project contributors. See the COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+############################################################################
+option(CHAI_ENABLE_HIP Off CACHE BOOL "Enable HIP")
+option(CHAI_ENABLE_GPU_SIMULATION_MODE Off CACHE BOOL "Enable GPU Simulation Mode")
+option(CHAI_ENABLE_OPENMP OFF CACHE BOOL "Enable OpenMP")
+option(CHAI_ENABLE_MPI Off CACHE BOOL "Enable MPI (for umpire replay only)")
+option(CHAI_ENABLE_IMPLICIT_CONVERSIONS "Enable implicit conversions to-from raw pointers" On)
+
+option(CHAI_DISABLE_RM "Make ManagedArray a thin wrapper" Off)
+mark_as_advanced(CHAI_DISABLE_RM)
+
+option(CHAI_ENABLE_UM "Use CUDA unified (managed) memory" Off)
+option(CHAI_ENABLE_PINNED "Use pinned host memory" Off)
+option(CHAI_ENABLE_RAJA_PLUGIN "Build plugin to set RAJA execution spaces" Off)
+option(CHAI_ENABLE_GPU_ERROR_CHECKING "Enable GPU error checking" On)
+option(CHAI_ENABLE_MANAGED_PTR "Enable managed_ptr" On)
+option(CHAI_DEBUG "Enable Debug Logging.")
+option(CHAI_ENABLE_RAJA_NESTED_TEST ON CACHE BOOL "Enable raja-chai-nested-tests, which fails to build on Debug CUDA builds.")
+
+option(CHAI_ENABLE_TESTS On CACHE BOOL "")
+option(CHAI_ENABLE_BENCHMARKS On CACHE BOOL "Enable benchmarks")
+option(CHAI_ENABLE_EXAMPLES On CACHE BOOL "")
+option(CHAI_ENABLE_REPRODUCERS Off CACHE BOOL "")
+option(CHAI_ENABLE_DOCS Off CACHE BOOL "")
+
+# options for Umpire as TPL
+set(ENABLE_GMOCK On CACHE BOOL "")
+option(CHAI_ENABLE_ASSERTS "Build Umpire with assert() enabled" On)
+set(ENABLE_GTEST_DEATH_TESTS ${CHAI_ENABLE_ASSERTS} CACHE BOOL "")
+
+option(CHAI_ENABLE_COPY_HEADERS Off CACHE BOOL "")
+
+set(ENABLE_CUDA Off CACHE BOOL "Enable CUDA")
+
+if (CHAI_ENABLE_UM AND NOT ENABLE_CUDA)
+  message(FATAL_ERROR "Option CHAI_ENABLE_UM requires ENABLE_CUDA")
+endif()

--- a/cmake/SetupChaiOptions.cmake
+++ b/cmake/SetupChaiOptions.cmake
@@ -4,10 +4,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ############################################################################
-option(CHAI_ENABLE_HIP Off CACHE BOOL "Enable HIP")
-option(CHAI_ENABLE_GPU_SIMULATION_MODE Off CACHE BOOL "Enable GPU Simulation Mode")
-option(CHAI_ENABLE_OPENMP OFF CACHE BOOL "Enable OpenMP")
-option(CHAI_ENABLE_MPI Off CACHE BOOL "Enable MPI (for umpire replay only)")
+option(CHAI_ENABLE_HIP "Enable HIP" Off)
+option(CHAI_ENABLE_GPU_SIMULATION_MODE "Enable GPU Simulation Mode" Off)
+option(CHAI_ENABLE_OPENMP "Enable OpenMP" Off)
+option(CHAI_ENABLE_MPI "Enable MPI (for umpire replay only)" Off)
 option(CHAI_ENABLE_IMPLICIT_CONVERSIONS "Enable implicit conversions to-from raw pointers" On)
 
 option(CHAI_DISABLE_RM "Make ManagedArray a thin wrapper" Off)
@@ -18,21 +18,21 @@ option(CHAI_ENABLE_PINNED "Use pinned host memory" Off)
 option(CHAI_ENABLE_RAJA_PLUGIN "Build plugin to set RAJA execution spaces" Off)
 option(CHAI_ENABLE_GPU_ERROR_CHECKING "Enable GPU error checking" On)
 option(CHAI_ENABLE_MANAGED_PTR "Enable managed_ptr" On)
-option(CHAI_DEBUG "Enable Debug Logging.")
-option(CHAI_ENABLE_RAJA_NESTED_TEST ON CACHE BOOL "Enable raja-chai-nested-tests, which fails to build on Debug CUDA builds.")
+option(CHAI_DEBUG "Enable Debug Logging." Off)
+option(CHAI_ENABLE_RAJA_NESTED_TEST "Enable raja-chai-nested-tests, which fails to build on Debug CUDA builds." On)
 
-option(CHAI_ENABLE_TESTS On CACHE BOOL "")
-option(CHAI_ENABLE_BENCHMARKS On CACHE BOOL "Enable benchmarks")
-option(CHAI_ENABLE_EXAMPLES On CACHE BOOL "")
-option(CHAI_ENABLE_REPRODUCERS Off CACHE BOOL "")
-option(CHAI_ENABLE_DOCS Off CACHE BOOL "")
+option(CHAI_ENABLE_TESTS "Enable CHAI tests" On)
+option(CHAI_ENABLE_BENCHMARKS "Enable benchmarks" On)
+option(CHAI_ENABLE_EXAMPLES "Enable CHAI examples" On)
+option(CHAI_ENABLE_REPRODUCERS "Enable CHAI reproducers" Off)
+option(CHAI_ENABLE_DOCS "Enable CHAI documentation" Off)
 
 # options for Umpire as TPL
 set(ENABLE_GMOCK On CACHE BOOL "")
 option(CHAI_ENABLE_ASSERTS "Build Umpire with assert() enabled" On)
 set(ENABLE_GTEST_DEATH_TESTS ${CHAI_ENABLE_ASSERTS} CACHE BOOL "")
 
-option(CHAI_ENABLE_COPY_HEADERS Off CACHE BOOL "")
+option(CHAI_ENABLE_COPY_HEADERS "Enable CHAI copy headers" Off)
 
 set(ENABLE_CUDA Off CACHE BOOL "Enable CUDA")
 

--- a/cmake/thirdparty/SetupChaiThirdparty.cmake
+++ b/cmake/thirdparty/SetupChaiThirdparty.cmake
@@ -47,7 +47,7 @@ if (NOT TARGET umpire)
   endif ()
 endif()
 
-if (ENABLE_RAJA_PLUGIN)
+if (CHAI_ENABLE_RAJA_PLUGIN)
   if (NOT TARGET RAJA)
     if (DEFINED RAJA_DIR)
       # this allows RAJA_DIR to be the install prefix if we are relying on RAJA's

--- a/docs/doxygen/Doxyfile.in
+++ b/docs/doxygen/Doxyfile.in
@@ -338,10 +338,10 @@ GENERATE_BUGLIST       = YES
 
 GENERATE_DEPRECATEDLIST= YES
 
-# The ENABLED_SECTIONS tag can be used to enable conditional 
+# The CHAI_ENABLED_SECTIONS tag can be used to enable conditional 
 # documentation sections, marked by \if sectionname ... \endif.
 
-ENABLED_SECTIONS       = 
+CHAI_ENABLED_SECTIONS       = 
 
 # The MAX_INITIALIZER_LINES tag determines the maximum number of lines 
 # the initial value of a variable or define consists of for it to appear in 
@@ -973,11 +973,11 @@ PERLMOD_MAKEVAR_PREFIX =
 # Configuration options related to the preprocessor   
 #---------------------------------------------------------------------------
 
-# If the ENABLE_PREPROCESSING tag is set to YES (the default) Doxygen will 
+# If the CHAI_ENABLE_PREPROCESSING tag is set to YES (the default) Doxygen will 
 # evaluate all C-preprocessor directives found in the sources and include 
 # files.
 
-ENABLE_PREPROCESSING   = YES
+CHAI_ENABLE_PREPROCESSING   = YES
 
 # If the MACRO_EXPANSION tag is set to YES Doxygen will expand all macro 
 # names in the source code. If set to NO (the default) only conditional 
@@ -1139,14 +1139,14 @@ UML_LOOK               = NO
 
 TEMPLATE_RELATIONS     = YES
 
-# If the ENABLE_PREPROCESSING, SEARCH_INCLUDES, INCLUDE_GRAPH, and HAVE_DOT 
+# If the CHAI_ENABLE_PREPROCESSING, SEARCH_INCLUDES, INCLUDE_GRAPH, and HAVE_DOT 
 # tags are set to YES then doxygen will generate a graph for each documented 
 # file showing the direct and indirect include dependencies of the file with 
 # other documented files.
 
 INCLUDE_GRAPH          = NO
 
-# If the ENABLE_PREPROCESSING, SEARCH_INCLUDES, INCLUDED_BY_GRAPH, and 
+# If the CHAI_ENABLE_PREPROCESSING, SEARCH_INCLUDES, INCLUDED_BY_GRAPH, and 
 # HAVE_DOT tags are set to YES then doxygen will generate a graph for each 
 # documented header file showing the documented files that directly or 
 # indirectly include this file.

--- a/docs/sphinx/advanced_configuration.rst
+++ b/docs/sphinx/advanced_configuration.rst
@@ -17,10 +17,10 @@ Here is a summary of the configuration options, their default value, and meaning
       ===========================  ======== ===============================================================================
       ENABLE_CUDA                  Off      Enable CUDA support.
       ENABLE_HIP                   Off      Enable HIP support.
-      ENABLE_GPU_SIMULATION_MODE   Off      Simulates GPU execution.
-      ENABLE_UM                    Off      Enable support for CUDA Unified Memory.
-      ENABLE_IMPLICIT_CONVERSIONS  On       Enable implicit conversions between ManagedArray and raw pointers
-      DISABLE_RM                   Off      Disable the ArrayManager and make ManagedArray a thin wrapper around a pointer.
+      CHAI_ENABLE_GPU_SIMULATION_MODE   Off      Simulates GPU execution.
+      CHAI_ENABLE_UM                    Off      Enable support for CUDA Unified Memory.
+      CHAI_ENABLE_IMPLICIT_CONVERSIONS  On       Enable implicit conversions between ManagedArray and raw pointers
+      CHAI_DISABLE_RM                   Off      Disable the ArrayManager and make ManagedArray a thin wrapper around a pointer.
       ENABLE_TESTS                 On       Build test executables.
       ENABLE_BENCHMARKS            On       Build benchmark programs.
       ===========================  ======== ===============================================================================
@@ -35,23 +35,23 @@ These arguments are explained in more detail below:
   This option enables support for GPUs using HIP. If CHAI is built without CUDA, HIP, or
   GPU_SIMULATION_MODE support, then only the ``CPU`` execution space is available for use.
 
-* ENABLE_GPU_SIMULATION_MODE
+* CHAI_ENABLE_GPU_SIMULATION_MODE
   This option simulates GPU support by enabling the GPU execution space, backed by a HOST
   umpire allocator. If CHAI is built without CUDA, HIP, or GPU_SIMULATION_MODE support, 
   then only the ``CPU`` execution space is available for use.
 
-* ENABLE_UM
+* CHAI_ENABLE_UM
   This option enables support for Unified Memory as an optional execution
   space. When a ``ManagedArray`` is allocated in the ``UM`` space, CHAI will
   not manually copy data. Data movement in this case is handled by the CUDA
   driver and runtime.
 
-* ENABLE_IMPLICIT_CONVERSIONS
+* CHAI_ENABLE_IMPLICIT_CONVERSIONS
   This option will allow implicit casting between an object of type
   ``ManagedArray<T>`` and the correpsonding raw pointer type ``T*``. This
   option is disabled by default, and should be used with caution.
 
-* DISABLE_RM
+* CHAI_DISABLE_RM
   This option will remove all usage of the ``ArrayManager`` class and let the
   ``ManagedArray`` objects function as thin wrappers around a raw pointer. This
   option can be used with CPU-only allocations, or with CUDA Unified Memory.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,12 +7,12 @@
 set (chai_umpire_example_depends
   chai)
 
-if (ENABLE_CUDA)
+if (CHAI_ENABLE_CUDA)
   set (chai_umpire_example_depends
     ${chai_umpire_example_depends}
     cuda)
 endif()
-if (ENABLE_HIP)
+if (CHAI_ENABLE_HIP)
   set (chai_umpire_example_depends
     ${chai_umpire_example_depends}
     hip)
@@ -23,7 +23,7 @@ blt_add_executable(
   SOURCES chai-umpire-allocators.cpp
   DEPENDS_ON ${chai_umpire_example_depends})
 
-if (ENABLE_CUDA OR ENABLE_HIP)
+if (CHAI_ENABLE_CUDA OR CHAI_ENABLE_HIP)
   blt_add_executable(
     NAME chai-example.exe
     SOURCES example.cpp

--- a/reproducers/CMakeLists.txt
+++ b/reproducers/CMakeLists.txt
@@ -6,15 +6,15 @@
 ##############################################################################
 set (chai_reproducer_depends chai)
 
-if (ENABLE_CUDA)
+if (CHAI_ENABLE_CUDA)
   list(APPEND chai_reproducer_depends cuda)
 endif ()
 
-if (ENABLE_HIP)
+if (CHAI_ENABLE_HIP)
   list(APPEND chai_reproducer_depends hip)
 endif ()
 
-if (CHAI_ENABLE_MANAGED_PTR AND ENABLE_HIP)
+if (CHAI_ENABLE_MANAGED_PTR AND CHAI_ENABLE_HIP)
   blt_add_executable(
     NAME virtual_function_simple_reproducer.exe
     SOURCES virtual_function_simple_reproducer.cpp

--- a/scripts/spack_packages/chai/package.py
+++ b/scripts/spack_packages/chai/package.py
@@ -256,11 +256,11 @@ class Chai(CMakePackage, CudaPackage, ROCmPackage):
             cfg.write("# RAJA\n")
             cfg.write("#------------------{0}\n\n".format("-" * 60))
 
-            cfg.write(cmake_cache_option("ENABLE_RAJA_PLUGIN", True))
+            cfg.write(cmake_cache_option("CHAI_ENABLE_RAJA_PLUGIN", True))
             raja_dir = spec['raja'].prefix
             cfg.write(cmake_cache_entry("RAJA_DIR", raja_dir))
         else:
-            cfg.write(cmake_cache_option("ENABLE_RAJA_PLUGIN", False))
+            cfg.write(cmake_cache_option("CHAI_ENABLE_RAJA_PLUGIN", False))
 
         # shared vs static libs
         cfg.write(cmake_cache_option("BUILD_SHARED_LIBS","+shared" in spec))

--- a/src/chai/CMakeLists.txt
+++ b/src/chai/CMakeLists.txt
@@ -4,16 +4,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################
-set(CHAI_ENABLE_PICK ${ENABLE_PICK})
-set(CHAI_ENABLE_CUDA ${ENABLE_CUDA})
-set(CHAI_ENABLE_HIP ${ENABLE_HIP})
-set(CHAI_ENABLE_IMPLICIT_CONVERSIONS ${ENABLE_IMPLICIT_CONVERSIONS})
-set(CHAI_DISABLE_RM ${DISABLE_RM})
-set(CHAI_ENABLE_UM ${ENABLE_UM})
-set(CHAI_ENABLE_RAJA_PLUGIN ${ENABLE_RAJA_PLUGIN})
-set(CHAI_ENABLE_GPU_SIMULATION_MODE ${ENABLE_GPU_SIMULATION_MODE})
-set(CHAI_ENABLE_PINNED ${ENABLE_PINNED})
-
 configure_file(
   ${PROJECT_SOURCE_DIR}/src/chai/config.hpp.in
   ${PROJECT_BINARY_DIR}/include/chai/config.hpp)
@@ -29,7 +19,7 @@ set (chai_headers
   PointerRecord.hpp
   Types.hpp)
 
-if(DISABLE_RM)
+if(CHAI_DISABLE_RM)
   set(chai_headers
     ${chai_headers}
     ManagedArray_thin.inl)
@@ -41,18 +31,18 @@ set (chai_sources
 set (chai_depends
   umpire)
 
-if (ENABLE_CUDA)
+if (CHAI_ENABLE_CUDA)
   set (chai_depends
     ${chai_depends}
     cuda_runtime)
 endif ()
-if (ENABLE_HIP)
+if (CHAI_ENABLE_HIP)
   set (chai_depends
     ${chai_depends}
     hip_runtime)
 endif ()
 
-if (ENABLE_RAJA_PLUGIN)
+if (CHAI_ENABLE_RAJA_PLUGIN)
   set (chai_headers
     ${chai_headers}
     pluginLinker.hpp
@@ -67,7 +57,7 @@ if (ENABLE_RAJA_PLUGIN)
     ${chai_depends}
     RAJA)
 
-  if (ENABLE_CUDA)
+  if (CHAI_ENABLE_CUDA)
     set (chai_depends
       ${chai_depends}
       cuda)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -7,9 +7,9 @@
 set (chai_integration_test_depends
      chai umpire gtest)
 
-blt_list_append(TO chai_integration_test_depends ELEMENTS cuda IF ${ENABLE_CUDA})
-blt_list_append(TO chai_integration_test_depends ELEMENTS hip IF ${ENABLE_HIP})
-blt_list_append(TO chai_integration_test_depends ELEMENTS openmp IF ${ENABLE_OPENMP})
+blt_list_append(TO chai_integration_test_depends ELEMENTS cuda IF ${CHAI_ENABLE_CUDA})
+blt_list_append(TO chai_integration_test_depends ELEMENTS hip IF ${CHAI_ENABLE_HIP})
+blt_list_append(TO chai_integration_test_depends ELEMENTS openmp IF ${CHAI_ENABLE_OPENMP})
 
 # ManagedArray tests
 blt_add_executable(
@@ -40,7 +40,7 @@ if (CHAI_ENABLE_MANAGED_PTR)
     COMMAND managed_ptr_tests)
 endif ()
   
-if (ENABLE_RAJA_PLUGIN)
+if (CHAI_ENABLE_RAJA_PLUGIN)
   set(raja_test_depends
     ${chai_integration_test_depends}
     RAJA)
@@ -58,7 +58,7 @@ if (ENABLE_RAJA_PLUGIN)
     raja-chai-tests
     PUBLIC ${PROJECT_BINARY_DIR}/include)
 
-  if (ENABLE_RAJA_NESTED_TEST)
+  if (CHAI_ENABLE_RAJA_NESTED_TEST)
     blt_add_executable(
       NAME raja-chai-nested-tests 
       SOURCES raja-chai-nested.cpp

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -7,8 +7,8 @@
 set (chai_unit_test_depends
      chai umpire gtest)
      
-blt_list_append(TO chai_unit_test_depends ELEMENTS cuda IF ${ENABLE_CUDA})
-blt_list_append(TO chai_unit_test_depends ELEMENTS hip IF ${ENABLE_HIP})
+blt_list_append(TO chai_unit_test_depends ELEMENTS cuda IF ${CHAI_ENABLE_CUDA})
+blt_list_append(TO chai_unit_test_depends ELEMENTS hip IF ${CHAI_ENABLE_HIP})
 
 blt_add_executable(
   NAME managed_array_unit_tests


### PR DESCRIPTION
Updating the cmake_dependent_options so that those cmake flags that are unique to CHAI will have the CHAI_ prefix. I also updated the azure_pipelines file so that it works properly with other Docker updates