### PR TITLE
Add experimental ManagedArraySharedPointer

### DIFF
--- a/docs/sphinx/expt/design.rst
+++ b/docs/sphinx/expt/design.rst
@@ -134,6 +134,47 @@ shallow copies.
     a[i] -= 1;  // Use CHAI data structures in the DEVICE context...
   });
 
+  a.free();
+
+-------------------------
+ManagedArraySharedPointer
+-------------------------
+
+This class provides a uniform interface for working with different types of memory
+across multiple backends. It has shared pointer semantics, meaning that copies are
+shallow, which allows this object to be passed by value to a CUDA or HIP kernel.
+When copy constructed, it queries the array manager to update the cached size and
+pointer from the array manager. Like with std::shared_ptr, the underlying memory
+will be cleaned up automatically once the last host copy is destroyed.
+
+.. code-block:: cpp
+
+  #include "chai/expt/ContextRAJAPlugin.hpp"
+  #include "chai/expt/ManagedArraySharedPointer.hpp"
+  #include "RAJA/RAJA.hpp"
+
+  static ::RAJA::util::PluginRegistry::add<chai::expt::ContextRAJAPlugin> P(
+    "CHAIContextPlugin",
+    "Plugin that integrates CHAI context management with RAJA.");
+
+  // It's recommended to use an alias so that it is easy to swap out the array manager.
+  template <typename T>
+  using ManagedArraySharedPointer = ::chai::expt::ManagedArraySharedPointer<T, UnifiedArrayManager>;
+
+  const std::size_t N = 1000000;
+  ManagedArraySharedPointer<int> a;
+  a.resize(N);
+
+  ::RAJA::forall<::RAJA::seq_exec>(::RAJA::TypedRangeSegment<int>(0, N), [=] (int i) {
+    a[i] = i;  // Use CHAI data structures in the HOST context...
+  });
+
+  constexpr int BLOCK_SIZE = 256;
+
+  ::RAJA::forall<::RAJA::cuda_exec_async<BLOCK_SIZE>>(::RAJA::TypedRangeSegment<int>(0, N), [=] __device__ (int i) {
+    a[i] -= 1;  // Use CHAI data structures in the DEVICE context...
+  });
+
 ----------------
 HostArrayManager
 ----------------

--- a/docs/sphinx/expt/design.rst
+++ b/docs/sphinx/expt/design.rst
@@ -144,8 +144,10 @@ This class provides a uniform interface for working with different types of memo
 across multiple backends. It has shared pointer semantics, meaning that copies are
 shallow, which allows this object to be passed by value to a CUDA or HIP kernel.
 When copy constructed, it queries the array manager to update the cached size and
-pointer from the array manager. Like with std::shared_ptr, the underlying memory
-will be cleaned up automatically once the last host copy is destroyed.
+pointer from the array manager. Similar to std::shared_ptr, all host copies have
+shared ownership such that when the last host copy is destroyed, it will trigger
+clean up of the underlying resources. Note that device copies are not reference
+counted since clean up cannot be triggered from the device.
 
 .. code-block:: cpp
 

--- a/src/chai/CMakeLists.txt
+++ b/src/chai/CMakeLists.txt
@@ -39,7 +39,9 @@ if(CHAI_ENABLE_EXPERIMENTAL)
     expt/ContextGuard.hpp
     expt/ContextManager.hpp
     expt/HostArrayManager.hpp
+    expt/HostSharedPointer.hpp
     expt/ManagedArrayPointer.hpp
+    expt/ManagedArraySharedPointer.hpp
     ManagedSharedPtr.hpp
     SharedPtrCounter.hpp
     SharedPtrManager.hpp

