### PR TITLE
Remove incr and decr methods on ManagedArray

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,7 @@ The format of this file is based on [Keep a Changelog](http://keepachangelog.com
 
 ### Removed
 - Removes deprecated ManagedArray::getPointer method. Use ManagedArray::data instead.
+- Removes ManagedArray::incr and ManagedArray::decr methods. Use ManagedArray::pick and ManagedArray::set instead.
 - Removes optional support for implicitly casting between raw pointers and ManagedArrays (CHAI\_ENABLE\_IMPLICIT\_CONVERSIONS). Use makeManagedArray and ManagedArray::data to perform explicit conversions instead.
 - Removes equality and inequality comparison operators between ManagedArrays and raw pointers.
 - Removes make\_managed\_from\_factory function for creating managed\_ptr objects from factory functions. This change will lead to safer adoption of allocators during construction and destruction of managed\_ptr objects.

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -289,22 +289,6 @@ public:
    * \tparam T The type of data value in ManagedArray.
    */
   CHAI_HOST_DEVICE void set(size_t i, T val) const;
-
-  /*!
-   * \brief Increment the value of element i in the ManagedArray.
-   *
-   * \param index The index of the element to be incremented
-   * \tparam T The type of data value in ManagedArray.
-   */
-  CHAI_HOST_DEVICE void incr(size_t i) const;
-
-  /*!
-   * \brief Decrement the value of element i in the ManagedArray.
-   *
-   * \param index The index of the element to be decremented
-   * \tparam T The type of data value in ManagedArray.
-   */
-  CHAI_HOST_DEVICE void decr(size_t i) const;
 #endif
 
 

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -382,7 +382,6 @@ public:
 
 
 private:
-  CHAI_HOST void modify(size_t i, const T& val) const;
   // The following are only used by ManagedArray.inl, but for template
   // shenanigan reasons need to be defined here.
 #if !defined(CHAI_DISABLE_RM)

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -364,40 +364,6 @@ CHAI_HOST_DEVICE void ManagedArray<T>::set(size_t i, T val) const {
   #endif // !defined(CHAI_DEVICE_COMPILE)
 }
 
-template<typename T>
-CHAI_INLINE
-CHAI_HOST void ManagedArray<T>::modify(size_t i, const T& val) const { 
-  #if defined(CHAI_ENABLE_UM)
-    if(m_pointer_record->m_pointers[UM] == m_active_pointer) {
-      synchronize();
-      m_active_pointer[i] = m_active_pointer[i] + val;
-      return;
-    }
-  #endif
-    T_non_const temp = pick(i);
-    temp = temp + val;
-    set(i, temp);
-}
-
-template<typename T>
-CHAI_INLINE
-CHAI_HOST_DEVICE void ManagedArray<T>::incr(size_t i) const { 
-  #if !defined(CHAI_DEVICE_COMPILE)
-    modify(i, (T)1);
-  #else
-     ++m_active_pointer[i]; 
-  #endif
-}
-
-template<typename T>
-CHAI_INLINE
-CHAI_HOST_DEVICE void ManagedArray<T>::decr(size_t i) const { 
-  #if !defined(CHAI_DEVICE_COMPILE)
-    modify(i, (T)-1);
-  #else
-     --m_active_pointer[i]; 
-  #endif
-}
 #endif
 
 template <typename T>

--- a/src/chai/ManagedArrayView.hpp
+++ b/src/chai/ManagedArrayView.hpp
@@ -33,8 +33,8 @@ using ManagedArrayMultiView =
     RAJA::MultiView<ValueType,
                     LayoutType,
                     P2Pidx,
-                    chai::ManagedArray<ValueType> *,
-                    chai::ManagedArray<camp::type::cv::rem<ValueType>> *>;
+                    chai::ManagedArray<chai::ManagedArray<ValueType>>,
+                    chai::ManagedArray<chai::ManagedArray<camp::type::cv::rem<ValueType>>>>;
 
 } // end of namespace chai
 

--- a/src/chai/ManagedArrayView.hpp
+++ b/src/chai/ManagedArrayView.hpp
@@ -33,8 +33,8 @@ using ManagedArrayMultiView =
     RAJA::MultiView<ValueType,
                     LayoutType,
                     P2Pidx,
-                    chai::ManagedArray<chai::ManagedArray<ValueType>>,
-                    chai::ManagedArray<chai::ManagedArray<camp::type::cv::rem<ValueType>>>>;
+                    chai::ManagedArray<ValueType> *,
+                    chai::ManagedArray<camp::type::cv::rem<ValueType>> *>;
 
 } // end of namespace chai
 

