### PR TITLE
Fix set() for uninitialized managed arrays

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,9 @@ The format of this file is based on [Keep a Changelog](http://keepachangelog.com
 ### Changed
 - Use memcpy instead of umpire copy for CPU-only thin managed array realloc (allows tracking to be disabled).
 
+### Fixed
+- Fixed ManagedArray::set when the initial space is not CPU in the two memory space configuration.
+
 ## [Version 2025.03.0] - Release date 2025-03-19
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,7 +19,7 @@ The format of this file is based on [Keep a Changelog](http://keepachangelog.com
 - Use memcpy instead of umpire copy for CPU-only thin managed array realloc (allows tracking to be disabled).
 
 ### Fixed
-- Fixed ManagedArray::set when the initial space is not CPU in the two memory space configuration.
+- Fixed ManagedArray::set when CHAI\_DISABLE\_RM=OFF and the initial space is not CPU
 
 ## [Version 2025.03.0] - Release date 2025-03-19
 

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -363,7 +363,13 @@ CHAI_HOST_DEVICE void ManagedArray<T>::set(size_t i, T val) const {
     #endif
 
     if (m_pointer_record->m_last_space == NONE) {
-       m_pointer_record->m_last_space = CPU;
+       // Use the first non-null pointer if managed array was not used yet
+       for (int s = CPU; s < NUM_EXECUTION_SPACES; ++s) {
+          if (m_pointer_record->m_pointers[s] != nullptr) {
+             m_pointer_record->m_last_space = static_cast<ExecutionSpace>(s);
+             break;
+          }
+       }
     }
 
     m_pointer_record->m_touched[m_pointer_record->m_last_space] = true;


### PR DESCRIPTION
Fix set() for uninitialized managed arrays if the default space is not CPU. This is for the case when the resource manager is enabled.