### PR TITLE
Support allocators in thin mode

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,8 @@ The format of this file is based on [Keep a Changelog](http://keepachangelog.com
 ### Fixed
 - Fixes reallocate when using pinned or unified memory.
 - Adds missing synchronize when using pinned memory.
+- Fixes possible hangs when evicting data.
+- Now respects allocators passed to ManagedArray constructors when CHAI\_DISABLE\_RM=TRUE.
 
 ### Removed
 - Removes deprecated ManagedArray::getPointer method. Use ManagedArray::data instead.

--- a/src/chai/ArrayManager.cpp
+++ b/src/chai/ArrayManager.cpp
@@ -37,7 +37,14 @@ ArrayManager::ArrayManager() :
 {
   m_pointer_map.clear();
   m_current_execution_space = NONE;
+#if defined(CHAI_THIN_GPU_ALLOCATE)
+  m_default_allocation_space = GPU;
+#else
   m_default_allocation_space = CPU;
+#endif
+
+  m_allocators[NONE] =
+      new umpire::Allocator(m_resource_manager.getAllocator("HOST"));
 
   m_allocators[CPU] =
       new umpire::Allocator(m_resource_manager.getAllocator("HOST"));
@@ -330,6 +337,7 @@ void ArrayManager::allocate(
   auto alloc = m_resource_manager.getAllocator(pointer_record->m_allocators[space]);
 
   pointer_record->m_pointers[space] = alloc.allocate(size);
+
   callback(pointer_record, ACTION_ALLOC, space);
   registerPointer(pointer_record, space);
 
@@ -481,8 +489,8 @@ PointerRecord* ArrayManager::makeManaged(void* pointer,
   pointer_record->m_size = size;
   pointer_record->m_user_callback = [] (const PointerRecord*, Action, ExecutionSpace) {};
   
-  for (int space = CPU; space < NUM_EXECUTION_SPACES; ++space) {
-    pointer_record->m_allocators[space] = getAllocatorId(ExecutionSpace(space));
+  for (int iSpace = CPU; iSpace < NUM_EXECUTION_SPACES; ++iSpace) {
+    pointer_record->m_allocators[iSpace] = getAllocatorId(ExecutionSpace(iSpace));
   }
 
   if (pointer && size > 0) {
@@ -600,22 +608,29 @@ void ArrayManager::evict(ExecutionSpace space, ExecutionSpace destinationSpace) 
          // Get the pointer record
          auto record = *entry.second;
 
-         // Move the data and register the touches
-         move(record, destinationSpace);
-         registerTouch(record, destinationSpace);
-
-         // If the destinationSpace is ever allowed to be NONE, then we will need to
-         // update the touch in the eviction space and make sure the last space is not
-         // the eviction space.
-
-         // Mark record for eviction later in this routine
-         pointersToEvict.push_back(record);
+         // only evict if the pointers are different, same pointers
+         // implies UM or PINNED
+         if (record->m_pointers[space] != record->m_pointers[destinationSpace]) {
+            // Mark record for eviction later in this routine
+            pointersToEvict.push_back(record);
+         }
       }
    }
 
-   // This must be done in a second pass because free erases from m_pointer_map,
-   // which would invalidate the iterator in the above loop
+   // This must be done in a second pass because free erases from m_pointer_map
+   // and move has the potential to allocate, both of which which would
+   // invalidate the iterator in the above loop. Additionally, m_pointer_map
+   // is guarded by a mutex, so modifying it in the above loop (via move and/or
+   // free) creates deadlock.
    for (const auto& entry : pointersToEvict) {
+      // Move the data and register the touches
+      move(entry, destinationSpace);
+      registerTouch(entry, destinationSpace);
+
+      // If the destinationSpace is ever allowed to be NONE, then we will need to
+      // update the touch in the eviction space and make sure the last space is not
+      // the eviction space.
+
       free(entry, space);
    }
 }

--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -391,6 +391,15 @@ public:
    * \return The allocator for the given space.
    */
   umpire::Allocator getAllocator(ExecutionSpace space);
+
+  /*!
+   * \brief Get the allocator for an allocator id
+   *
+   * \param allocator_id id for the allocator
+   *
+   * \return The allocator for the given allocator id.
+   */
+  umpire::Allocator getAllocator(int allocator_id);
   
  /*!
    * \brief Turn callbacks on.

--- a/src/chai/ArrayManager.inl
+++ b/src/chai/ArrayManager.inl
@@ -30,24 +30,24 @@ void* ArrayManager::reallocate(void* pointer, size_t elems, PointerRecord* point
 {
   ExecutionSpace my_space = CPU;
 
-  for (int space = CPU; space < NUM_EXECUTION_SPACES; ++space) {
-    if (pointer_record->m_pointers[space] == pointer) {
-      my_space = static_cast<ExecutionSpace>(space);
+  for (int iSpace = CPU; iSpace < NUM_EXECUTION_SPACES; ++iSpace) {
+    if (pointer_record->m_pointers[iSpace] == pointer) {
+      my_space = static_cast<ExecutionSpace>(iSpace);
       break;
     }
   }
 
-  for (int space = CPU; space < NUM_EXECUTION_SPACES; ++space) {
-    if (!pointer_record->m_owned[space]) {
+  for (int iSpace = CPU; iSpace < NUM_EXECUTION_SPACES; ++iSpace) {
+    if (!pointer_record->m_owned[iSpace]) {
       CHAI_LOG(Debug, "Cannot reallocate unowned pointer");
       return pointer_record->m_pointers[my_space];
     }
   }
 
   // Call callback with ACTION_FREE before changing the size
-  for (int space = CPU; space < NUM_EXECUTION_SPACES; ++space) {
-    void* space_ptr = pointer_record->m_pointers[space];
-    int actualSpace = space;
+  for (int iSpace = CPU; iSpace < NUM_EXECUTION_SPACES; ++iSpace) {
+    void* space_ptr = pointer_record->m_pointers[iSpace];
+    int actualSpace = iSpace;
     if (space_ptr) {
 #if defined(CHAI_ENABLE_UM)
       if (space_ptr == pointer_record->m_pointers[UM]) {
@@ -75,10 +75,10 @@ void* ArrayManager::reallocate(void* pointer, size_t elems, PointerRecord* point
   // only copy however many bytes overlap
   size_t num_bytes_to_copy = std::min(old_size, new_size);
 
-  for (int space = CPU; space < NUM_EXECUTION_SPACES; ++space) {
-    void* space_ptr = pointer_record->m_pointers[space];
-    auto alloc = m_resource_manager.getAllocator(pointer_record->m_allocators[space]);
-    int actualSpace = space;
+  for (int iSpace = CPU; iSpace < NUM_EXECUTION_SPACES; ++iSpace) {
+    void* space_ptr = pointer_record->m_pointers[iSpace];
+    auto alloc = m_resource_manager.getAllocator(pointer_record->m_allocators[iSpace]);
+    int actualSpace = iSpace;
 
     if (space_ptr) {
 #if defined(CHAI_ENABLE_UM)
@@ -94,7 +94,7 @@ void* ArrayManager::reallocate(void* pointer, size_t elems, PointerRecord* point
       } else
 #endif
       {
-        alloc = m_resource_manager.getAllocator(pointer_record->m_allocators[space]);
+        alloc = m_resource_manager.getAllocator(pointer_record->m_allocators[iSpace]);
       }
       void* new_ptr = alloc.allocate(new_size);
 #if CHAI_ENABLE_ZERO_INITIALIZED_MEMORY
@@ -152,6 +152,11 @@ void ArrayManager::copy(void * dst, void * src, size_t size) {
 CHAI_INLINE
 umpire::Allocator ArrayManager::getAllocator(ExecutionSpace space) {
    return *m_allocators[space];
+}
+
+CHAI_INLINE
+umpire::Allocator ArrayManager::getAllocator(int allocator_id) {
+   return m_resource_manager.getAllocator(allocator_id);
 }
 
 CHAI_INLINE

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -21,6 +21,7 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray():
   m_size(0),
   m_offset(0),
   m_pointer_record(nullptr),
+  m_allocator_id(-1),
   m_is_slice(false)
 {
 #if !defined(CHAI_DEVICE_COMPILE)
@@ -89,6 +90,7 @@ CHAI_HOST ManagedArray<T>::ManagedArray(PointerRecord* record, ExecutionSpace sp
   m_size(record->m_size),
   m_offset(0),
   m_pointer_record(record),
+  m_allocator_id(-1),
   m_is_slice(false)
 {
    m_resource_manager = ArrayManager::getInstance();
@@ -107,6 +109,7 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(ManagedArray const& other):
   m_size(other.m_size),
   m_offset(other.m_offset),
   m_pointer_record(other.m_pointer_record),
+  m_allocator_id(-1),
   m_is_slice(other.m_is_slice)
 {
 #if !defined(CHAI_DEVICE_COMPILE)
@@ -129,6 +132,7 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(T* data, ArrayManager* array_mana
   m_size(elems*sizeof(T)),
   m_offset(0),
   m_pointer_record(pointer_record),
+  m_allocator_id(-1),
   m_is_slice(false)
 {
 #if !defined(CHAI_DEVICE_COMPILE)
@@ -171,14 +175,11 @@ CHAI_HOST void ManagedArray<T>::allocate(
        m_pointer_record->m_user_callback = cback;
        m_size = elems*sizeof(T);
        m_pointer_record->m_size = m_size;
-
-       if (space != NONE) {
-         m_resource_manager->allocate(m_pointer_record, space);
-         m_active_base_pointer = static_cast<T*>(m_pointer_record->m_pointers[space]);
-       } else {
-         m_active_base_pointer = nullptr;
-         m_pointer_record->m_pointers[space] = nullptr;
+       if (space == NONE) {
+         space = chai::ArrayManager::getInstance()->getDefaultAllocationSpace();
        }
+       m_resource_manager->allocate(m_pointer_record, space);
+       m_active_base_pointer = static_cast<T*>(m_pointer_record->m_pointers[space]);
        m_active_pointer = m_active_base_pointer; // Cannot be a slice
 
        // if T is a CHAICopyable, then it is important to initialize all the
@@ -231,8 +232,7 @@ CHAI_HOST void ManagedArray<T>::reallocate(size_t elems)
 
       m_size = elems*sizeof(T);
       m_active_base_pointer =
-        static_cast<T*>(m_resource_manager->reallocate<T>(m_active_base_pointer, elems,
-                                                        m_pointer_record));
+        static_cast<T*>(m_resource_manager->reallocate<T>(m_active_base_pointer, elems, m_pointer_record));
       m_active_pointer = m_active_base_pointer; // Cannot be a slice
  
       // if T is a CHAICopyable, then it is important to initialize all the new
@@ -271,11 +271,12 @@ CHAI_HOST void ManagedArray<T>::free(ExecutionSpace space)
     m_active_pointer = nullptr;
     m_active_base_pointer = nullptr;
 
-    m_size = 0;
-    m_offset = 0;
     // The call to m_resource_manager::free, above, has deallocated m_pointer_record if space == NONE.
+    // It's also freed all pointers, so our size and offset should be reset
     if (space == NONE) {
        m_pointer_record = &ArrayManager::s_null_record;
+       m_size = 0;
+       m_offset = 0;
     }
   } else {
     CHAI_LOG(Debug, "Cannot free a slice!");
@@ -409,20 +410,6 @@ template<typename Idx>
 CHAI_INLINE
 CHAI_HOST_DEVICE T& ManagedArray<T>::operator[](const Idx i) const {
   return m_active_pointer[i];
-}
-
-template<typename T>
-CHAI_HOST_DEVICE T*
-ManagedArray<T>::getActiveBasePointer() const
-{
-  return m_active_base_pointer;
-}
-
-template<typename T>
-CHAI_HOST_DEVICE T*
-ManagedArray<T>::getActivePointer() const
-{
-  return m_active_pointer;
 }
 
 template<typename T>

--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -23,12 +23,14 @@ CHAI_INLINE ManagedArray<T>::ManagedArray(
     std::initializer_list<umpire::Allocator> allocators)
     : ManagedArray()
 {
-  if (m_pointer_record) {
-     int i = 0;
-
-     for (const auto& space : spaces) {
-       m_pointer_record->m_allocators[space] = allocators.begin()[i++].getId();
-     }
+  int i = 0;
+  auto allocators_begin = allocators.begin();
+  auto default_space = chai::ArrayManager::getInstance()->getDefaultAllocationSpace();
+  for (const auto& space : spaces) {
+    if (space == default_space) {
+       m_allocator_id = allocators_begin[i].getId();
+    }
+    ++i;
   }
 }
 
@@ -42,7 +44,15 @@ ManagedArray<T>::ManagedArray(
   ManagedArray(spaces, allocators)
 {
   m_size = elems*sizeof(T);
-  this->allocate(elems, space);
+  int i = 0;
+  auto allocators_begin = allocators.begin();
+  for (const auto& s : spaces) {
+     if (s == space) {
+       m_allocator_id = allocators_begin[i].getId();
+     }
+     ++i;
+  }
+  this->allocate(elems);
 }
 
 template<typename T>
@@ -68,6 +78,7 @@ CHAI_INLINE CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(std::nullptr_t)
       m_size(0),
       m_offset(0),
       m_pointer_record(nullptr),
+      m_allocator_id(-1),
       m_is_slice(false)
 {
 }
@@ -82,6 +93,7 @@ CHAI_HOST ManagedArray<T>::ManagedArray(PointerRecord* record, ExecutionSpace sp
   m_size(record->m_size),
   m_offset(0),
   m_pointer_record(nullptr),
+  m_allocator_id(-1),
   m_is_slice(!record->m_owned[space])
 {
 }
@@ -100,21 +112,14 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(T* data,
   m_active_base_pointer(data),
   m_resource_manager(array_manager),
   m_size(elems*sizeof(T)),
-  m_pointer_record(pointer_record)
+  m_pointer_record(pointer_record),
+  m_allocator_id(-1)
 {
+   if (pointer_record) {
+      m_allocator_id = pointer_record->m_allocators[pointer_record->m_last_space];
+   }
 }
 
-template <typename T>
-CHAI_HOST_DEVICE T* ManagedArray<T>::getActiveBasePointer() const
-{
-  return m_active_base_pointer;
-}
-
-template <typename T>
-CHAI_HOST_DEVICE T* ManagedArray<T>::getActivePointer() const
-{
-  return m_active_pointer;
-}
 
 template <typename T>
 CHAI_HOST_DEVICE T* ManagedArray<T>::data() const
@@ -163,24 +168,31 @@ CHAI_HOST void ManagedArray<T>::allocate(size_t elems,
                                          ExecutionSpace space,
                                          const UserCallback&) {
   if (!m_is_slice) {
+     if (m_allocator_id == -1) {
+#if defined(CHAI_THIN_GPU_ALLOCATE)
+       if (space == NONE) {
+          space = chai::ArrayManager::getInstance()->getDefaultAllocationSpace();
+       }
+
+#elif defined(CHAI_ENABLE_UM)
+       space = chai::UM;
+#else
+       space = chai::CPU;
+#endif
+
+       m_allocator_id = chai::ArrayManager::getInstance()->getAllocatorId(space);
+     }
+
      if (elems > 0) {
-       (void) space; // Quiet compiler warning when CHAI_LOG does nothing
        CHAI_LOG(Debug, "Allocating array of size " << elems
                                                    << " in space "
                                                    << space);
 
+       auto allocator = chai::ArrayManager::getInstance()->getAllocator(m_allocator_id);
        m_size = elems*sizeof(T);
-
-     #if defined(CHAI_THIN_GPU_ALLOCATE)
-       m_active_pointer = (T*) chai::ArrayManager::getInstance()->getAllocator(chai::GPU).allocate(m_size);
-     #elif defined(CHAI_ENABLE_UM)
-       gpuMallocManaged(&m_active_pointer, m_size);
-     #else // not CHAI_ENABLE_UM
-       m_active_pointer = static_cast<T*>(malloc(sizeof(T) * elems));
-     #endif
+       m_active_pointer = (T*) allocator.allocate(m_size);
 
        CHAI_LOG(Debug, "m_active_ptr allocated at address: " << m_active_pointer);
-     
      }
      else {
         m_active_pointer = nullptr;
@@ -190,6 +202,7 @@ CHAI_HOST void ManagedArray<T>::allocate(size_t elems,
   else {
     CHAI_LOG(Debug, "Attempted to allocate slice!");
   }
+
   m_active_base_pointer = m_active_pointer;
 }
 
@@ -198,41 +211,36 @@ CHAI_INLINE
 CHAI_HOST void ManagedArray<T>::reallocate(size_t new_elems)
 {
   if (!m_is_slice) {
-    CHAI_LOG(Debug, "Reallocating array of size " << m_size*sizeof(T)
-                                                  << " with new size"
-                                                  << new_elems*sizeof(T));
-
-    T* new_ptr = nullptr;
-
-  #if defined(CHAI_THIN_GPU_ALLOCATE)
-    auto allocator = chai::ArrayManager::getInstance()->getAllocator(chai::GPU);
-    if (new_elems > 0) {
-        new_ptr = (T*) allocator.allocate(sizeof(T) * new_elems);
-        ArrayManager::getInstance()->syncIfNeeded();
-        chai::gpuMemcpy(new_ptr, m_active_pointer, std::min(m_size, new_elems*sizeof(T)), gpuMemcpyDefault);
-        registerTouch(chai::GPU);
+    // reallocating a nullptr is equivalent to an allocate
+    if (m_size == 0 && m_active_base_pointer == nullptr) {
+      return allocate(new_elems);
     }
-    allocator.deallocate(m_active_pointer);
-  #elif defined(CHAI_ENABLE_UM)
-    if (new_elems > 0) {
-       gpuMallocManaged(&new_ptr, sizeof(T) * new_elems);
-       gpuMemcpy(new_ptr, m_active_pointer, std::min(new_elems*sizeof(T), m_size), gpuMemcpyDefault);
-    }
-    gpuFree(m_active_pointer);
-  #else  // not CHAI_ENABLE_UM
-    if (new_elems > 0) {
-       new_ptr = static_cast<T*>(realloc(m_active_pointer, sizeof(T) * new_elems));
-    }
-    else {
-       ::free((void *)m_active_pointer);
-    }
-  #endif
 
-    m_size= new_elems*sizeof(T);
-    m_active_pointer = new_ptr;
-    m_active_base_pointer = m_active_pointer;
+    if (m_size != new_elems*sizeof(T)) {
+       CHAI_LOG(Debug, "Reallocating array of size " << m_size*sizeof(T)
+                                                     << " with new size"
+                                                     << new_elems*sizeof(T));
 
-    CHAI_LOG(Debug, "m_active_ptr reallocated at address: " << m_active_pointer);
+       T* new_ptr = nullptr;
+
+       auto arrayManager = ArrayManager::getInstance();
+       auto allocator = arrayManager->getAllocator(m_allocator_id);
+
+       if (new_elems > 0) {
+           new_ptr = (T*) allocator.allocate(sizeof(T) * new_elems);
+           arrayManager->syncIfNeeded();
+           arrayManager->copy(new_ptr, m_active_pointer, std::min(m_size, new_elems*sizeof(T)));
+           registerTouch(chai::GPU);
+       }
+
+       allocator.deallocate(m_active_pointer);
+
+       m_size = new_elems*sizeof(T);
+       m_active_pointer = new_ptr;
+       m_active_base_pointer = m_active_pointer;
+
+       CHAI_LOG(Debug, "m_active_ptr reallocated at address: " << m_active_pointer);
+    }
   }
   else {
     CHAI_LOG(Debug, "Attempted to realloc slice!");
@@ -240,27 +248,25 @@ CHAI_HOST void ManagedArray<T>::reallocate(size_t new_elems)
 }
 
 template <typename T>
-CHAI_INLINE CHAI_HOST void ManagedArray<T>::free(ExecutionSpace space)
+CHAI_INLINE CHAI_HOST void ManagedArray<T>::free(ExecutionSpace /*space*/ )
 {
-  if (!m_is_slice) {
-    if (space == CPU || space == NONE) {
-#if defined(CHAI_THIN_GPU_ALLOCATE)
-      if (m_active_pointer) {
-         auto allocator = chai::ArrayManager::getInstance()->getAllocator(chai::GPU);
-         allocator.deallocate((void *)m_active_pointer);
-      }
-#elif defined(CHAI_ENABLE_UM)
-      chai::gpuFree(m_active_pointer);
-#else
-      ::free((void *)m_active_pointer);
-#endif
-      m_active_pointer = nullptr;
-      m_active_base_pointer = nullptr;
-      m_size = 0;
-    }
-  }
-  else {
-    CHAI_LOG(Debug, "tried to free slice!");
+  if (m_allocator_id != -1) {
+     if (!m_is_slice) {
+       auto arrayManager = ArrayManager::getInstance();
+
+       if (m_active_pointer) {
+          auto allocator = arrayManager->getAllocator(m_allocator_id);
+          allocator.deallocate((void *)m_active_pointer);
+       }
+
+       m_active_pointer = nullptr;
+       m_active_base_pointer = nullptr;
+       m_size = 0;
+       m_allocator_id = -1;
+     }
+     else {
+       CHAI_LOG(Debug, "tried to free slice!");
+     }
   }
 }
 
@@ -353,6 +359,7 @@ CHAI_INLINE CHAI_HOST_DEVICE ManagedArray<T>& ManagedArray<T>::operator=(std::nu
   m_active_base_pointer = from;
   m_size = 0;
   m_is_slice = false;
+  m_allocator_id = -1;
   return *this;
 }
 


### PR DESCRIPTION
When CHAI is configured with -DCHAI_DISABLE_RM=TRUE, allocators passed to the constructor of ManagedArray will now be respected. Previously, the only way to set allocators for this mode was by setting them globally in the ArrayManager.

Also fixes a hang when eviction is used.

Closes #294 

This fix is from @robinson96. Thanks, Peter!
@liu15 also contributed to the hang fix. Thanks, Ben!