### PR TITLE
Update radiuss-shared-ci, fix reproducer, update spack, update RSC

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,7 +73,7 @@ stages:
     include:
       - local: '.gitlab/custom-jobs-and-variables.yml'
       - project: 'radiuss/radiuss-shared-ci'
-        ref: 'v2023.12.0'
+        ref: 'v2023.12.3'
         file: 'pipelines/${CI_MACHINE}.yml'
       - artifact: '${CI_MACHINE}-jobs.yml'
         job: 'generate-job-lists'
@@ -84,7 +84,7 @@ stages:
 include:
   # [Optional] checks preliminary to running the actual CI test
   #- project: 'radiuss/radiuss-shared-ci'
-  #  ref: 'v2023.12.0'
+  #  ref: 'v2023.12.3'
   #  file: 'preliminary-ignore-draft-pr.yml'
   # pipelines subscribed by the project
   - local: '.gitlab/subscribed-pipelines.yml'

--- a/.gitlab/jobs/corona.yml
+++ b/.gitlab/jobs/corona.yml
@@ -6,7 +6,8 @@
 ##############################################################################
 
 # Override reproducer section to define project specific variables.
-.corona_reproducer_vars: &corona_reproducer_vars
+.corona_reproducer_vars:
+  script:
     - |
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""

--- a/.gitlab/jobs/lassen.yml
+++ b/.gitlab/jobs/lassen.yml
@@ -6,7 +6,8 @@
 ##############################################################################
 
 # Override reproducer section to define project specific variables.
-.lassen_reproducer_vars: &lassen_reproducer_vars
+.lassen_reproducer_vars:
+  script:
     - |
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""

--- a/.gitlab/jobs/poodle.yml
+++ b/.gitlab/jobs/poodle.yml
@@ -6,7 +6,8 @@
 ###############################################################################
 
 # Override reproducer section to define projet specific variables.
-.poodle_reproducer_vars: &poodle_reproducer_vars
+.poodle_reproducer_vars:
+  script:
     - |
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""

--- a/.gitlab/jobs/ruby.yml
+++ b/.gitlab/jobs/ruby.yml
@@ -6,7 +6,8 @@
 ###############################################################################
 
 # Override reproducer section to define project specific variables.
-.ruby_reproducer_vars: &ruby_reproducer_vars
+.ruby_reproducer_vars:
+  script:
     - |
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -6,7 +6,8 @@
 ##############################################################################
 
 # Override reproducer section to define project specific variables.
-.tioga_reproducer_vars: &tioga_reproducer_vars
+.tioga_reproducer_vars:
+  script:
     - |
       echo -e "export MODULE_LIST=\"${MODULE_LIST}\""
       echo -e "export SPEC=\"${SPEC//\"/\\\"}\""

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,11 +4,10 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "develop-2024-01-21",
+"spack_branch": "develop-2024-02-18",
 "spack_activate" : {},
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/packages",
 "spack_concretizer": "clingo",
-"spack_setup_clingo": false,
-"debug": true
+"spack_setup_clingo": false
 }


### PR DESCRIPTION
# Summary

- This PR updates the submodule RADIUSS Spack Configs
- This PR updates Shared CI from 2023.12.0 to 2023.12.3 with fix of the CI reproducer

## Purpose

In RADIUSS Spack Configs:
- The compilers (wrappers) on Lassen have been updated to better support the use of gcc 8.3.1 toolchain.
- The local spack packages have been updated to be as close as possible to what we are pushing in https://github.com/spack/spack/pull/41375.

## Notes

Packages in RADIUSS Spack Configs still have some specific changes compared to the PR mentioned above.

Supersedes https://github.com/LLNL/Umpire/pull/876