### PR TITLE
Remove ManagedArray implicit casts

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,7 @@ The format of this file is based on [Keep a Changelog](http://keepachangelog.com
 
 ### Removed
 - Removes deprecated ManagedArray::getPointer method. Use ManagedArray::data instead.
+- Removes optional support for implicitly casting between raw pointers and ManagedArrays (CHAI\_ENABLE\_IMPLICIT\_CONVERSIONS). Use makeManagedArray and ManagedArray::data to perform explicit conversions instead.
 
 ## [Version 2024.07.0] - Release date 2024-07-26
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,7 @@ The format of this file is based on [Keep a Changelog](http://keepachangelog.com
 ### Removed
 - Removes deprecated ManagedArray::getPointer method. Use ManagedArray::data instead.
 - Removes optional support for implicitly casting between raw pointers and ManagedArrays (CHAI\_ENABLE\_IMPLICIT\_CONVERSIONS). Use makeManagedArray and ManagedArray::data to perform explicit conversions instead.
+- Removes equality and inequality comparison operators between ManagedArrays and raw pointers
 
 ## [Version 2024.07.0] - Release date 2024-07-26
 

--- a/cmake/SetupChaiOptions.cmake
+++ b/cmake/SetupChaiOptions.cmake
@@ -7,7 +7,6 @@
 option(CHAI_ENABLE_GPU_SIMULATION_MODE "Enable GPU Simulation Mode" Off)
 option(CHAI_ENABLE_OPENMP "Enable OpenMP" Off)
 option(CHAI_ENABLE_MPI "Enable MPI (for umpire replay only)" Off)
-option(CHAI_ENABLE_IMPLICIT_CONVERSIONS "Enable implicit conversions to-from raw pointers" On)
 
 option(CHAI_DISABLE_RM "Make ManagedArray a thin wrapper" Off)
 mark_as_advanced(CHAI_DISABLE_RM)

--- a/docs/sphinx/advanced_configuration.rst
+++ b/docs/sphinx/advanced_configuration.rst
@@ -25,7 +25,6 @@ Here is a summary of the configuration options, their default value, and meaning
       ENABLE_HIP                   Off      Enable HIP support.
       CHAI_ENABLE_GPU_SIMULATION_MODE   Off      Simulates GPU execution.
       CHAI_ENABLE_UM                    Off      Enable support for CUDA Unified Memory.
-      CHAI_ENABLE_IMPLICIT_CONVERSIONS  On       Enable implicit conversions between ManagedArray and raw pointers
       CHAI_DISABLE_RM                   Off      Disable the ArrayManager and make ManagedArray a thin wrapper around a pointer.
       ENABLE_TESTS                 On       Build test executables.
       ENABLE_BENCHMARKS            On       Build benchmark programs.
@@ -51,11 +50,6 @@ These arguments are explained in more detail below:
   space. When a ``ManagedArray`` is allocated in the ``UM`` space, CHAI will
   not manually copy data. Data movement in this case is handled by the CUDA
   driver and runtime.
-
-* CHAI_ENABLE_IMPLICIT_CONVERSIONS
-  This option will allow implicit casting between an object of type
-  ``ManagedArray<T>`` and the correpsonding raw pointer type ``T*``. This
-  option is disabled by default, and should be used with caution.
 
 * CHAI_DISABLE_RM
   This option will remove all usage of the ``ArrayManager`` class and let the

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -48,12 +48,8 @@ int main(int CHAI_UNUSED_ARG(argc), char** CHAI_UNUSED_ARG(argv))
   std::cout << "Doubling v2 on device." << std::endl;
   forall(gpu(), 0, 10, [=] __device__(int i) { v2[i] *= 2.0f; });
 
-  std::cout << "Casting v2 to a pointer." << std::endl;
-#if defined(CHAI_ENABLE_IMPLICIT_CONVERSIONS)
-  float* raw_v2 = v2;
-#else
+  std::cout << "Extracting pointer from v2." << std::endl;
   float* raw_v2 = v2.data();
-#endif
 
   std::cout << "raw_v2 = [";
   for (int i = 0; i < 10; i++) {
@@ -61,12 +57,8 @@ int main(int CHAI_UNUSED_ARG(argc), char** CHAI_UNUSED_ARG(argv))
   }
   std::cout << " ]" << std::endl;
 
-  std::cout << "Casting device_array to a pointer." << std::endl;
-#if defined(CHAI_ENABLE_IMPLICIT_CONVERSIONS)
-  int* raw_device_array = device_array;
-#else  
+  std::cout << "Extracting pointer from device_array." << std::endl;
   int* raw_device_array = device_array.data();
-#endif
   std::cout << "device_array = [";
   for (int i = 0; i < 10; i++) {
     std::cout << " " << device_array[i];

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -43,18 +43,6 @@ class CHAICopyable
 };
 
 /*!
- * \class CHAIDISAMBIGUATE
- *
- * \brief Type to disambiguate otherwise ambiguous constructors.
- *
- */
-class CHAIDISAMBIGUATE
-{
-public:
-  CHAI_HOST_DEVICE CHAIDISAMBIGUATE(){};
-  CHAI_HOST_DEVICE ~CHAIDISAMBIGUATE(){};
-};
-/*!
  * \class ManagedArray
  *
  * \brief Provides an array-like class that automatically transfers data

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -323,29 +323,6 @@ public:
 #endif
 
 
-#if defined(CHAI_ENABLE_IMPLICIT_CONVERSIONS)
-  /*!
-   * \brief Cast the ManagedArray to a raw pointer.
-   *
-   * \return Raw pointer to data.
-   */
-  CHAI_HOST_DEVICE operator T*() const;
-
-  /*!
-   * \brief Construct a ManagedArray from a raw pointer.
-   *
-   * This raw pointer *must* have taken from an existing ManagedArray object.
-   *
-   * \param data Raw pointer to data.
-   * \param enable Boolean argument (unused) added to differentiate constructor.
-   */
-  template <bool Q = false>
-  CHAI_HOST_DEVICE ManagedArray(T* data,
-                                CHAIDISAMBIGUATE test = CHAIDISAMBIGUATE(),
-                                bool foo = Q);
-#endif
-
-
 #ifndef CHAI_DISABLE_RM
   /*!
    * \brief Assign a user-defined callback triggerd upon memory migration.

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -262,9 +262,6 @@ public:
   CHAI_HOST_DEVICE bool operator==(const ManagedArray<T>& rhs) const;
   CHAI_HOST_DEVICE bool operator!=(const ManagedArray<T>& from) const;
 
-  CHAI_HOST_DEVICE bool operator==(const T* from) const;
-  CHAI_HOST_DEVICE bool operator!=(const T* from) const;
-
   CHAI_HOST_DEVICE bool operator==(std::nullptr_t from) const;
   CHAI_HOST_DEVICE bool operator!=(std::nullptr_t from) const;
 

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -448,41 +448,6 @@ CHAI_HOST_DEVICE T& ManagedArray<T>::operator[](const Idx i) const {
   return m_active_pointer[i];
 }
 
-#if defined(CHAI_ENABLE_IMPLICIT_CONVERSIONS)
-template<typename T>
-CHAI_INLINE
-CHAI_HOST_DEVICE ManagedArray<T>::operator T*() const {
-   return data();
-}
-
-template<typename T>
-template<bool Q>
-CHAI_INLINE
-CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(T* data, CHAIDISAMBIGUATE, bool ) :
-  m_active_pointer(data),
-  m_active_base_pointer(data),
-#if !defined(CHAI_DEVICE_COMPILE)
-  m_resource_manager(ArrayManager::getInstance()),
-  m_size(m_resource_manager->getSize((void *)m_active_base_pointer)),
-  m_offset(0),
-  m_pointer_record(m_resource_manager->getPointerRecord((void *)data)),
-#else
-  m_resource_manager(nullptr),
-  m_size(0),
-  m_offset(0),
-  m_pointer_record(nullptr),
-#endif
-  m_is_slice(false)
-{
-#if !defined(CHAI_DEVICE_COMPILE)
-
-   if (m_active_pointer && (m_pointer_record == &ArrayManager::s_null_record || m_active_pointer != m_pointer_record->m_pointers[CPU])) {
-      CHAI_LOG(Warning,"REINTEGRATED external pointer unknown by CHAI.");
-   }
-#endif
-}
-#endif
-
 template<typename T>
 CHAI_HOST_DEVICE T*
 ManagedArray<T>::getActiveBasePointer() const

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -614,23 +614,6 @@ ManagedArray<T>::operator!= (const ManagedArray<T>& rhs) const
   return (m_active_pointer !=  rhs.m_active_pointer);
 }
 
-
-template<typename T>
-CHAI_INLINE
-CHAI_HOST_DEVICE
-bool
-ManagedArray<T>::operator== (const T * from) const {
-   return m_active_pointer == from;
-}
-
-template<typename T>
-CHAI_INLINE
-CHAI_HOST_DEVICE
-bool
-ManagedArray<T>::operator!= (const T * from) const {
-   return m_active_pointer != from;
-}
-
 template<typename T>
 CHAI_INLINE
 CHAI_HOST_DEVICE

--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -399,19 +399,6 @@ CHAI_INLINE CHAI_HOST_DEVICE bool ManagedArray<T>::operator!=(
   return (m_active_pointer != rhs.m_active_pointer);
 }
 
-
-template <typename T>
-CHAI_INLINE CHAI_HOST_DEVICE bool ManagedArray<T>::operator==(const T* from) const
-{
-  return m_active_pointer == from;
-}
-
-template <typename T>
-CHAI_INLINE CHAI_HOST_DEVICE bool ManagedArray<T>::operator!=(const T* from) const
-{
-  return m_active_pointer != from;
-}
-
 template <typename T>
 CHAI_INLINE CHAI_HOST_DEVICE bool ManagedArray<T>::operator==( std::nullptr_t from) const
 {

--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -352,28 +352,6 @@ CHAI_INLINE CHAI_HOST_DEVICE T& ManagedArray<T>::operator[](const Idx i) const
   return m_active_pointer[i];
 }
 
-#if defined(CHAI_ENABLE_IMPLICIT_CONVERSIONS)
-template <typename T>
-CHAI_INLINE CHAI_HOST_DEVICE ManagedArray<T>::operator T*() const
-{
-  return m_active_pointer;
-}
-
-template <typename T>
-template <bool Q>
-CHAI_INLINE CHAI_HOST_DEVICE
-ManagedArray<T>::ManagedArray(T* data, CHAIDISAMBIGUATE, bool) :
-  m_active_pointer(data),
-  m_active_base_pointer(data),
-  m_resource_manager(nullptr),
-  m_size(-1),
-  m_pointer_record(nullptr),
-  m_offset(0),
-  m_is_slice(false)
-{
-}
-#endif
-
 template <typename T>
 template <typename U>
 ManagedArray<T>::operator typename std::

--- a/src/chai/config.hpp.in
+++ b/src/chai/config.hpp.in
@@ -10,7 +10,6 @@
 #cmakedefine CHAI_ENABLE_PICK
 #cmakedefine CHAI_ENABLE_CUDA 
 #cmakedefine CHAI_ENABLE_HIP 
-#cmakedefine CHAI_ENABLE_IMPLICIT_CONVERSIONS
 #cmakedefine CHAI_DISABLE_RM
 #cmakedefine CHAI_THIN_GPU_ALLOCATE
 #cmakedefine CHAI_ENABLE_UM

--- a/tests/integration/managed_array_tests.cpp
+++ b/tests/integration/managed_array_tests.cpp
@@ -774,22 +774,6 @@ TEST(ManagedArray, NullpointerConversions)
   assert_empty_map(true);
 }
 
-#if defined(CHAI_ENABLE_IMPLICIT_CONVERSIONS)
-TEST(ManagedArray, ImplicitConversions)
-{
-  chai::ManagedArray<float> a(1);
-  a[0] = 3.14159;
-
-  chai::ManagedArray<float> a2 = a;
-  
-  ASSERT_EQ(a2[0], a[0]);
-
-  a.free();
-  SUCCEED();
-  assert_empty_map(true);
-}
-#endif
-
 TEST(ManagedArray, PodTest)
 {
   chai::ManagedArray<my_point> array(1);
@@ -877,11 +861,8 @@ TEST(ManagedArray, ExternalOwnedFromManagedArray)
   chai::ManagedArray<float> arrayCopy =
       chai::makeManagedArray<float>(array.data(chai::CPU), 20, chai::CPU, true);
 
-#if defined(CHAI_ENABLE_IMPLICIT_CONVERSIONS)
-  ASSERT_EQ(array, arrayCopy);
-#else
   ASSERT_EQ(array.data(), arrayCopy.data());
-#endif
+
   // should be able to free through the new ManagedArray
   arrayCopy.free();
   assert_empty_map(true);

--- a/tests/integration/managed_ptr_tests.cpp
+++ b/tests/integration/managed_ptr_tests.cpp
@@ -481,11 +481,7 @@ GPU_TEST(managed_ptr, gpu_class_with_raw_array_and_callback)
      array[i] = expectedValue;
   });
 
-#if defined(CHAI_ENABLE_IMPLICIT_CONVERSIONS)
-  auto cpuPointer = new RawArrayClass(array);
-#else
   auto cpuPointer = new RawArrayClass(array.data());
-#endif
   auto gpuPointer = chai::make_on_device<RawArrayClass>(chai::unpack(array));
 
   auto callback = [=] (chai::Action action, chai::ExecutionSpace space, void*) mutable -> bool {


### PR DESCRIPTION
* Remove optional support for implicitly casting between raw pointers and ManagedArrays
* Remove CHAI_ENABLE_IMPLICIT_CONVERSIONS configuration option
* Use makeManagedArray and ManagedArray::data to perform explicit conversions
* Remove operator== and operator!= overloads for raw pointers (can easily accomplish this using ManagedArray::data)