### PR TITLE
Update packages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,10 @@ variables:
 # at the same location whoever triggers a pipeline.
   CUSTOM_CI_BUILDS_DIR: /usr/workspace/umdev/gitlab-runner
 # Tells Gitlab to recursively update the submodules when cloning the project.
-  GIT_SUBMODULE_STRATEGY: recursive
+  GIT_SUBMODULE_STRATEGY: normal
+  GIT_SUBMODULE_DEPTH: 1
+  GIT_SUBMODULE_UPDATE_FLAGS: --jobs 2
+  GIT_SUBMODULE_PATHS: scripts/radiuss-spack-configs scripts/uberenv
 
 ##### PROJECT VARIABLES
 # We build the projects in the CI clone directory (used in

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,7 @@ variables:
 # Use the service user workspace. Solves permission issues, stores everything
 # at the same location whoever triggers a pipeline.
   CUSTOM_CI_BUILDS_DIR: /usr/workspace/umdev/gitlab-runner
-# Tells Gitlab to recursively update the submodules when cloning the project.
+# Submodules: We don't need to fetch dependencies handled by Spack.
   GIT_SUBMODULE_STRATEGY: normal
   GIT_SUBMODULE_DEPTH: 1
   GIT_SUBMODULE_UPDATE_FLAGS: --jobs 2

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -7,6 +7,5 @@
 "spack_branch": "woptim/rsc-2025-03-0",
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/packages",
-"spack_concretizer": "clingo",
 "spack_setup_clingo": false
 }

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "woptim/rsc-2025-03-0",
+"spack_branch": "rsc-2025-03-0",
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/packages",
 "spack_setup_clingo": false

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "develop-2025-02-09",
+"spack_branch": "woptim/rsc-2025-03-0",
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/packages",
 "spack_concretizer": "clingo",

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "rsc-2025-03-0",
+"spack_commit": "280017a9ba3f6a969743deca0eebc96e7c0e5cfd",
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/packages",
 "spack_setup_clingo": false

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -269,7 +269,7 @@ then
 
     timed_message "Preparing tests xml reports for export"
     tree Testing
-    xsltproc -o junit.xml ${project_dir}/blt/tests/ctest-to-junit.xsl Testing/*/Test.xml
+    xsltproc -o junit.xml ${project_dir}/scripts/radiuss-spack-configs/utilities/ctest-to-junit.xsl Testing/*/Test.xml
     mv junit.xml ${project_dir}/junit.xml
 
     if grep -q "Errors while running CTest" ./tests_output.txt


### PR DESCRIPTION
- Update RSC (see https://github.com/LLNL/radiuss-spack-configs/pull/126 for changes)
- Optimize submodule usage in GitLab.
- Use radiuss-spack-configs version of ctest-to-junit conversion utility to avoid having to fetch BLT as a submodule.
- Point at specific commit in Spack _before compiler as nodes feature_.
- Update Spack mirror oci options syntax
- Set BLT variable to allow mpi tests to overlap parent allocation (do not run tests on another node).