--- a/src/chai/expt/HostSharedPointer.hpp
+++ b/src/chai/expt/HostSharedPointer.hpp
@@ -1,0 +1,164 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+// project contributors. See the CHAI LICENSE file for details.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef CHAI_HOST_SHARED_POINTER_HPP
+#define CHAI_HOST_SHARED_POINTER_HPP
+
+#include "chai/config.hpp"
+#include "chai/ChaiMacros.hpp"
+#include <cstddef>
+#include <memory>
+#include <new>
+
+namespace chai::expt
+{
+  /*!
+   * \brief HostSharedPointer is a wrapper around std::shared_ptr that acts
+   *        like std::shared_ptr on the host but has no effect on the device.
+   *
+   * \tparam T The type of object contained.
+   */
+  template <typename T>
+  class HostSharedPointer
+  {
+    private:
+      using SharedPointer = std::shared_ptr<T>;
+
+    public:
+      constexpr HostSharedPointer() noexcept
+      {
+        ::new (static_cast<void*>(std::addressof(m_storage))) SharedPointer();
+      }
+
+      constexpr HostSharedPointer(std::nullptr_t) noexcept
+      {
+        ::new (static_cast<void*>(std::addressof(m_storage))) SharedPointer(nullptr);
+      }
+
+      template <typename U>
+      explicit HostSharedPointer(U* ptr)
+      {
+        ::new (static_cast<void*>(std::addressof(m_storage))) SharedPointer(ptr);
+      }
+
+      template <typename U>
+      HostSharedPointer(const HostSharedPointer<U>& other) noexcept
+      {
+        ::new (static_cast<void*>(std::addressof(m_storage))) SharedPointer(other);
+      }
+
+      CHAI_HOST_DEVICE HostSharedPointer(const HostSharedPointer& other) noexcept
+      {
+#if !defined(CHAI_DEVICE_COMPILE)
+        ::new (static_cast<void*>(std::addressof(m_storage))) SharedPointer(other.shared_ptr());
+#endif
+      }
+
+      HostSharedPointer(HostSharedPointer&& other) noexcept
+      {
+        ::new (static_cast<void*>(std::addressof(m_storage))) SharedPointer(std::move(other.shared_ptr()));
+      }
+
+      template <typename U>
+      HostSharedPointer(HostSharedPointer<U>&& other) noexcept
+      {
+        ::new (static_cast<void*>(std::addressof(m_storage))) SharedPointer(std::move(other.shared_ptr()));
+      }
+
+      CHAI_HOST_DEVICE ~HostSharedPointer()
+      {
+#if !defined(CHAI_DEVICE_COMPILE)
+        shared_ptr().~SharedPointer();
+#endif
+      }
+
+      HostSharedPointer& operator=(const HostSharedPointer& other) noexcept
+      {
+        shared_ptr() = other.shared_ptr();
+        return *this;
+      }
+
+      template <typename U>
+      HostSharedPointer& operator=(const HostSharedPointer<U>& other) noexcept
+      {
+        shared_ptr() = other.shared_ptr();
+        return *this;
+      }
+
+      HostSharedPointer& operator=(HostSharedPointer&& other) noexcept
+      {
+        shared_ptr() = other.shared_ptr();
+        return *this;
+      }
+
+      template <typename U>
+      HostSharedPointer& operator=(HostSharedPointer<U>&& other) noexcept
+      {
+        shared_ptr() = other.shared_ptr();
+        return *this;
+      }
+
+      T* get() const noexcept
+      {
+        return shared_ptr().get();
+      }
+
+      T& operator*() const noexcept
+      {
+        return *get();
+      }
+
+      T* operator->() const noexcept
+      {
+        return get();
+      }
+
+      explicit operator bool() const noexcept
+      {
+        return get() != nullptr;
+      }
+
+    private:
+      /*!
+       * \brief Raw, properly-aligned storage for the underlying std::shared_ptr<T>.
+       *
+       * The shared_ptr is constructed/destructed in-place via placement new to avoid
+       * device-side effects when copy constructed or destroyed on the device.
+       */
+      alignas(SharedPointer) std::byte m_storage[sizeof(SharedPointer)];
+
+      /*!
+       * \brief Access the underlying std::shared_ptr<T> instance.
+       *
+       * \note The std::shared_ptr<T> is stored in raw aligned storage and constructed
+       *       in-place via placement new. std::launder is used to obtain a valid
+       *       pointer to the active object.
+       *
+       * \return A mutable reference to the contained std::shared_ptr<T>.
+       */
+      SharedPointer& shared_ptr()
+      {
+        return *std::launder(reinterpret_cast<SharedPointer*>(std::addressof(m_storage)));
+      }
+
+      /*!
+       * \brief Access the underlying std::shared_ptr<T> instance (const).
+       *
+       * \note The std::shared_ptr<T> is stored in raw aligned storage and constructed
+       *       in-place via placement new. std::launder is used to obtain a valid
+       *       pointer to the active object.
+       *
+       * \return A const reference to the contained std::shared_ptr<T>.
+       */
+      const SharedPointer& shared_ptr() const
+      {
+        return *std::launder(reinterpret_cast<const SharedPointer*>(std::addressof(m_storage)));
+      }
+  };  // class HostSharedPointer
+}  // namespace chai::expt
+
+#endif  // CHAI_HOST_SHARED_POINTER_HPP