--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -272,6 +272,7 @@ CHAI_INLINE CHAI_HOST void ManagedArray<T>::reset()
 
 
 #if defined(CHAI_ENABLE_PICK)
+
 template <typename T>
 CHAI_INLINE CHAI_HOST_DEVICE typename ManagedArray<T>::T_non_const ManagedArray<
     T>::pick(size_t i) const
@@ -299,31 +300,6 @@ CHAI_INLINE CHAI_HOST_DEVICE void ManagedArray<T>::set(size_t i, T val) const
   m_active_pointer[i] = val;
 }
 
-template <typename T>
-CHAI_INLINE CHAI_HOST_DEVICE void ManagedArray<T>::incr(size_t i) const
-{
-#if defined(CHAI_THIN_GPU_ALLOCATE)
-#if !defined(CHAI_DEVICE_COMPILE)
-  ArrayManager::getInstance()->syncIfNeeded();
-#endif
-#elif defined(CHAI_ENABLE_UM)
-   synchronize();
-#endif
-  ++m_active_pointer[i];
-}
-
-template <typename T>
-CHAI_INLINE CHAI_HOST_DEVICE void ManagedArray<T>::decr(size_t i) const
-{
-#if defined(CHAI_THIN_GPU_ALLOCATE)
-#if !defined(CHAI_DEVICE_COMPILE)
-  ArrayManager::getInstance()->syncIfNeeded();
-#endif
-#elif defined(CHAI_ENABLE_UM)
-   synchronize();
-#endif
-  --m_active_pointer[i];
-}
 #endif // CHAI_ENABLE_PICK
 
 template <typename T>

--- a/tests/integration/managed_array_tests.cpp
+++ b/tests/integration/managed_array_tests.cpp
@@ -209,32 +209,6 @@ TEST(ManagedArray, SetHostToHost)
 }
 
 
-TEST(ManagedArray, IncrementDecrementOnHost)
-{
-  chai::ManagedArray<int> arrayI(10);
-  chai::ManagedArray<int> arrayD(10);
-
-  forall(sequential(), 0, 10, [=](int i) {
-    arrayI[i] = i;
-    arrayD[i] = i;
-  });
-
-  forall(sequential(), 0, 10, [=](int i) {
-    arrayI.incr(i);
-    arrayD.decr(i);
-  });
-
-  forall(sequential(), 0, 10, [=](int i) {
-    ASSERT_EQ(arrayI[i], i + 1);
-    ASSERT_EQ(arrayD[i], i - 1);
-  });
-
-  arrayI.free();
-  arrayD.free();
-  assert_empty_map(true);
-}
-
-
 #if defined(CHAI_ENABLE_UM)
 #if (!defined(CHAI_DISABLE_RM))
 TEST(ManagedArray, PickHostFromHostConstUM) {
@@ -279,30 +253,6 @@ TEST(ManagedArray, SetHostToHostUM)
   assert_empty_map(true);
 }
 
-TEST(ManagedArray, IncrementDecrementOnHostUM)
-{
-  chai::ManagedArray<int> arrayI(10, chai::UM);
-  chai::ManagedArray<int> arrayD(10, chai::UM);
-
-  forall(sequential(), 0, 10, [=](int i) {
-    arrayI[i] = i;
-    arrayD[i] = i;
-  });
-
-  forall(sequential(), 0, 10, [=](int i) {
-    arrayI.incr(i);
-    arrayD.decr(i);
-  });
-
-  forall(sequential(), 0, 10, [=](int i) {
-    ASSERT_EQ(arrayI[i], i + 1);
-    ASSERT_EQ(arrayD[i], i - 1);
-  });
-
-  arrayI.free();
-  arrayD.free();
-  assert_empty_map(true);
-}
 #endif
 
 #endif
@@ -369,51 +319,6 @@ GPU_TEST(ManagedArray, SetHostToDeviceUM)
   array.set(5, temp);
   temp = array.pick(5);
   ASSERT_EQ(temp, 10);
