### PR TITLE
Deprecate API for synchronization after device kernels

### DIFF
--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -399,16 +399,19 @@ public:
   /*!
    * \brief Turn on device synchronization after every kernel.
    */
+  [[deprecated("Set the CUDA_LAUNCH_BLOCKING or HIP_LAUNCH_BLOCKING environment variable instead")]]
   void enableDeviceSynchronize() { m_device_synchronize = true; }
 
   /*!
    * \brief Turn off device synchronization after every kernel.
    */
+  [[deprecated("Set the CUDA_LAUNCH_BLOCKING or HIP_LAUNCH_BLOCKING environment variable instead")]]
   void disableDeviceSynchronize() { m_device_synchronize = false; }
 
   /*!
    * \brief Turn on device synchronization after every kernel.
    */
+  [[deprecated("Set the CUDA_LAUNCH_BLOCKING or HIP_LAUNCH_BLOCKING environment variable instead")]]
   bool deviceSynchronize() { return m_device_synchronize; }
 
   /*!

--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -411,7 +411,6 @@ public:
   /*!
    * \brief Turn on device synchronization after every kernel.
    */
-  [[deprecated("Set the CUDA_LAUNCH_BLOCKING or HIP_LAUNCH_BLOCKING environment variable instead")]]
   bool deviceSynchronize() { return m_device_synchronize; }
 
   /*!


### PR DESCRIPTION
* Deprecates ArrayManager::enableDeviceSynchronization and ArrayManager::disableDeviceSynchronization
* Instead, use the environment variables for device synchronization after all kernels (e.g. CUDA_LAUNCH_BLOCKING or HIP_LAUNCH_BLOCKING)