--- a/src/chai/expt/ManagedArraySharedPointer.hpp
+++ b/src/chai/expt/ManagedArraySharedPointer.hpp
@@ -21,8 +21,10 @@ namespace chai::expt
    *        across multiple backends. It has shared pointer semantics, meaning that copies are
    *        shallow, which allows this object to be passed by value to a CUDA or HIP kernel.
    *        When copy constructed, it queries the array manager to update the cached size and
-   *        pointer from the array manager. All copies have shared ownership, such that when
-   *        the last copy is destroyed, all underlying memory will be cleaned up.
+   *        pointer from the array manager. Similar to std::shared_ptr, all host copies have
+   *        shared ownership such that when the last host copy is destroyed, it will trigger
+   *        clean up of the underlying resources. Note that device copies are not reference
+   *        counted since clean up cannot be triggered from the device.
    *
    * \tparam ElementType The type of elements contained in this array.
    * \tparam ManagerType Manages the underlying memory.

--- a/src/chai/expt/ManagedArraySharedPointer.hpp
+++ b/src/chai/expt/ManagedArraySharedPointer.hpp
@@ -1,0 +1,251 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+// project contributors. See the CHAI LICENSE file for details.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef CHAI_MANAGED_ARRAY_SHARED_POINTER_HPP
+#define CHAI_MANAGED_ARRAY_SHARED_POINTER_HPP
+
+#include "chai/config.hpp"
+#include "chai/ChaiMacros.hpp"
+#include "chai/expt/HostSharedPointer.hpp"
+#include <cstddef>
+#include <type_traits>
+
+namespace chai::expt
+{
+  /*!
+   * \brief This class provides a uniform interface for working with different types of memory
+   *        across multiple backends. It has shared pointer semantics, meaning that copies are
+   *        shallow, which allows this object to be passed by value to a CUDA or HIP kernel.
+   *        When copy constructed, it queries the array manager to update the cached size and
+   *        pointer from the array manager. All copies have shared ownership, such that when
+   *        the last copy is destroyed, all underlying memory will be cleaned up.
+   *
+   * \tparam ElementType The type of elements contained in this array.
+   * \tparam ManagerType Manages the underlying memory.
+   */
+  template <typename ElementType, typename ManagerType>
+  class ManagedArraySharedPointer
+  {
+    public:
+      /**
+      * \brief Factory that constructs a ManagerType then wraps it in a ManagedArraySharedPointer.
+      *
+      * \tparam Args Argument types used to construct ManagerType.
+      * \param args Arguments forwarded to ManagerType's constructor.
+      * \return A ManagedArraySharedPointer owning a newly constructed ManagerType.
+      */
+      template <typename... Args>
+      static ManagedArraySharedPointer make(Args&&... args)
+      {
+        return ManagedArraySharedPointer{
+          ManagerType{std::forward<Args>(args)...}
+        };
+      }
+
+      /*!
+       * \brief Constructs a default ManagedArraySharedPointer.
+       *
+       * \details Creates a null pointer with size zero and no associated manager.
+       */
+      ManagedArraySharedPointer() = default;
+
+      /*!
+       * \brief Constructs an ManagedArraySharedPointer from an existing manager.
+       *
+       * \param manager An object that owns/manages the underlying array.
+       *
+       * \note Deep copies of the ManagerType object can and should be avoided
+       *       by passing a temporary or an rvalue reference to this constructor.
+       */
+      explicit ManagedArraySharedPointer(ManagerType manager)
+        : m_data{manager.data()},
+          m_size{manager.size()},
+          m_manager{new ManagerType{std::move(manager)}}
+      {
+      }
+
+      /*!
+       * \brief Copy-constructs an ManagedArraySharedPointer from another ManagedArraySharedPointer.
+       *
+       * \param other The ManagedArraySharedPointer to copy.
+       *
+       * \details Copies the cached pointer, size, and manager pointer. Ownership
+       * semantics are preserved (the manager pointer is shared). The internal
+       * cached pointer/size are synchronized by calling update().
+       */
+      CHAI_HOST_DEVICE ManagedArraySharedPointer(const ManagedArraySharedPointer& other)
+        : m_data{other.m_data},
+          m_size{other.m_size},
+          m_manager{other.m_manager}
+      {
+        update();
+      }
+
+      /*!
+       * \brief Converting copy-constructor from a non-const ManagedArraySharedPointer to a const ManagedArraySharedPointer.
+       *
+       * \tparam OtherElementType The source element type; must be non-const, and this
+       *         ManagedArraySharedPointer's ElementType must be const-qualified version of it.
+       *
+       * \param other The source ManagedArraySharedPointer to copy from.
+       *
+       * \details This constructor is enabled only when converting from
+       * ManagedArraySharedPointer<T, ManagerType> to ManagedArraySharedPointer<const T, ManagerType>. The manager
+       * pointer is shared (ownership semantics are preserved).
+       */
+      template <typename OtherElementType, 
+                typename = std::enable_if_t<!std::is_const_v<OtherElementType> &&
+                                            std::is_same_v<ElementType, std::add_const_t<OtherElementType>>>>
+      CHAI_HOST_DEVICE ManagedArraySharedPointer(const ManagedArraySharedPointer<OtherElementType, ManagerType>& other)
+        : m_data{other.m_data},
+          m_size{other.m_size},
+          m_manager{other.m_manager}
+      {
+      }
+
+      /*!
+       * \brief Copy-assigns from another ManagedArraySharedPointer.
+       *
+       * \param other The ManagedArraySharedPointer to copy from.
+       *
+       * \return Reference to this ManagedArraySharedPointer.
+       *
+       * \details Copies the cached pointer, size, and manager pointer. Ownership
+       * semantics are preserved (the manager pointer is shared).
+       */
+      ManagedArraySharedPointer& operator=(const ManagedArraySharedPointer& other) = default;
+
+      /*!
+       * \brief Resizes the underlying managed array.
+       *
+       * \param new_size New number of elements.
+       *
+       * \details If no manager is associated with this ManagedArraySharedPointer, a new manager is
+       * default-constructed. The cached pointer and size are invalidated (set to nullptr
+       * and zero, respectively), and the resize request is forwarded to the manager.
+       */
+      void resize(std::size_t new_size)
+      {
+        if (!m_manager)
+        {
+          m_manager = HostSharedPointer<ManagerType>{new ManagerType{}};
+        }
+
+        m_manager->resize(new_size);
+        m_data = m_manager->data();
+        m_size = new_size;
+      }
+
+      /*!
+       * \brief Returns the number of elements in the underlying managed array.
+       *
+       * \return The number of elements.
+       *
+       * \details On host builds, synchronizes the cached size from the manager (if present).
+       * On device builds (CHAI_DEVICE_COMPILE), returns the last cached size.
+       */
+      CHAI_HOST_DEVICE std::size_t size() const
+      {
+#if !defined(CHAI_DEVICE_COMPILE)
+        if (m_manager)
+        {
+          m_size = m_manager->size();
+        }
+#endif
+        return m_size;
+      }
+
+      /*!
+       * \brief Returns the cached pointer to the managed array's data.
+       *
+       * \return Pointer to the first element of the underlying managed array, or nullptr.
+       *
+       * \details On host builds, if a manager is present and provides a non-null data pointer,
+       * refreshes the cached pointer `m_data` from `m_manager->data()`. On device builds
+       * (CHAI_DEVICE_COMPILE), returns the cached pointer without querying the manager.
+       */
+      CHAI_HOST_DEVICE ElementType* data() const
+      {
+#if !defined(CHAI_DEVICE_COMPILE)
+        if (m_manager)
+        {
+          if (ElementType* data = m_manager->data(); data)
+          {
+            m_data = data;
+          }
+        }
+#endif
+        return m_data;
+      }
+
+      /*!
+       * \brief Synchronizes the cached pointer and size from the manager.
+       *
+       * \details On host builds, if a manager is present, refreshes `m_data` from
+       * `m_manager->data()` (when non-null) and updates `m_size` from
+       * `m_manager->size()`. On device builds (CHAI_DEVICE_COMPILE), this function
+       * is a no-op and the cached values are returned as-is.
+       */
+      CHAI_HOST_DEVICE void update() const
+      {
+#if !defined(CHAI_DEVICE_COMPILE)
+        if (m_manager)
+        {
+          if (ElementType* data = m_manager->data(); data)
+          {
+            m_data = data;
+          }
+
+          m_size = m_manager->size();
+        }
+#endif
+      }
+
+      /*!
+       * \brief Unchecked element access.
+       *
+       * \param i Element index.
+       *
+       * \return Reference to element i in the cached data pointer.
+       *
+       * \note No bounds checking is performed.
+       * \note Uses the cached pointer `m_data` and does not call update().
+       */
+      CHAI_HOST_DEVICE ElementType& operator[](std::size_t i) const
+      {
+        return m_data[i];
+      }
+
+    private:
+      /*!
+       * \brief Cached pointer to the managed array.
+       *
+       * \details This value is synchronized from the manager by data()/update().
+       * It is marked mutable to allow cache refresh in const member functions.
+       */
+      mutable ElementType* m_data{nullptr};
+
+      /*!
+       * \brief Cached number of elements in the managed array.
+       *
+       * \details This value is synchronized from the manager by size()/update().
+       * It is marked mutable to allow cache refresh in const member functions.
+       */
+      mutable std::size_t m_size{0};
+
+      /*!
+       * \brief Manager that owns/manages the underlying array.
+       */
+      HostSharedPointer<ManagerType> m_manager{};
+
+      /// Needed for the converting constructor
+      template <typename OtherElementType, typename OtherManagerType>
+      friend class ManagedArraySharedPointer;
+  };  // class ManagedArraySharedPointer
+}  // namespace chai::expt
+
+#endif  // CHAI_MANAGED_ARRAY_SHARED_POINTER_HPP