-
-  array.free();
-  assert_empty_map(true);
-}
-
-GPU_TEST(ManagedArray, IncrementDecrementOnDeviceUM)
-{
-  chai::ManagedArray<int> arrayI(10, chai::UM);
-  chai::ManagedArray<int> arrayD(10, chai::UM);
-
-  forall(gpu(), 0, 10, [=] __device__(int i) {
-    arrayI[i] = i;
-    arrayD[i] = i;
-  });
-
-  forall(gpu(), 0, 10, [=] __device__(int i) {
-    arrayI.incr(i);
-    arrayD.decr(i);
-  });
-
-  forall(sequential(), 0, 10, [=](int i) {
-    ASSERT_EQ(arrayI[i], i + 1);
-    ASSERT_EQ(arrayD[i], i - 1);
-  });
-
-  arrayI.free();
-  arrayD.free();
-  assert_empty_map(true);
-}
-
-GPU_TEST(ManagedArray, IncrementDecrementFromHostOnDeviceUM)
-{
-  chai::ManagedArray<int> array(10, chai::UM);
-
-  forall(gpu(), 0, 10, [=] __device__(int i) { array[i] = i; });
-
-  array.incr(5);
-  array.decr(9);
-
-  int temp;
-  temp = array.pick(5);
-  ASSERT_EQ(temp, 6);
-
-  temp = array.pick(9);
-  ASSERT_EQ(temp, 8);
 
   array.free();
   assert_empty_map(true);
@@ -534,50 +439,7 @@ GPU_TEST(ManagedArray, SetHostToDevice)
   array.free();
   assert_empty_map(true);
 }
-GPU_TEST(ManagedArray, IncrementDecrementOnDevice)
-{
-  chai::ManagedArray<int> arrayI(10);
-  chai::ManagedArray<int> arrayD(10);
 
-  forall(gpu(), 0, 10, [=] __device__(int i) {
-    arrayI[i] = i;
-    arrayD[i] = i;
-  });
-
-  forall(gpu(), 0, 10, [=] __device__(int i) {
-    arrayI.incr(i);
-    arrayD.decr(i);
-  });
-
-  forall(sequential(), 0, 10, [=](int i) {
-    ASSERT_EQ(arrayI[i], i + 1);
-    ASSERT_EQ(arrayD[i], i - 1);
-  });
-
-  arrayI.free();
-  arrayD.free();
-  assert_empty_map(true);
-}
-
-GPU_TEST(ManagedArray, IncrementDecrementFromHostOnDevice)
-{
-  chai::ManagedArray<int> array(10);
-
-  forall(gpu(), 0, 10, [=] __device__(int i) { array[i] = i; });
-
-  array.incr(5);
-  array.decr(9);
-
-  int temp;
-  temp = array.pick(5);
-  ASSERT_EQ(temp, 6);
-
-  temp = array.pick(9);
-  ASSERT_EQ(temp, 8);
-
-  array.free();
-  assert_empty_map(true);
-}
 #endif
 #endif
 

--- a/tests/integration/raja-chai-tests.cpp
+++ b/tests/integration/raja-chai-tests.cpp
@@ -104,13 +104,17 @@ CUDA_TEST(ChaiTest, Views)
   v2_array.free();
 }
 
+#if defined(CHAI_ENABLE_MULTIVIEW_TEST)
 CUDA_TEST(ChaiTest, MultiView)
 {
-  chai::ManagedArray<chai::ManagedArray<float>> all_arrays(2);
+  chai::ManagedArray<float> v1_array(10);
+  chai::ManagedArray<float> v2_array(10);
 
-  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, 2), [=] (int i) {
-    all_arrays[i] = chai::ManagedArray<float>(10);
-  });
+  // TODO: This stack array gets converted to a raw host pointer, which appears
+  //       to be dereferenced on the device when accessing the multiview.
+  chai::ManagedArray<float> all_arrays[2];
+  all_arrays[0] = v1_array;
+  all_arrays[1] = v2_array;
 
   // default MultiView
   using view = chai::ManagedArrayMultiView<float, RAJA::Layout<1>>;
@@ -120,36 +124,31 @@ CUDA_TEST(ChaiTest, MultiView)
   using view1p = chai::ManagedArrayMultiView<float, RAJA::Layout<1>, 1>;
   view1p mview1p(all_arrays, RAJA::Layout<1>(10));
 
-  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, 10), [=] (int i) {
-    mview(0, i) = static_cast<float>(i * 1.0f);
+  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, 10), [=](int i) {
+    mview(0,i) = static_cast<float>(i * 1.0f);
   });
 
-  RAJA::forall<parallel_raja_policy>(RAJA::RangeSegment(0, 10), [=] PARALLEL_RAJA_DEVICE (int i) {
+  RAJA::forall<parallel_raja_policy>(RAJA::RangeSegment(0, 10), [=] PARALLEL_RAJA_DEVICE(int i) {
     // use both MultiViews
-    mview(1, i) = mview1p(i, 0) * 2.0f;
+    mview(1,i) = mview1p(i,0) * 2.0f;
   });
 
-  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, 10), [=] (int i) {
-    ASSERT_FLOAT_EQ(mview(1, i), i * 2.0f);
+  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, 10), [=](int i) {
+    ASSERT_FLOAT_EQ(mview(1,i), i * 2.0f);
   });
 
