### PR TITLE
Always enable pick and set

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,7 @@ The format of this file is based on [Keep a Changelog](http://keepachangelog.com
 - Removes optional support for implicitly casting between raw pointers and ManagedArrays (CHAI\_ENABLE\_IMPLICIT\_CONVERSIONS). Use makeManagedArray and ManagedArray::data to perform explicit conversions instead.
 - Removes equality and inequality comparison operators between ManagedArrays and raw pointers.
 - Removes make\_managed\_from\_factory function for creating managed\_ptr objects from factory functions. This change will lead to safer adoption of allocators during construction and destruction of managed\_ptr objects.
+- Removes CHAI\_ENABLE\_PICK CMake option. ManagedArray::pick and ManagedArray::set will always be available.
 
 ## [Version 2024.07.0] - Release date 2024-07-26
 

--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -253,13 +253,11 @@ public:
    */
   CHAISHAREDDLL_API void free(PointerRecord* pointer, ExecutionSpace space = NONE);
 
-#if defined(CHAI_ENABLE_PICK)
   template <typename T>
-   T_non_const<T> pick(T* src_ptr, size_t index);
+  T_non_const<T> pick(T* src_ptr, size_t index);
 
   template <typename T>
-   void set(T* dst_ptr, size_t index, const T& val);
-#endif
+  void set(T* dst_ptr, size_t index, const T& val);
 
   /*!
    * \brief Get the size of the given pointer.

--- a/src/chai/ArrayManager.inl
+++ b/src/chai/ArrayManager.inl
@@ -124,7 +124,6 @@ void* ArrayManager::reallocate(void* pointer, size_t elems, PointerRecord* point
   return pointer_record->m_pointers[my_space];
 }
 
-#if defined(CHAI_ENABLE_PICK)
 template<typename T>
 CHAI_INLINE
 typename ArrayManager::T_non_const<T> ArrayManager::pick(T* src_ptr, size_t index)
@@ -144,7 +143,6 @@ void ArrayManager::set(T* dst_ptr, size_t index, const T& val)
   m_resource_manager.copy(const_cast<T_non_const<T>*>(dst_ptr+index), const_cast<T_non_const<T>*>(&val), sizeof(T));
   m_resource_manager.deregisterAllocation(const_cast<T_non_const<T>*>(&val));
 }
-#endif
 
 CHAI_INLINE
 void ArrayManager::copy(void * dst, void * src, size_t size) {

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -268,8 +268,6 @@ public:
 
   CHAI_HOST_DEVICE explicit operator bool() const;
 
-
-#if defined(CHAI_ENABLE_PICK)
   /*!
    * \brief Return the value of element i in the ManagedArray.
    * ExecutionSpace space to the current one
@@ -289,8 +287,6 @@ public:
    * \tparam T The type of data value in ManagedArray.
    */
   CHAI_HOST_DEVICE void set(size_t i, T val) const;
-#endif
-
 
 #ifndef CHAI_DISABLE_RM
   /*!

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -304,8 +304,6 @@ CHAI_HOST void ManagedArray<T>::registerTouch(ExecutionSpace space) {
   m_resource_manager->registerTouch(m_pointer_record, space);
 }
 
-
-#if defined(CHAI_ENABLE_PICK)
 template<typename T>
 CHAI_INLINE
 CHAI_HOST_DEVICE
@@ -363,8 +361,6 @@ CHAI_HOST_DEVICE void ManagedArray<T>::set(size_t i, T val) const {
     m_active_pointer[i] = val; 
   #endif // !defined(CHAI_DEVICE_COMPILE)
 }
-
-#endif
 
 template <typename T>
 CHAI_INLINE

--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -270,9 +270,6 @@ CHAI_INLINE CHAI_HOST void ManagedArray<T>::reset()
 {
 }
 
-
-#if defined(CHAI_ENABLE_PICK)
-
 template <typename T>
 CHAI_INLINE CHAI_HOST_DEVICE typename ManagedArray<T>::T_non_const ManagedArray<
     T>::pick(size_t i) const
@@ -299,8 +296,6 @@ CHAI_INLINE CHAI_HOST_DEVICE void ManagedArray<T>::set(size_t i, T val) const
 #endif
   m_active_pointer[i] = val;
 }
-
-#endif // CHAI_ENABLE_PICK
 
 template <typename T>
 CHAI_INLINE CHAI_HOST_DEVICE size_t ManagedArray<T>::size() const

--- a/src/chai/config.hpp.in
+++ b/src/chai/config.hpp.in
@@ -7,7 +7,6 @@
 #ifndef CHAI_config_HPP
 #define CHAI_config_HPP
 
-#cmakedefine CHAI_ENABLE_PICK
 #cmakedefine CHAI_ENABLE_CUDA 
 #cmakedefine CHAI_ENABLE_HIP 
 #cmakedefine CHAI_DISABLE_RM

--- a/tests/integration/managed_array_tests.cpp
+++ b/tests/integration/managed_array_tests.cpp
@@ -164,7 +164,6 @@ TEST(ManagedArray, ArrayOfSlices) {
   assert_empty_map(true);
 }
 
-#if defined(CHAI_ENABLE_PICK)
 #if (!defined(CHAI_DISABLE_RM))
 TEST(ManagedArray, PickHostFromHostConst) {
   chai::ManagedArray<int> array(10);
@@ -255,10 +254,7 @@ TEST(ManagedArray, SetHostToHostUM)
 
 #endif
 
-#endif
-
 #if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
-#if defined(CHAI_ENABLE_PICK)
 
 #if defined(CHAI_ENABLE_UM)
 GPU_TEST(ManagedArray, PickandSetDeviceToDeviceUM)
@@ -440,7 +436,6 @@ GPU_TEST(ManagedArray, SetHostToDevice)
   assert_empty_map(true);
 }
 
-#endif
 #endif
 
 GPU_TEST(ManagedArray, ArrayOfSlicesDevice) {


### PR DESCRIPTION
We've had complaints about how complicated CHAI is to configure. This MR removes the CHAI_ENABLE_PICK configuration in favor of always enabling the pick and set methods on ManagedArray.