### PR TITLE
Fix default argument for callback

### DIFF
--- a/host-configs/lc/toss_4_x86_64_ib/gcc.cmake
+++ b/host-configs/lc/toss_4_x86_64_ib/gcc.cmake
@@ -1,0 +1,14 @@
+##############################################################################
+# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
+# project contributors. See the CHAI LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+##############################################################################
+
+# Set up software versions
+set(GCC_VERSION "11.2.1" CACHE PATH "")
+
+# Set up compilers
+set(COMPILER_BASE "/usr/tce/packages/gcc/gcc-${GCC_VERSION}-magic" CACHE PATH "")
+set(CMAKE_C_COMPILER "${COMPILER_BASE}/bin/gcc" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "${COMPILER_BASE}/bin/g++" CACHE PATH "")

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -43,6 +43,20 @@ class CHAICopyable
 };
 
 /*!
+ * \class DefaultCallback
+ *
+ * \brief A functor object that serves as the default no-op callback.
+ *
+ * \note Previously, a lambda was used as the default argument for the
+ *       callback, but that tripped up some compilers and led to errors
+ *       of the following form:
+ *         redefinition of ‘const char _ZTSZN4chai12ManagedArrayIdE8allocateEmNS_14ExecutionSpaceERKSt8functionIFvPKNS_13PointerRecordENS_6ActionES2_EEEd_UlS6_S7_S2_E_ []’
+ */
+struct DefaultCallback {
+  void operator()(const PointerRecord*, Action, ExecutionSpace) const {}
+};
+
+/*!
  * \class ManagedArray
  *
  * \brief Provides an array-like class that automatically transfers data
@@ -126,10 +140,7 @@ public:
    */
   CHAI_HOST void allocate(size_t elems,
                           ExecutionSpace space = NONE,
-                          const UserCallback& cback =
-                          [] (const PointerRecord*, Action, ExecutionSpace) {});
-
-
+                          const UserCallback& cback = DefaultCallback());
 
   /*!
    * \brief Reallocate data for the ManagedArray.


### PR DESCRIPTION
Some compilers (e.g. gcc 11.2.1) get tripped up by the use of a lambda as a default argument in a header file. I believe it has to do with possible ODR violations since no two lambdas are the same type. Using a functor object instead works around the issue. It should still be inlined.