### PR TITLE
Remove ManagedArray::getActiveBasePointer

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,7 @@ The format of this file is based on [Keep a Changelog](http://keepachangelog.com
 - Adds missing synchronize when using pinned memory.
 
 ### Removed
+- Removes ManagedArray::getActiveBasePointer method.
 - Removes deprecated ManagedArray::getPointer method. Use ManagedArray::data instead.
 - Removes ManagedArray::incr and ManagedArray::decr methods. Use ManagedArray::pick and ManagedArray::set instead.
 - Removes optional support for implicitly casting between raw pointers and ManagedArrays (CHAI\_ENABLE\_IMPLICIT\_CONVERSIONS). Use makeManagedArray and ManagedArray::data to perform explicit conversions instead.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,9 @@ The format of this file is based on [Keep a Changelog](http://keepachangelog.com
 
 ## [Unreleased] - Release date yyyy-mm-dd
 
+### Added
+- Added a ManagedArray::clone function and deprecated chai::deepCopy.
+
 ### Fixed
 - Fixes reallocate when using pinned or unified memory.
 - Adds missing synchronize when using pinned memory.

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -178,12 +178,6 @@ public:
 
   /*!
    * \brief get access to m_active_pointer
-   * @return a copy of m_active_base_pointer
-   */
-  CHAI_HOST_DEVICE T* getActiveBasePointer() const;
-
-  /*!
-   * \brief get access to m_active_pointer
    * @return a copy of m_active_pointer
    */
   CHAI_HOST_DEVICE T* getActivePointer() const;
@@ -484,7 +478,7 @@ ManagedArray<T> makeManagedArray(T* data,
 template <typename T>
 ManagedArray<T> deepCopy(ManagedArray<T> const& array)
 {
-  T* data_ptr = array.getActiveBasePointer();
+  T* data_ptr = m_active_base_pointer;
 
   ArrayManager* manager = ArrayManager::getInstance();
 

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -108,13 +108,7 @@ public:
    *
    * \return A deep copy of the current ManagedArray.
    */
-  ManagedArray clone()
-  {
-    ArrayManager* manager = ArrayManager::getInstance();
-    const PointerRecord* record = manager->getPointerRecord(m_active_base_pointer);
-    PointerRecord* copy_record = manager->deepCopyRecord(record);
-    return ManagedArray(copy_record, copy_record->m_last_space);
-  }
+  ManagedArray clone();
 
   /*!
    * \brief Construct a ManagedArray from a nullptr.

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -475,12 +475,6 @@ ManagedArray<T> makeManagedArray(T* data,
 }
 
 template <typename T>
-CHAI_HOST_DEVICE T* ManagedArray<T>::getActiveBasePointer() const
-{
-  return m_active_base_pointer;
-}
-
-template <typename T>
 CHAI_HOST_DEVICE T* ManagedArray<T>::getActivePointer() const
 {
   return m_active_pointer;

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -103,6 +103,20 @@ public:
   CHAI_HOST_DEVICE ManagedArray(ManagedArray const& other);
 
   /*!
+   * \brief Create a deep copy of the current ManagedArray with a single
+   * allocation in the active space of the current ManagedArray.
+   *
+   * \return A deep copy of the current ManagedArray.
+   */
+  ManagedArray clone()
+  {
+    ArrayManager* manager = ArrayManager::getInstance();
+    const PointerRecord* record = manager->getPointerRecord(m_active_base_pointer);
+    PointerRecord* copy_record = manager->deepCopyRecord(record);
+    return ManagedArray(copy_record, copy_record->m_last_space);
+  }
+
+  /*!
    * \brief Construct a ManagedArray from a nullptr.
    */
   CHAI_HOST_DEVICE ManagedArray(std::nullptr_t other);
@@ -476,17 +490,10 @@ ManagedArray<T> makeManagedArray(T* data,
  * \return A copy of the given ManagedArray.
  */
 template <typename T>
+[[deprecated("Use ManagedArray<T>::clone instead.")]]
 ManagedArray<T> deepCopy(ManagedArray<T> const& array)
 {
-  T* data_ptr = m_active_base_pointer;
-
-  ArrayManager* manager = ArrayManager::getInstance();
-
-  PointerRecord const* record = manager->getPointerRecord(data_ptr);
-
-  PointerRecord* copy_record = manager->deepCopyRecord(record);
-
-  return ManagedArray<T>(copy_record, copy_record->m_last_space);
+  return array.clone();
 }
 
 template <typename T>

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -147,6 +147,15 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(T* data, ArrayManager* array_mana
 #endif
 }
 
+template <typename T>
+CHAI_INLINE
+ManagedArray<T> ManagedArray<T>::clone()
+{
+  ArrayManager* manager = ArrayManager::getInstance();
+  const PointerRecord* record = manager->getPointerRecord(m_active_base_pointer);
+  PointerRecord* copy_record = manager->deepCopyRecord(record);
+  return ManagedArray(copy_record, copy_record->m_last_space);
+}
 
 template<typename T>
 CHAI_INLINE

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -413,13 +413,6 @@ CHAI_HOST_DEVICE T& ManagedArray<T>::operator[](const Idx i) const {
 
 template<typename T>
 CHAI_HOST_DEVICE T*
-ManagedArray<T>::getActiveBasePointer() const
-{
-  return m_active_base_pointer;
-}
-
-template<typename T>
-CHAI_HOST_DEVICE T*
 ManagedArray<T>::getActivePointer() const
 {
   return m_active_pointer;

--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -105,12 +105,6 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(T* data,
 }
 
 template <typename T>
-CHAI_HOST_DEVICE T* ManagedArray<T>::getActiveBasePointer() const
-{
-  return m_active_base_pointer;
-}
-
-template <typename T>
 CHAI_HOST_DEVICE T* ManagedArray<T>::getActivePointer() const
 {
   return m_active_pointer;

--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -125,12 +125,13 @@ CHAI_INLINE
 ManagedArray<T> ManagedArray<T>::clone()
 {
   ManagedArray<T> result;
-#if 0
-  ArrayManager* manager = ArrayManager::getInstance();
-  const PointerRecord* record = manager->getPointerRecord(m_active_base_pointer);
-  PointerRecord* copy_record = manager->deepCopyRecord(record);
-  return ManagedArray(copy_record, copy_record->m_last_space);
-#endif
+  result.m_allocator_id = m_allocator_id;
+  result.allocate(size());
+  auto arrayManager = ArrayManager::getInstance();
+  arrayManager->syncIfNeeded();
+  arrayManager->copy(result.m_active_pointer, m_active_pointer, m_size);
+  result.registerTouch(chai::GPU);
+  return result;
 }
 
 template <typename T>

--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -105,6 +105,19 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(T* data,
 }
 
 template <typename T>
+CHAI_INLINE
+ManagedArray<T> ManagedArray<T>::clone()
+{
+  ManagedArray<T> result;
+#if 0
+  ArrayManager* manager = ArrayManager::getInstance();
+  const PointerRecord* record = manager->getPointerRecord(m_active_base_pointer);
+  PointerRecord* copy_record = manager->deepCopyRecord(record);
+  return ManagedArray(copy_record, copy_record->m_last_space);
+#endif
+}
+
+template <typename T>
 CHAI_HOST_DEVICE T* ManagedArray<T>::getActivePointer() const
 {
   return m_active_pointer;

--- a/tests/integration/managed_array_tests.cpp
+++ b/tests/integration/managed_array_tests.cpp
@@ -1703,7 +1703,7 @@ GPU_TEST(ManagedArray, MoveInnerToDeviceAgain)
 #endif  // CHAI_DISABLE_RM
 #endif  // defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
 
-TEST(ManagedArray, DeepCopy)
+TEST(ManagedArray, Clone)
 {
   chai::ManagedArray<float> array(10);
   ASSERT_EQ(array.size(), 10u);
@@ -1726,7 +1726,7 @@ TEST(ManagedArray, DeepCopy)
 }
 
 #if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
-GPU_TEST(ManagedArray, DeviceDeepCopy)
+GPU_TEST(ManagedArray, DeviceClone)
 {
   chai::ManagedArray<float> array(10, chai::GPU);
   ASSERT_EQ(array.size(), 10u);

--- a/tests/integration/managed_array_tests.cpp
+++ b/tests/integration/managed_array_tests.cpp
@@ -1703,8 +1703,6 @@ GPU_TEST(ManagedArray, MoveInnerToDeviceAgain)
 #endif  // CHAI_DISABLE_RM
 #endif  // defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
 
-
-#ifndef CHAI_DISABLE_RM
 TEST(ManagedArray, DeepCopy)
 {
   chai::ManagedArray<float> array(10);
@@ -1712,7 +1710,7 @@ TEST(ManagedArray, DeepCopy)
 
   forall(sequential(), 0, 10, [=](int i) { array[i] = i; });
 
-  chai::ManagedArray<float> copy = chai::deepCopy(array);
+  chai::ManagedArray<float> copy = array.clone();
   ASSERT_EQ(copy.size(), 10u);
 
   forall(sequential(), 0, 10, [=](int i) { array[i] = -5.5 * i; });
@@ -1726,10 +1724,8 @@ TEST(ManagedArray, DeepCopy)
   copy.free();
   assert_empty_map(true);
 }
-#endif
 
 #if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
-#ifndef CHAI_DISABLE_RM
 GPU_TEST(ManagedArray, DeviceDeepCopy)
 {
   chai::ManagedArray<float> array(10, chai::GPU);
@@ -1737,7 +1733,7 @@ GPU_TEST(ManagedArray, DeviceDeepCopy)
 
   forall(gpu(), 0, 10, [=] __device__(int i) { array[i] = i; });
 
-  chai::ManagedArray<float> copy = chai::deepCopy(array);
+  chai::ManagedArray<float> copy = array.clone();
   ASSERT_EQ(copy.size(), 10u);
 
   forall(gpu(), 0, 10, [=] __device__(int i) { array[i] = -5.5 * i; });
@@ -1752,6 +1748,7 @@ GPU_TEST(ManagedArray, DeviceDeepCopy)
   assert_empty_map(true);
 }
 
+#ifndef CHAI_DISABLE_RM
 GPU_TEST(ManagedArray, CopyConstruct)
 {
   const int expectedValue = rand();


### PR DESCRIPTION
This function breaks encapsulation. As far as I can tell, it is only used in one place in CARE, and that usage can be replaced with much simpler code.

Add ManagedArray::clone (necessary to be able to remove getActiveBasePointer) and deprecate the chai::deepCopy free function.