### PR TITLE
Use memcpy instead of umpire copy for CPU-only thin managed array realloc

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,11 @@ in this file.
 
 The format of this file is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] - Release date yyyy-mm-dd
+
+### Changed
+- Use memcpy instead of umpire copy for CPU-only thin managed array realloc (allows tracking to be disabled).
+
 ## [Version 2025.03.0] - Release date 2025-03-19
 
 ### Added

--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -242,7 +242,11 @@ CHAI_HOST void ManagedArray<T>::reallocate(size_t new_elems)
        if (new_elems > 0) {
            new_ptr = (T*) allocator.allocate(sizeof(T) * new_elems);
            arrayManager->syncIfNeeded();
+#if !defined(CHAI_THIN_GPU_ALLOCATE)
+           std::memcpy(new_ptr, m_active_pointer, std::min(m_size, new_elems*sizeof(T)));
+#else
            arrayManager->copy(new_ptr, m_active_pointer, std::min(m_size, new_elems*sizeof(T)));
+#endif
            registerTouch(chai::GPU);
        }
 


### PR DESCRIPTION
This allows pointer tracking to be disabled, if desired.