### PR TITLE
Fix thin version of a ManagedArray constructor

### DIFF
--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -52,7 +52,7 @@ ManagedArray<T>::ManagedArray(
      }
      ++i;
   }
-  this->allocate(elems);
+  this->allocate(elems, space);
 }
 
 template<typename T>


### PR DESCRIPTION
Forward the execution space argument to the allocate call. I don't believe it is actually needed, but there might be some corner case.