### PR TITLE
Restore getActiveBasePointer

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,7 +25,6 @@ The format of this file is based on [Keep a Changelog](http://keepachangelog.com
 - Now respects allocators passed to ManagedArray constructors when CHAI\_DISABLE\_RM=TRUE.
 
 ### Removed
-- Removes ManagedArray::getActiveBasePointer method.
 - Removes deprecated ManagedArray::getPointer method. Use ManagedArray::data instead.
 - Removes ManagedArray::incr and ManagedArray::decr methods. Use ManagedArray::pick and ManagedArray::set instead.
 - Removes optional support for implicitly casting between raw pointers and ManagedArrays (CHAI\_ENABLE\_IMPLICIT\_CONVERSIONS). Use makeManagedArray and ManagedArray::data to perform explicit conversions instead.

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -183,6 +183,12 @@ public:
   CHAI_HOST_DEVICE T& operator[](const Idx i) const;
 
   /*!
+   * \brief get access to m_active_base_pointer
+   * @return a copy of m_active_base_pointer
+   */
+  CHAI_HOST_DEVICE T* getActiveBasePointer() const;
+
+  /*!
    * \brief get access to m_active_pointer
    * @return a copy of m_active_pointer
    */
@@ -472,6 +478,12 @@ ManagedArray<T> makeManagedArray(T* data,
 #endif
 
   return array;
+}
+
+template <typename T>
+CHAI_HOST_DEVICE T* ManagedArray<T>::getActiveBasePointer() const
+{
+  return m_active_base_pointer;
 }
 
 template <typename T>


### PR DESCRIPTION
Removing getActiveBasePointer broke at least one user, so we're bringing it back for now.