### PR TITLE
Document when XNACK is required

### DIFF
--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -428,7 +428,8 @@ protected:
  *
  * \return A new ManagedArray containing the raw data pointer.
  *
- * \note If using this method on HIP platforms, XNACK must be enabled.
+ * \note If using this method on HIP platforms, XNACK must be enabled
+ *       (see https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/hip_runtime_api/memory_management/unified_memory.html).
  */
 template <typename T>
 ManagedArray<T> makeManagedArray(T* data,

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -427,6 +427,8 @@ protected:
  * \tparam T Type of the raw data.
  *
  * \return A new ManagedArray containing the raw data pointer.
+ *
+ * \note If using this method on HIP platforms, XNACK must be enabled.
  */
 template <typename T>
 ManagedArray<T> makeManagedArray(T* data,


### PR DESCRIPTION
If a client uses chai::makeManagedArray on a HIP platform, XNACK must be enabled.