### PR TITLE
Prevent resource manager from being created by empty managed arrays

### DIFF
--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -134,6 +134,8 @@ public:
   /*!
    * \brief Allocate data for the ManagedArray in the specified space.
    *
+   * Once a ManagedArray is allocated, it will have a valid resource manager.
+   *
    * \param elems Number of elements to allocate.
    * \param space Execution space in which to allocate data.
    * \param cback User defined callback for memory events (alloc, free, move)
@@ -289,6 +291,7 @@ public:
    * \brief Return the value of element i in the ManagedArray.
    * ExecutionSpace space to the current one
    *
+   * \pre ManagedArray must be allocated
    * \param index The index of the element to be fetched
    * \param space The index of the element to be fetched
    * \return The value of the i-th element in the ManagedArray.
@@ -299,6 +302,7 @@ public:
   /*!
    * \brief Set the value of element i in the ManagedArray to be val.
    *
+   * \pre ManagedArray must be allocated
    * \param index The index of the element to be set
    * \param val Source location of the value
    * \tparam T The type of data value in ManagedArray.

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -25,7 +25,6 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray():
   m_is_slice(false)
 {
 #if !defined(CHAI_DEVICE_COMPILE)
-  m_resource_manager = ArrayManager::getInstance();
   m_pointer_record = &ArrayManager::s_null_record;
 #endif
 }
@@ -37,6 +36,7 @@ ManagedArray<T>::ManagedArray(
     std::initializer_list<umpire::Allocator> allocators):
   ManagedArray()
 {
+  m_resource_manager = ArrayManager::getInstance();
   m_pointer_record = new PointerRecord();
   int i = 0;
   for (int s = CPU; s < NUM_EXECUTION_SPACES; ++s) {
@@ -169,6 +169,9 @@ CHAI_HOST void ManagedArray<T>::allocate(
     const UserCallback& cback) 
 {
   if(!m_is_slice) {
+     if (m_resource_manager == nullptr) {
+       m_resource_manager = ArrayManager::getInstance();
+     }
      if (elems > 0) {
        CHAI_LOG(Debug, "Allocating array of size " << elems << " in space " << space);
 
@@ -300,6 +303,9 @@ template<typename T>
 CHAI_INLINE
 CHAI_HOST void ManagedArray<T>::reset()
 {
+  if (m_resource_manager == nullptr) {
+     m_resource_manager = ArrayManager::getInstance();
+  }
   m_resource_manager->resetTouch(m_pointer_record);
 }
 
@@ -312,6 +318,9 @@ CHAI_HOST_DEVICE size_t ManagedArray<T>::size() const {
 template<typename T>
 CHAI_INLINE
 CHAI_HOST void ManagedArray<T>::registerTouch(ExecutionSpace space) {
+  if (m_resource_manager == nullptr) {
+     m_resource_manager = ArrayManager::getInstance();
+  }
   if (m_active_pointer && (m_pointer_record == nullptr || m_pointer_record == &ArrayManager::s_null_record)) {
      CHAI_LOG(Warning,"registerTouch called on ManagedArray with nullptr pointer record.");
      m_pointer_record = m_resource_manager->makeManaged((void *)m_active_base_pointer,m_size,space,true);
@@ -324,6 +333,9 @@ CHAI_INLINE
 CHAI_HOST_DEVICE
 typename ManagedArray<T>::T_non_const ManagedArray<T>::pick(size_t i) const { 
   #if !defined(CHAI_DEVICE_COMPILE)
+      if (m_resource_manager == nullptr) {
+        m_resource_manager = ArrayManager::getInstance();
+      }
     #if defined(CHAI_ENABLE_GPU_SIMULATION_MODE)
       if (m_resource_manager->isGPUSimMode()) {
         return (T_non_const)(m_active_pointer[i]);
@@ -352,6 +364,9 @@ template<typename T>
 CHAI_INLINE
 CHAI_HOST_DEVICE void ManagedArray<T>::set(size_t i, T val) const { 
   #if !defined(CHAI_DEVICE_COMPILE)
+      if (m_resource_manager == nullptr) {
+        m_resource_manager = ArrayManager::getInstance();
+      }
     #if defined(CHAI_ENABLE_GPU_SIMULATION_MODE)
       if (m_resource_manager->isGPUSimMode()) {
         m_active_pointer[i] = val;
@@ -556,7 +571,7 @@ ManagedArray<T>::operator= (std::nullptr_t) {
   m_offset = 0;
   #if !defined(CHAI_DEVICE_COMPILE)
   m_pointer_record = &ArrayManager::s_null_record;
-  m_resource_manager = ArrayManager::getInstance();
+  m_resource_manager = nullptr;
   #else
   m_pointer_record = nullptr;
   m_resource_manager = nullptr;

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -304,7 +304,7 @@ CHAI_INLINE
 CHAI_HOST void ManagedArray<T>::reset()
 {
   if (m_resource_manager == nullptr) {
-     m_resource_manager = ArrayManager::getInstance();
+     return;
   }
   m_resource_manager->resetTouch(m_pointer_record);
 }
@@ -319,7 +319,7 @@ template<typename T>
 CHAI_INLINE
 CHAI_HOST void ManagedArray<T>::registerTouch(ExecutionSpace space) {
   if (m_resource_manager == nullptr) {
-     m_resource_manager = ArrayManager::getInstance();
+     return;
   }
   if (m_active_pointer && (m_pointer_record == nullptr || m_pointer_record == &ArrayManager::s_null_record)) {
      CHAI_LOG(Warning,"registerTouch called on ManagedArray with nullptr pointer record.");
@@ -333,9 +333,6 @@ CHAI_INLINE
 CHAI_HOST_DEVICE
 typename ManagedArray<T>::T_non_const ManagedArray<T>::pick(size_t i) const { 
   #if !defined(CHAI_DEVICE_COMPILE)
-      if (m_resource_manager == nullptr) {
-        m_resource_manager = ArrayManager::getInstance();
-      }
     #if defined(CHAI_ENABLE_GPU_SIMULATION_MODE)
       if (m_resource_manager->isGPUSimMode()) {
         return (T_non_const)(m_active_pointer[i]);
@@ -364,9 +361,6 @@ template<typename T>
 CHAI_INLINE
 CHAI_HOST_DEVICE void ManagedArray<T>::set(size_t i, T val) const { 
   #if !defined(CHAI_DEVICE_COMPILE)
-      if (m_resource_manager == nullptr) {
-        m_resource_manager = ArrayManager::getInstance();
-      }
     #if defined(CHAI_ENABLE_GPU_SIMULATION_MODE)
       if (m_resource_manager->isGPUSimMode()) {
         m_active_pointer[i] = val;


### PR DESCRIPTION
This prevents pre-main cuda calls for global static Managed Arrays.