### PR TITLE
ArrayManager Memory Leak.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,7 +19,8 @@ The format of this file is based on [Keep a Changelog](http://keepachangelog.com
 - Use memcpy instead of umpire copy for CPU-only thin managed array realloc (allows tracking to be disabled).
 
 ### Fixed
-- Fixed ManagedArray::set when CHAI\_DISABLE\_RM=OFF and the initial space is not CPU
+- Fixed ManagedArray::set when CHAI\_DISABLE\_RM=OFF and the initial space is not CPU.
+- Fixed memory leaks in ArrayManager.
 
 ## [Version 2025.03.0] - Release date 2025-03-19
 

--- a/src/chai/ArrayManager.cpp
+++ b/src/chai/ArrayManager.cpp
@@ -80,6 +80,13 @@ ArrayManager::ArrayManager() :
 #endif
 }
 
+ArrayManager::~ArrayManager() {
+  for (size_t i = 0; i < NUM_EXECUTION_SPACES; ++i) {
+    if (m_allocators[i])
+      delete m_allocators[i];
+  }
+}
+
 void ArrayManager::registerPointer(
    PointerRecord* record,
    ExecutionSpace space,

--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -447,6 +447,12 @@ protected:
    */
   ArrayManager();
 
+  /*!
+   * \brief Destruct a new ArrayManager.
+   *
+   * The destructor is a protected member.
+   */
+  ~ArrayManager();
 
 
 private:


### PR DESCRIPTION
Valgrind memcheck was reporting some memory leaks from ArrayManager allocators that need to be cleaned up on destruction.