### PR TITLE
Use project specific variable to specify github status token

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,7 +76,7 @@ include:
     inputs:
       github_project_name: $GITHUB_PROJECT_NAME
       github_project_org: $GITHUB_PROJECT_ORG
-      github_token: $GITHUB_TOKEN
+      github_token: $RSCI_GITHUB_STATUS_TOKEN
 
   # Local custom variables (used for component inputs and forwarded to child pipelines)
   - local: '.gitlab/custom-variables.yml'


### PR DESCRIPTION
Fix issue with machine outage report.

The issue identified is that token cannot be accessed correctly when defined at group level anymore.

Instead, we defined the token at project level.