--- a/tests/expt/CMakeLists.txt
+++ b/tests/expt/CMakeLists.txt
@@ -80,3 +80,14 @@ blt_add_executable(
 blt_add_test(
   NAME HostArrayPointerTests
   COMMAND HostArrayPointerTests)
+
+blt_add_executable(
+  NAME HostArraySharedPointerTests
+  SOURCES HostArraySharedPointerTests.cpp
+  HEADERS ${chai_expt_test_headers}
+  INCLUDES ${PROJECT_BINARY_DIR}/include
+  DEPENDS_ON ${chai_expt_test_depends})
+
+blt_add_test(
+  NAME HostArraySharedPointerTests
+  COMMAND HostArraySharedPointerTests)

--- a/tests/expt/HostArraySharedPointerTests.cpp
+++ b/tests/expt/HostArraySharedPointerTests.cpp
@@ -1,0 +1,281 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+// project contributors. See the CHAI LICENSE file for details.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//////////////////////////////////////////////////////////////////////////////
+
+#include "chai/expt/HostArrayManager.hpp"
+#include "chai/expt/ManagedArraySharedPointer.hpp"
+#include "gtest/gtest.h"
+#include <cstddef>
+#include <cstdlib>
+
+template <typename ElementType>
+using HostArrayManager = ::chai::expt::HostArrayManager<ElementType>;
+
+template <typename ElementType>
+using HostArraySharedPointer = ::chai::expt::ManagedArraySharedPointer<ElementType, HostArrayManager<ElementType>>;
+
+template <typename ElementType>
+using ConstHostArraySharedPointer = ::chai::expt::ManagedArraySharedPointer<const ElementType, HostArrayManager<ElementType>>;
+
+TEST(HostArraySharedPointer, DefaultConstructor) {
+  HostArraySharedPointer<int> a;
+  EXPECT_EQ(a.size(), 0);
+  EXPECT_EQ(a.data(), nullptr);
+}
+
+TEST(HostArraySharedPointer, ManagerDefaultConstructor) {
+  HostArraySharedPointer<int> a{HostArrayManager<int>()};
+  EXPECT_EQ(a.size(), 0);
+  EXPECT_EQ(a.data(), nullptr);
+}
+
+TEST(HostArraySharedPointer, MakeManagerDefaultConstructor) {
+  HostArraySharedPointer<int> a = HostArraySharedPointer<int>::make();
+  EXPECT_EQ(a.size(), 0);
+  EXPECT_EQ(a.data(), nullptr);
+}
+
+TEST(HostArraySharedPointer, ManagerSizeConstructor) {
+  const std::size_t N = 10;
+  HostArraySharedPointer<int> a{HostArrayManager<int>(N)};
+  EXPECT_EQ(a.size(), N);
+  ASSERT_NE(a.data(), nullptr);
+
+  // For memory checking tools, use the allocated array.
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    a[i] = i;
+  }
+}
+
+TEST(HostArraySharedPointer, MakeManagerSizeConstructor) {
+  const std::size_t N = 10;
+  HostArraySharedPointer<int> a = HostArraySharedPointer<int>::make(N);
+  EXPECT_EQ(a.size(), N);
+  ASSERT_NE(a.data(), nullptr);
+
+  // For memory checking tools, use the allocated array.
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    a[i] = i;
+  }
+}
+
+/*
+ * Note: The copy constructor is shallow.
+ */
+TEST(HostArraySharedPointer, CopyConstructor) {
+  // Set up array a
+  const std::size_t N = 10;
+  HostArraySharedPointer<int> a{HostArrayManager<int>(N)};
+
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    a[i] = i;
+  }
+
+  // Copy construct b
+  HostArraySharedPointer<int> b(a);
+
+  // Check that a is unchanged
+  EXPECT_EQ(a.size(), N);
+  EXPECT_NE(a.data(), nullptr);
+
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    EXPECT_EQ(a[i], i);
+  }
+
+  // Check that b matches a
+  EXPECT_EQ(b.size(), a.size());
+  EXPECT_EQ(b.data(), a.data());
+
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    EXPECT_EQ(b[i], i);
+  }
+
+  // Check that the copy is shallow
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    b[i] = -i;
+    EXPECT_EQ(a[i], -i);
+  }
+}
+
+TEST(HostArraySharedPointer, ConvertingConstructor) {
+  // Set up array a
+  const std::size_t N = 10;
+  HostArraySharedPointer<int> a{HostArrayManager<int>(N)};
+
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    a[i] = i;
+  }
+
+  // Use the converting constructor to construct b
+  ConstHostArraySharedPointer<int> b(a);
+
+  // Check that a is unchanged
+  EXPECT_EQ(a.size(), N);
+  EXPECT_NE(a.data(), nullptr);
+
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    EXPECT_EQ(a[i], i);
+  }
+
+  // Check that b matches a
+  EXPECT_EQ(b.size(), a.size());
+  EXPECT_EQ(b.data(), a.data());
+
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    EXPECT_EQ(b[i], i);
+  }
+
+  // Check that the copy is shallow
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    a[i] = -i;
+    EXPECT_EQ(b[i], -i);
+  }
+}
+
+TEST(HostArraySharedPointer, CopyAssignmentOperator) {
+  HostArraySharedPointer<int> a;
+
+  const std::size_t N = 10;
+  a = HostArraySharedPointer<int>(HostArrayManager<int>(N));
+
+  EXPECT_EQ(a.size(), N);
+  EXPECT_NE(a.data(), nullptr);
+}
+
+TEST(HostArraySharedPointer, ResizeAllocate) {
+  const std::size_t N = 10;
+  HostArraySharedPointer<int> a;
+  a.resize(N);
+
+  EXPECT_EQ(a.size(), N);
+  EXPECT_NE(a.data(), nullptr);
+
+  // For memory checking tools, use the allocated array.
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    a[i] = i;
+  }
+}
+
+TEST(HostArraySharedPointer, ResizeDeallocate) {
+  std::size_t N = 10;
+  HostArraySharedPointer<int> a{HostArrayManager<int>(N)};
+
+  N = 0;
+  a.resize(N);
+
+  EXPECT_EQ(a.size(), N);
+  EXPECT_EQ(a.data(), nullptr);
+}
+
+TEST(HostArraySharedPointer, ResizeSmaller) {
+  const std::size_t old_size = 10;
+  HostArraySharedPointer<int> a{HostArrayManager<int>(old_size)};
+
+  for (std::size_t i = 0; i < old_size; ++i)
+  {
+    a[i] = i;
+  }
+
+  const std::size_t new_size = 5;
+  a.resize(new_size);
+
+  EXPECT_EQ(a.size(), new_size);
+  EXPECT_NE(a.data(), nullptr);
+
+  for (std::size_t i = 0; i < new_size; ++i)
+  {
+    EXPECT_EQ(a[i], i);
+  }
+}
+
+TEST(HostArraySharedPointer, ResizeLarger) {
+  const std::size_t old_size = 5;
+  HostArraySharedPointer<int> a{HostArrayManager<int>(old_size)};
+
+  for (std::size_t i = 0; i < old_size; ++i)
+  {
+    a[i] = i;
+  }
+
+  const std::size_t new_size = 10;
+  a.resize(new_size);
+
+  EXPECT_EQ(a.size(), new_size);
+  EXPECT_NE(a.data(), nullptr);
+
+  for (std::size_t i = 0; i < old_size; ++i)
+  {
+    EXPECT_EQ(a[i], i);
+  }
+}
+
+TEST(HostArraySharedPointer, Data) {
+  const std::size_t N = 10;
+  HostArraySharedPointer<int> a{HostArrayManager<int>(N)};
+
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    a[i] = i;
+  }
+
+  int* data = a.data();
+
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    EXPECT_EQ(data[i], i);
+  }
+}
+
+TEST(HostArraySharedPointer, Update) {
+  const std::size_t N = 10;
+  HostArraySharedPointer<int> a{HostArrayManager<int>(N)};
+  a.update();
+
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    a[i] = i;
+  }
+
+  int* data = a.data();
+
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    EXPECT_EQ(data[i], i);
+  }
+}
+
+TEST(HostArraySharedPointer, LambdaCapture) {
+  const std::size_t N = 10;
+  HostArraySharedPointer<int> a{HostArrayManager<int>(N)};
+
+  auto f = [=] (std::size_t i)
+  {
+    a[i] = i;
+  };
+
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    f(i);
+  }
+
+  int* data = a.data();
+
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    EXPECT_EQ(data[i], i);
+  }
+}


### PR DESCRIPTION
This class is an array interface like ManagedArrayPointer, except that it acts like std::shared_ptr such that underlying memory is cleaned up automatically when the last host copy is destroyed (device copies do not and should not count since memory allocation calls are launched from the host).