### PR TITLE
MigrateInner on CHAI Copyable for PINNED / UM

### DIFF
--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -406,10 +406,14 @@ void ManagedArray<T>::move(ExecutionSpace space, bool registerTouch) const
      CHAI_LOG(Debug, "Moved to " << m_active_pointer);
 #if defined(CHAI_ENABLE_UM)
     if (m_pointer_record->m_last_space == UM) {
+       // just because we were allocated in UM doesn't mean our CHAICopyable array values were
+       moveInnerImpl();
     } else
 #endif
 #if defined(CHAI_ENABLE_PINNED)
     if (m_pointer_record->m_last_space == PINNED) {
+       // just because we were allocated in PINNED doesn't mean our CHAICopyable array valueswere
+       moveInnerImpl();
     } else 
 #endif
      if (registerTouch) {

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -412,7 +412,7 @@ void ManagedArray<T>::move(ExecutionSpace space, bool registerTouch) const
 #endif
 #if defined(CHAI_ENABLE_PINNED)
     if (m_pointer_record->m_last_space == PINNED) {
-       // just because we were allocated in PINNED doesn't mean our CHAICopyable array valueswere
+       // just because we were allocated in PINNED doesn't mean our CHAICopyable array values were
        moveInnerImpl();
     } else 
 #endif


### PR DESCRIPTION
Fixes an issue where ManagedArray<CHAICopyable<T>> would not work as expected if the outer array was allocated in the PINNED execution space and the inner CHAICopyable values were allocated in CPU / GPU Execution spaces.