-  RAJA::forall<parallel_raja_policy>(RAJA::RangeSegment(0, 10), [=] PARALLEL_RAJA_DEVICE (int i) {
-    mview(1, i) *= 2.0f;
+  RAJA::forall<parallel_raja_policy>(RAJA::RangeSegment(0, 10), [=] PARALLEL_RAJA_DEVICE(int i) {
+    mview(1,i) *= 2.0f;
   });
 
   // accessing pointer to v2_array
-  chai::ManagedArray<chai::ManagedArray<float>> retrieved_all_arrays = mview.data();
-  chai::ManagedArray<float>* raw_all_arrays = retrieved_all_arrays.data();
-  float* raw_v2 = raw_all_arrays[1].data();
-
+  float* raw_v2 = mview.data[1].data();
   for (int i = 0; i < 10; i++) {
     ASSERT_FLOAT_EQ(raw_v2[i], i * 1.0f * 2.0f * 2.0f);
     ;
   }
 
-  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, 2), [=](int i) {
-    all_arrays[i].free();
-  });
-
-  all_arrays.free();
+  v1_array.free();
+  v2_array.free();
 }
+#endif  // defined(CHAI_ENABLE_MULTIVIEW_TEST)

--- a/tests/integration/raja-chai-tests.cpp
+++ b/tests/integration/raja-chai-tests.cpp
@@ -106,12 +106,11 @@ CUDA_TEST(ChaiTest, Views)
 
 CUDA_TEST(ChaiTest, MultiView)
 {
-  chai::ManagedArray<float> v1_array(10);
-  chai::ManagedArray<float> v2_array(10);
+  chai::ManagedArray<chai::ManagedArray<float>> all_arrays(2);
 
-  chai::ManagedArray<float> all_arrays[2];
-  all_arrays[0] = v1_array;
-  all_arrays[1] = v2_array;
+  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, 2), [=] (int i) {
+    all_arrays[i] = chai::ManagedArray<float>(10);
+  });
 
   // default MultiView
   using view = chai::ManagedArrayMultiView<float, RAJA::Layout<1>>;
@@ -121,30 +120,36 @@ CUDA_TEST(ChaiTest, MultiView)
   using view1p = chai::ManagedArrayMultiView<float, RAJA::Layout<1>, 1>;
   view1p mview1p(all_arrays, RAJA::Layout<1>(10));
 
-  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, 10), [=](int i) {
-    mview(0,i) = static_cast<float>(i * 1.0f);
+  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, 10), [=] (int i) {
+    mview(0, i) = static_cast<float>(i * 1.0f);
   });
 
-  RAJA::forall<parallel_raja_policy>(RAJA::RangeSegment(0, 10), [=] PARALLEL_RAJA_DEVICE(int i) {
+  RAJA::forall<parallel_raja_policy>(RAJA::RangeSegment(0, 10), [=] PARALLEL_RAJA_DEVICE (int i) {
     // use both MultiViews
-    mview(1,i) = mview1p(i,0) * 2.0f;
+    mview(1, i) = mview1p(i, 0) * 2.0f;
   });
 
-  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, 10), [=](int i) {
-    ASSERT_FLOAT_EQ(mview(1,i), i * 2.0f);
+  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, 10), [=] (int i) {
+    ASSERT_FLOAT_EQ(mview(1, i), i * 2.0f);
   });
 
-  RAJA::forall<parallel_raja_policy>(RAJA::RangeSegment(0, 10), [=] PARALLEL_RAJA_DEVICE(int i) {
-    mview(1,i) *= 2.0f;
+  RAJA::forall<parallel_raja_policy>(RAJA::RangeSegment(0, 10), [=] PARALLEL_RAJA_DEVICE (int i) {
+    mview(1, i) *= 2.0f;
   });
 
   // accessing pointer to v2_array
-  float* raw_v2 = mview.data[1].data();
+  chai::ManagedArray<chai::ManagedArray<float>> retrieved_all_arrays = mview.data();
+  chai::ManagedArray<float>* raw_all_arrays = retrieved_all_arrays.data();
+  float* raw_v2 = raw_all_arrays[1].data();
+
   for (int i = 0; i < 10; i++) {
     ASSERT_FLOAT_EQ(raw_v2[i], i * 1.0f * 2.0f * 2.0f);
     ;
   }
 
-  v1_array.free();
-  v2_array.free();
+  RAJA::forall<RAJA::seq_exec>(RAJA::RangeSegment(0, 2), [=](int i) {
+    all_arrays[i].free();
+  });
+
+  all_arrays.free();
 }


### PR DESCRIPTION
These are rarely (never as far as I can tell) used and can easily be replaced using pick and set. Also, incr and decr aren't general for all types.