### PR TITLE
Simplify copyright changes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,10 @@
+##############################################################################
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+##############################################################################
+
 BasedOnStyle : google
 IndentWidth : 2
 BreakBeforeBraces : Linux

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,9 @@
+##############################################################################
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+##############################################################################
+
 .git
 build*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+##############################################################################
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+##############################################################################
+
 build*/
 install*/
 .vscode/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,9 @@
-###############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+##############################################################################
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
-# SPDX-License-Identifier: (MIT)
-###############################################################################
+# SPDX-License-Identifier: BSD-3-Clause
+##############################################################################
 
 # DESCRIPTION:
 ###############################################################################

--- a/.gitlab/custom-jobs.yml
+++ b/.gitlab/custom-jobs.yml
@@ -2,7 +2,7 @@
 # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
-# SPDX-License-Identifier: (MIT)
+# SPDX-License-Identifier: BSD-3-Clause
 ###############################################################################
 
 # This file defines JOB TEMPLATES ONLY.

--- a/.gitlab/custom-jobs.yml
+++ b/.gitlab/custom-jobs.yml
@@ -1,6 +1,6 @@
 ###############################################################################
 # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: (MIT)
 ###############################################################################

--- a/.gitlab/custom-jobs.yml
+++ b/.gitlab/custom-jobs.yml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/.gitlab/custom-variables.yml
+++ b/.gitlab/custom-variables.yml
@@ -1,6 +1,6 @@
 ###############################################################################
 # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: (MIT)
 ###############################################################################

--- a/.gitlab/custom-variables.yml
+++ b/.gitlab/custom-variables.yml
@@ -2,7 +2,7 @@
 # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
-# SPDX-License-Identifier: (MIT)
+# SPDX-License-Identifier: BSD-3-Clause
 ###############################################################################
 
 # This file defines project-specific VARIABLES ONLY.

--- a/.gitlab/custom-variables.yml
+++ b/.gitlab/custom-variables.yml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/.gitlab/jobs/corona.yml
+++ b/.gitlab/jobs/corona.yml
@@ -1,6 +1,6 @@
 ##############################################################################
 # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################

--- a/.gitlab/jobs/corona.yml
+++ b/.gitlab/jobs/corona.yml
@@ -2,7 +2,7 @@
 # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
-# SPDX-License-Identifier: (MIT)
+# SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################
 
 # Override reproducer section to define project specific variables.

--- a/.gitlab/jobs/corona.yml
+++ b/.gitlab/jobs/corona.yml
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/.gitlab/jobs/dane.yml
+++ b/.gitlab/jobs/dane.yml
@@ -1,6 +1,6 @@
 ###############################################################################
 # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: (MIT)
 ###############################################################################

--- a/.gitlab/jobs/dane.yml
+++ b/.gitlab/jobs/dane.yml
@@ -2,7 +2,7 @@
 # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
-# SPDX-License-Identifier: (MIT)
+# SPDX-License-Identifier: BSD-3-Clause
 ###############################################################################
 
 # Override reproducer section to define projet specific variables.

--- a/.gitlab/jobs/dane.yml
+++ b/.gitlab/jobs/dane.yml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/.gitlab/jobs/matrix.yml
+++ b/.gitlab/jobs/matrix.yml
@@ -1,6 +1,6 @@
 ###############################################################################
 # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: (MIT)
 ###############################################################################

--- a/.gitlab/jobs/matrix.yml
+++ b/.gitlab/jobs/matrix.yml
@@ -2,7 +2,7 @@
 # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
-# SPDX-License-Identifier: (MIT)
+# SPDX-License-Identifier: BSD-3-Clause
 ###############################################################################
 
 # Override reproducer section to define projet specific variables.

--- a/.gitlab/jobs/matrix.yml
+++ b/.gitlab/jobs/matrix.yml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -1,6 +1,6 @@
 ##############################################################################
 # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -2,7 +2,7 @@
 # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
-# SPDX-License-Identifier: (MIT)
+# SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################
 
 # Override reproducer section to define project specific variables.

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/.gitlab/jobs/tuolumne.yml
+++ b/.gitlab/jobs/tuolumne.yml
@@ -1,6 +1,6 @@
 ##############################################################################
 # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################

--- a/.gitlab/jobs/tuolumne.yml
+++ b/.gitlab/jobs/tuolumne.yml
@@ -2,7 +2,7 @@
 # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
-# SPDX-License-Identifier: (MIT)
+# SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################
 
 # Override reproducer section to define project specific variables.

--- a/.gitlab/jobs/tuolumne.yml
+++ b/.gitlab/jobs/tuolumne.yml
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: (MIT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,10 @@
+[comment]: # (#################################################################)
+[comment]: # (Copyright Lawrence Livermore National Security, LLC and other CHAI)
+[comment]: # (contributors. See the CHAI LICENSE and COPYRIGHT files for details.)
+[comment]: # 
+[comment]: # (# SPDX-License-Identifier: BSD-3-Clause)
+[comment]: # (#################################################################)
+
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,10 @@
+[comment]: # (#################################################################)
+[comment]: # (Copyright Lawrence Livermore National Security, LLC and other CHAI)
+[comment]: # (contributors. See the CHAI LICENSE and COPYRIGHT files for details.)
+[comment]: # 
+[comment]: # (# SPDX-License-Identifier: BSD-3-Clause)
+[comment]: # (#################################################################)
+
 # Contributing to CHAI
 
 This document is intented for developers who want to add new features or

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,17 +1,19 @@
 Intellectual Property Notice
 ------------------------------
 
+This file is part of CHAI.
+For details, see https://github.com/llnl/CHAI
+
 CHAI is produced at the Lawrence Livermore National Laboratory.
+See NOTICE file.
 
 Unlimited Open Source - BSD Distribution
 LLNL-CODE-705877
 OCEC-16-189
 
-This file is part of CHAI.
-For details, see https://github.com/llnl/CHAI
-
 CHAI licensed under the BSD 3-Clause license
 (BSD-3-Clause or https://opensource.org/licenses/BSD-3-Clause).
+See LICENSE file.
 
 Copyrights and patents in the CHAI project are retained by contributors.
 No copyright assignment is required to contribute to CHAI.
@@ -38,7 +40,6 @@ views and opinions of authors expressed herein do not necessarily state or
 reflect those of the United States Government or Lawrence Livermore National
 Security, LLC, and shall not be used for advertising or product endorsement
 purposes.
-
 
 SPDX usage
 ------------

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,11 +1,44 @@
 Intellectual Property Notice
 ------------------------------
 
-CHAI is licensed under the BSD 3 Clause license (LICENSE or
-https://opensource.org/licenses/BSD-3-Clause).
+CHAI is produced at the Lawrence Livermore National Laboratory.
 
-Copyrights and patents in the CHAI project are retained by contributors.  No
-copyright assignment is required to contribute to CHAI.
+Unlimited Open Source - BSD Distribution
+LLNL-CODE-705877
+OCEC-16-189
+
+This file is part of CHAI.
+For details, see https://github.com/llnl/CHAI
+
+CHAI licensed under the BSD 3-Clause license
+(BSD-3-Clause or https://opensource.org/licenses/BSD-3-Clause).
+
+Copyrights and patents in the CHAI project are retained by contributors.
+No copyright assignment is required to contribute to CHAI.
+
+See https://github.com/llnl/CHAI/contributors for the list of contributors.
+
+Additional BSD Notice
+
+1. This notice is required to be provided under our contract with the U.S.
+Department of Energy (DOE). This work was produced at Lawrence Livermore
+National Laboratory under Contract No. DE-AC52-07NA27344 with the DOE.
+
+2. Neither the United States Government nor Lawrence Livermore National
+Security, LLC nor any of their employees, makes any warranty, express or
+implied, or assumes any liability or responsibility for the accuracy,
+completeness, or usefulness of any information, apparatus, product, or process
+disclosed, or represents that its use would not infringe privately-owned rights.
+
+3. Also, reference herein to any specific commercial products, process, or
+services by trade name, trademark, manufacturer or otherwise does not
+necessarily constitute or imply its endorsement, recommendation, or favoring by
+the United States Government or Lawrence Livermore National Security, LLC. The
+views and opinions of authors expressed herein do not necessarily state or
+reflect those of the United States Government or Lawrence Livermore National
+Security, LLC, and shall not be used for advertising or product endorsement
+purposes.
+
 
 SPDX usage
 ------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+##############################################################################
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+##############################################################################
+
 FROM ghcr.io/llnl/radiuss:ubuntu-22.04-gcc-13 AS gcc
 ENV GTEST_COLOR=1
 COPY . /home/chai/workspace

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+BSD 3-Clause License
+
 Copyright (c) 2016-26, Lawrence Livermore National Security, LLC.
 All rights reserved.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016-25, Lawrence Livermore National Security, LLC.
+Copyright (c) 2016-26, Lawrence Livermore National Security, LLC.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 BSD 3-Clause License
 
-Copyright (c) 2016-26, Lawrence Livermore National Security, LLC.
+Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and other CHAI contributors.
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -55,9 +55,11 @@ Produced at the Lawrence Livermore National Laboratory
 All rights reserved.
 
 Unlimited Open Source - BSD Distribution
+`LLNL-CODE-705877`
+`OCEC-16-189`
 
-For release details and restrictions, please read the LICENSE file.
-It is also linked here: [LICENSE](./LICENSE)
+For release details and restrictions, please read the following:
+- [LICENSE](./LICENSE)
+- [COPYRIGHT](./COPYRIGHT)
+- [NOTICE](./NOTICE)
 
-- `LLNL-CODE-705877`
-- `OCEC-16-189`

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Contributors include:
 ## Release
 
 Copyright (c) 2016-26, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory
+Produced at the Lawrence Livermore National Laboratory.
 
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [comment]: # (#################################################################)
-[comment]: # (Copyright 2016-25, Lawrence Livermore National Security, LLC)
-[comment]: # (and CHAI project contributors. See the CHAI LICENSE file for)
-[comment]: # (details.)
+[comment]: # (Copyright Lawrence Livermore National Security, LLC and other CHAI)
+[comment]: # (contributors. See the CHAI LICENSE and COPYRIGHT files for details.)
 [comment]: # 
 [comment]: # (# SPDX-License-Identifier: BSD-3-Clause)
 [comment]: # (#################################################################)
@@ -50,7 +49,7 @@ Contributors include:
 
 ## Release
 
-Copyright (c) 2016, Lawrence Livermore National Security, LLC.
+Copyright (c) 2016-26, Lawrence Livermore National Security, LLC.
 Produced at the Lawrence Livermore National Laboratory
 
 All rights reserved.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,6 @@
 [comment]: # (#################################################################)
-[comment]: # (Copyright 2016-24, Lawrence Livermore National Security, LLC)
-[comment]: # (and CHAI project contributors. See the CHAI LICENSE file for)
-[comment]: # (details.)
+[comment]: # (Copyright Lawrence Livermore National Security, LLC and other CHAI)
+[comment]: # (contributors. See the CHAI LICENSE and COPYRIGHT files for details.)
 [comment]: # 
 [comment]: # (# SPDX-License-Identifier: BSD-3-Clause)
 [comment]: # (#################################################################)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,10 @@
+##############################################################################
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+##############################################################################
+
 jobs:
 - job: Docker
   timeoutInMinutes: 360

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/benchmarks/chai_arraymanager_benchmarks.cpp
+++ b/benchmarks/chai_arraymanager_benchmarks.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/benchmarks/chai_benchmark_utils.hpp
+++ b/benchmarks/chai_benchmark_utils.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/benchmarks/chai_managed_ptr_benchmarks.cpp
+++ b/benchmarks/chai_managed_ptr_benchmarks.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/benchmarks/chai_managedarray_benchmarks.cpp
+++ b/benchmarks/chai_managedarray_benchmarks.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/cmake/ChaiBasics.cmake
+++ b/cmake/ChaiBasics.cmake
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/cmake/SetupChaiOptions.cmake
+++ b/cmake/SetupChaiOptions.cmake
@@ -1,6 +1,6 @@
 ############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ############################################################################

--- a/cmake/chai-config.cmake.in
+++ b/cmake/chai-config.cmake.in
@@ -1,6 +1,6 @@
 ############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ############################################################################

--- a/cmake/thirdparty/SetupChaiThirdparty.cmake
+++ b/cmake/thirdparty/SetupChaiThirdparty.cmake
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/docs/doxygen/CMakeLists.txt
+++ b/docs/doxygen/CMakeLists.txt
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/docs/doxygen/Doxyfile.in
+++ b/docs/doxygen/Doxyfile.in
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/docs/sphinx/CMakeLists.txt
+++ b/docs/sphinx/CMakeLists.txt
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/docs/sphinx/advanced_configuration.rst
+++ b/docs/sphinx/advanced_configuration.rst
@@ -1,6 +1,6 @@
 ..
-    # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-    # project contributors. See the CHAI LICENSE file for details.
+    # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+    # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
     #
     # SPDX-License-Identifier: BSD-3-Clause
 

--- a/docs/sphinx/code_documentation.rst
+++ b/docs/sphinx/code_documentation.rst
@@ -1,6 +1,6 @@
 ..
-    # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-    # project contributors. See the CHAI LICENSE file for details.
+    # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+    # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
     #
     # SPDX-License-Identifier: BSD-3-Clause
 

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -53,7 +53,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'CHAI'
-copyright = u'Copyright (c) 2016-26, Lawrence Livermore National Security, LLC.'
+copyright = u'Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and other CHAI contributors.'
 author = u''
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -53,7 +53,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'CHAI'
-copyright = u'2016-2018, Lawrence Livermore National Security, LLC.'
+copyright = u'Copyright (c) 2016-26, Lawrence Livermore National Security, LLC.'
 author = u''
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -52,7 +52,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'CHAI'
-copyright = u'2016-2018, Lawrence Livermore National Security, LLC.'
+copyright = u'Copyright (c) 2016-26, Lawrence Livermore National Security, LLC.'
 author = u''
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -52,7 +52,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'CHAI'
-copyright = u'Copyright (c) 2016-26, Lawrence Livermore National Security, LLC.'
+copyright = u'Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and other CHAI contributors.'
 author = u''
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/docs/sphinx/contribution_guide.rst
+++ b/docs/sphinx/contribution_guide.rst
@@ -1,6 +1,6 @@
 ..
-    # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-    # project contributors. See the CHAI LICENSE file for details.
+    # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+    # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
     #
     # SPDX-License-Identifier: BSD-3-Clause
 

--- a/docs/sphinx/developer/ci.rst
+++ b/docs/sphinx/developer/ci.rst
@@ -1,6 +1,6 @@
 ..
-    # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-    # project contributors. See the CHAI LICENSE file for details.
+    # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+    # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
     #
     # SPDX-License-Identifier: BSD-3-Clause
 

--- a/docs/sphinx/developer/uberenv.rst
+++ b/docs/sphinx/developer/uberenv.rst
@@ -1,6 +1,6 @@
 ..
-    # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-    # project contributors. See the CHAI LICENSE file for details.
+    # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+    # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
     #
     # SPDX-License-Identifier: BSD-3-Clause
 

--- a/docs/sphinx/developer_guide.rst
+++ b/docs/sphinx/developer_guide.rst
@@ -1,6 +1,6 @@
 ..
-    # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-    # project contributors. See the CHAI LICENSE file for details.
+    # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+    # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
     #
     # SPDX-License-Identifier: BSD-3-Clause
 

--- a/docs/sphinx/expt/design.rst
+++ b/docs/sphinx/expt/design.rst
@@ -1,6 +1,6 @@
 ..
     # Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
-    # project contributors. See the CHAI LICENSE file for details.
+    # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
     #
     # SPDX-License-Identifier: BSD-3-Clause
 

--- a/docs/sphinx/expt/design.rst
+++ b/docs/sphinx/expt/design.rst
@@ -1,5 +1,5 @@
 ..
-    # Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+    # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
     # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
     #
     # SPDX-License-Identifier: BSD-3-Clause

--- a/docs/sphinx/getting_started.rst
+++ b/docs/sphinx/getting_started.rst
@@ -1,6 +1,6 @@
 ..
-    # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-    # project contributors. See the CHAI LICENSE file for details.
+    # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+    # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
     #
     # SPDX-License-Identifier: BSD-3-Clause
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -1,6 +1,6 @@
 ..
-    # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-    # project contributors. See the CHAI LICENSE file for details.
+    # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+    # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
     #
     # SPDX-License-Identifier: BSD-3-Clause
 

--- a/docs/sphinx/tutorial.rst
+++ b/docs/sphinx/tutorial.rst
@@ -1,6 +1,6 @@
 ..
-    # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-    # project contributors. See the CHAI LICENSE file for details.
+    # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+    # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
     #
     # SPDX-License-Identifier: BSD-3-Clause
 

--- a/docs/sphinx/user_guide.rst
+++ b/docs/sphinx/user_guide.rst
@@ -1,6 +1,6 @@
 ..
-    # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-    # project contributors. See the CHAI LICENSE file for details.
+    # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+    # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
     #
     # SPDX-License-Identifier: BSD-3-Clause
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/examples/chai-umpire-allocators.cpp
+++ b/examples/chai-umpire-allocators.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/examples/ex1.cpp
+++ b/examples/ex1.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/examples/managed_ptr_example.cpp
+++ b/examples/managed_ptr_example.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/examples/pinned.cpp
+++ b/examples/pinned.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/host-configs/lc/toss_4_x86_64_ib/clang.cmake
+++ b/host-configs/lc/toss_4_x86_64_ib/clang.cmake
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/host-configs/lc/toss_4_x86_64_ib/gcc.cmake
+++ b/host-configs/lc/toss_4_x86_64_ib/gcc.cmake
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/host-configs/lc/toss_4_x86_64_ib/intel.cmake
+++ b/host-configs/lc/toss_4_x86_64_ib/intel.cmake
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/host-configs/lc/toss_4_x86_64_ib/nvcc_clang.cmake
+++ b/host-configs/lc/toss_4_x86_64_ib/nvcc_clang.cmake
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/host-configs/lc/toss_4_x86_64_ib/nvcc_clang.cmake
+++ b/host-configs/lc/toss_4_x86_64_ib/nvcc_clang.cmake
@@ -1,6 +1,6 @@
 ##############################################################################
 # Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/host-configs/lc/toss_4_x86_64_ib_cray/amdclang-xnack.cmake
+++ b/host-configs/lc/toss_4_x86_64_ib_cray/amdclang-xnack.cmake
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/host-configs/lc/toss_4_x86_64_ib_cray/amdclang.cmake
+++ b/host-configs/lc/toss_4_x86_64_ib_cray/amdclang.cmake
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/reproducers/CMakeLists.txt
+++ b/reproducers/CMakeLists.txt
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/reproducers/managed_ptr_multiple_inheritance_reproducer.cpp
+++ b/reproducers/managed_ptr_multiple_inheritance_reproducer.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/reproducers/managed_ptr_reproducer.cpp
+++ b/reproducers/managed_ptr_reproducer.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/reproducers/virtual_function_complex_reproducer.cpp
+++ b/reproducers/virtual_function_complex_reproducer.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/reproducers/virtual_function_simple_reproducer.cpp
+++ b/reproducers/virtual_function_simple_reproducer.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/scripts/apply-license-info.sh
+++ b/scripts/apply-license-info.sh
@@ -36,6 +36,7 @@ files_no_license=$(grep -rL "SPDX-License-Identifier: BSD-3-Clause" . \
    --exclude=LICENSE \
    --exclude=COPYRIGHT \
    --exclude=NOTICE \
+   --exclude=license.txt \
    --exclude=*.json)
 
 echo $files_no_license | xargs $LIC_CMD -f scripts/license.txt 

--- a/scripts/apply-license-info.sh
+++ b/scripts/apply-license-info.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/scripts/apply-license-info.sh
+++ b/scripts/apply-license-info.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env zsh
+
 ##############################################################################
 # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
@@ -6,7 +7,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################
 
+# This is used for the ~*tpl* line to ignore files in bundled tpls
 setopt extended_glob
+
+autoload colors
 
 RED="\033[1;31m"
 GREEN="\033[1;32m"
@@ -14,22 +18,26 @@ NOCOLOR="\033[0m"
 
 LIC_CMD=$(which lic)
 if [ ! $LIC_CMD ]; then
-  echo "${RED} [!] This script requires the lic command."
+  echo "${RED} [!] This script requires the lic command.${NOCOLOR}"
   exit 255
 fi
 
 echo "Applying licenses to files"
 
-files_no_license=$(grep -L 'This file is part of Umpire.' \
-  benchmarks/**/*(^/) \
-  cmake/**/*(^/) \
-  docs/**/*~*rst(^/)\
-  examples/**/*(^/) \
-  scripts/**/*(^/) \
-  src/**/*~*tpl*(^/) \
-  tests/**/*(^/) \
-  CMakeLists.txt)
+files_no_license=$(grep -rL "SPDX-License-Identifier: BSD-3-Clause" . \
+   --exclude-dir=.git \
+   --exclude-dir=blt \
+   --exclude-dir=umpire \
+   --exclude-dir=raja \
+   --exclude-dir=radiuss-spack-configs \
+   --exclude-dir=uberenv \
+   --exclude=.gitmodules \
+   --exclude=.mailmap \
+   --exclude=LICENSE \
+   --exclude=COPYRIGHT \
+   --exclude=NOTICE \
+   --exclude=*.json)
 
 echo $files_no_license | xargs $LIC_CMD -f scripts/license.txt 
 
-echo "${GREEN} [Ok] License text applied. ${NOCOLOR}"
+echo "${GREEN} [Ok] License text applied.${NOCOLOR}"

--- a/scripts/check-license-info.sh
+++ b/scripts/check-license-info.sh
@@ -28,6 +28,7 @@ files_no_license=$(grep -rL "SPDX-License-Identifier: BSD-3-Clause" . \
    --exclude=LICENSE \
    --exclude=COPYRIGHT \
    --exclude=NOTICE \
+   --exclude=license.txt \
    --exclude=*.json)
 
 if [ $files_no_license ]; then

--- a/scripts/check-license-info.sh
+++ b/scripts/check-license-info.sh
@@ -15,13 +15,19 @@ RED="\033[1;31m"
 GREEN="\033[1;32m"
 NOCOLOR="\033[0m"
 
-files_no_license=$(grep -rL "the CHAI LICENSE file" . \
+files_no_license=$(grep -rL "SPDX-License-Identifier: BSD-3-Clause" . \
    --exclude-dir=.git \
    --exclude-dir=blt \
    --exclude-dir=umpire \
    --exclude-dir=raja \
    --exclude-dir=radiuss-spack-configs \
-   --exclude-dir=uberenv)
+   --exclude-dir=uberenv \
+   --exclude=.gitmodules \
+   --exclude=.mailmap \
+   --exclude=LICENSE \
+   --exclude=COPYRIGHT \
+   --exclude=NOTICE \
+   --exclude=*.json)
 
 if [ $files_no_license ]; then
   print "${RED} [!] Some files are missing license text: ${NOCOLOR}"

--- a/scripts/check-license-info.sh
+++ b/scripts/check-license-info.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################

--- a/scripts/check-license-info.sh
+++ b/scripts/check-license-info.sh
@@ -3,7 +3,7 @@
 # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
-# SPDX-License-Identifier: (MIT)
+# SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################
 
 # This is used for the ~*tpl* line to ignore files in bundled tpls

--- a/scripts/check-license-info.sh
+++ b/scripts/check-license-info.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env zsh
+
 ##############################################################################
 # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.

--- a/scripts/format-source.sh
+++ b/scripts/format-source.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -7,8 +7,8 @@ then
 fi
 
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/scripts/license.txt
+++ b/scripts/license.txt
@@ -1,9 +1,3 @@
-##############################################################################
-# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
-# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
-#
-# SPDX-License-Identifier: BSD-3-Clause
-##############################################################################
 Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 

--- a/scripts/license.txt
+++ b/scripts/license.txt
@@ -1,10 +1,10 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################
-Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-project contributors. See the CHAI LICENSE file for details.
+Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 
 SPDX-License-Identifier: BSD-3-Clause

--- a/scripts/make_release_tarball.sh
+++ b/scripts/make_release_tarball.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/scripts/travis/build_and_test.sh
+++ b/scripts/travis/build_and_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/scripts/travis/install_llvm.sh
+++ b/scripts/travis/install_llvm.sh
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/scripts/update-copyright.sh
+++ b/scripts/update-copyright.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: (MIT)
 ##############################################################################

--- a/scripts/update-copyright.sh
+++ b/scripts/update-copyright.sh
@@ -38,7 +38,7 @@
 #=============================================================================
 # First find all the files we want to modify
 #=============================================================================
-grep -rl "See the CHAI LICENSE" . --exclude-dir=.git --exclude-dir=blt --exclude-dir=umpire --exclude-dir=raja --exclude-dir=radiuss-spack-configs --exclude-dir=uberenv --exclude=update-copyright.sh > files2change
+grep -rl "Copyright (c) [0-9]\{4\}-[0-9]\{2\}" . --exclude-dir=.git --exclude-dir=blt --exclude-dir=umpire --exclude-dir=raja --exclude-dir=radiuss-spack-configs --exclude-dir=uberenv --exclude=update-copyright.sh > files2change
 
 #=============================================================================
 # Replace the old copyright dates with new dates
@@ -47,7 +47,7 @@ for i in `cat files2change`
 do
     echo $i
     cp $i $i.sed.bak
-    sed "s/Copyright (c) \([0-9]\{4\}\)-[0-9]\{2\},/Copyright (c) 2016-26,/" $i.sed.bak > $i
+    sed "s/Copyright (c) \([0-9]\{4\}\)-[0-9]\{2\},/Copyright (c) 2016-27,/" $i.sed.bak > $i
 done
 
 #=============================================================================

--- a/scripts/update-copyright.sh
+++ b/scripts/update-copyright.sh
@@ -4,12 +4,12 @@
 # Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
-# SPDX-License-Identifier: (MIT)
+# SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################
 
 #=============================================================================
 # Change the copyright date in all files that contain the text
-# "the CHAI LICENSE file", which is part of the copyright statement at the
+# "See the CHAI LICENSE", which is part of the copyright statement at the
 # top of each CHAI file. We use this to distinguish CHAI files from ones
 # that we do not own (e.g., other repos included as submodules), which we
 # do not want to modify. Note that this file and *.git files are omitted
@@ -47,18 +47,18 @@ for i in `cat files2change`
 do
     echo $i
     cp $i $i.sed.bak
-    sed "s/Copyright (c) \([0-9]\{4\}\)-[0-9]\{2\},/Copyright (c) 2016-25,/" $i.sed.bak > $i
+    sed "s/Copyright (c) \([0-9]\{4\}\)-[0-9]\{2\},/Copyright (c) 2016-26,/" $i.sed.bak > $i
 done
 
 echo LICENSE
 cp LICENSE LICENSE.sed.bak
-sed "s/Copyright (c) \([0-9]\{4\}\)-[0-9]\{4\}/Copyright (c) 2016-25/" LICENSE.sed.bak > LICENSE
+sed "s/Copyright (c) \([0-9]\{4\}\)-[0-9]\{4\}/Copyright (c) 2016-26/" LICENSE.sed.bak > LICENSE
 
 for i in README.md CONTRIBUTING.md
 do 
     echo $i
     cp $i $i.sed.bak
-    sed "s/\([0-9]\{4\}\)-[0-9]\{2\}/2016-25/" $i.sed.bak > $i
+    sed "s/\([0-9]\{4\}\)-[0-9]\{2\}/2016-26/" $i.sed.bak > $i
 done
 
 #=============================================================================

--- a/scripts/update-copyright.sh
+++ b/scripts/update-copyright.sh
@@ -38,7 +38,7 @@
 #=============================================================================
 # First find all the files we want to modify
 #=============================================================================
-grep -rl "the CHAI LICENSE file" . --exclude-dir=.git --exclude-dir=blt --exclude-dir=umpire --exclude-dir=raja --exclude-dir=radiuss-spack-configs --exclude-dir=uberenv --exclude=update-copyright.sh > files2change
+grep -rl "See the CHAI LICENSE" . --exclude-dir=.git --exclude-dir=blt --exclude-dir=umpire --exclude-dir=raja --exclude-dir=radiuss-spack-configs --exclude-dir=uberenv --exclude=update-copyright.sh > files2change
 
 #=============================================================================
 # Replace the old copyright dates with new dates
@@ -48,17 +48,6 @@ do
     echo $i
     cp $i $i.sed.bak
     sed "s/Copyright (c) \([0-9]\{4\}\)-[0-9]\{2\},/Copyright (c) 2016-26,/" $i.sed.bak > $i
-done
-
-echo LICENSE
-cp LICENSE LICENSE.sed.bak
-sed "s/Copyright (c) \([0-9]\{4\}\)-[0-9]\{4\}/Copyright (c) 2016-26/" LICENSE.sed.bak > LICENSE
-
-for i in README.md CONTRIBUTING.md
-do 
-    echo $i
-    cp $i $i.sed.bak
-    sed "s/\([0-9]\{4\}\)-[0-9]\{2\}/2016-26/" $i.sed.bak > $i
 done
 
 #=============================================================================

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/src/chai/ArrayManager.cpp
+++ b/src/chai/ArrayManager.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/ArrayManager.hpp
+++ b/src/chai/ArrayManager.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/ArrayManager.inl
+++ b/src/chai/ArrayManager.inl
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/CMakeLists.txt
+++ b/src/chai/CMakeLists.txt
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/src/chai/ChaiMacros.hpp
+++ b/src/chai/ChaiMacros.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/DeviceHelpers.hpp
+++ b/src/chai/DeviceHelpers.hpp
@@ -1,3 +1,10 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//////////////////////////////////////////////////////////////////////////////
+
 #ifndef CHAI_DEVICE_HELPERS_HPP
 #define CHAI_DEVICE_HELPERS_HPP
 

--- a/src/chai/ExecutionSpaces.hpp
+++ b/src/chai/ExecutionSpaces.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/ManagedArrayView.hpp
+++ b/src/chai/ManagedArrayView.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/ManagedSharedPtr.hpp
+++ b/src/chai/ManagedSharedPtr.hpp
@@ -1,3 +1,10 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//////////////////////////////////////////////////////////////////////////////
+
 #ifndef CHAI_MANAGED_SHARED_PTR
 #define CHAI_MANAGED_SHARED_PTR
 

--- a/src/chai/PointerRecord.hpp
+++ b/src/chai/PointerRecord.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/RajaExecutionSpacePlugin.cpp
+++ b/src/chai/RajaExecutionSpacePlugin.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/RajaExecutionSpacePlugin.hpp
+++ b/src/chai/RajaExecutionSpacePlugin.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/SharedPointerRecord.hpp
+++ b/src/chai/SharedPointerRecord.hpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-24, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/src/chai/SharedPointerRecord.hpp
+++ b/src/chai/SharedPointerRecord.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-24, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/SharedPtrCounter.hpp
+++ b/src/chai/SharedPtrCounter.hpp
@@ -1,7 +1,7 @@
 
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-24, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/SharedPtrCounter.hpp
+++ b/src/chai/SharedPtrCounter.hpp
@@ -1,6 +1,6 @@
 
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-24, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/src/chai/SharedPtrManager.cpp
+++ b/src/chai/SharedPtrManager.cpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-24, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/src/chai/SharedPtrManager.cpp
+++ b/src/chai/SharedPtrManager.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-24, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/SharedPtrManager.hpp
+++ b/src/chai/SharedPtrManager.hpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-24, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/src/chai/SharedPtrManager.hpp
+++ b/src/chai/SharedPtrManager.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-24, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/SharedPtrManager.inl
+++ b/src/chai/SharedPtrManager.inl
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-24, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/src/chai/SharedPtrManager.inl
+++ b/src/chai/SharedPtrManager.inl
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-24, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/Types.hpp
+++ b/src/chai/Types.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/config.hpp.in
+++ b/src/chai/config.hpp.in
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/expt/Context.hpp
+++ b/src/chai/expt/Context.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/expt/Context.hpp
+++ b/src/chai/expt/Context.hpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/src/chai/expt/ContextGuard.hpp
+++ b/src/chai/expt/ContextGuard.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/expt/ContextGuard.hpp
+++ b/src/chai/expt/ContextGuard.hpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/src/chai/expt/ContextManager.hpp
+++ b/src/chai/expt/ContextManager.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/expt/ContextManager.hpp
+++ b/src/chai/expt/ContextManager.hpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/src/chai/expt/ContextRAJAPlugin.cpp
+++ b/src/chai/expt/ContextRAJAPlugin.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/expt/ContextRAJAPlugin.cpp
+++ b/src/chai/expt/ContextRAJAPlugin.cpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/src/chai/expt/ContextRAJAPlugin.hpp
+++ b/src/chai/expt/ContextRAJAPlugin.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/expt/ContextRAJAPlugin.hpp
+++ b/src/chai/expt/ContextRAJAPlugin.hpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/src/chai/expt/HostArrayManager.hpp
+++ b/src/chai/expt/HostArrayManager.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/expt/HostSharedPointer.hpp
+++ b/src/chai/expt/HostSharedPointer.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/expt/HostSharedPointer.hpp
+++ b/src/chai/expt/HostSharedPointer.hpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/src/chai/expt/ManagedArrayPointer.hpp
+++ b/src/chai/expt/ManagedArrayPointer.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/expt/ManagedArrayPointer.hpp
+++ b/src/chai/expt/ManagedArrayPointer.hpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/src/chai/expt/ManagedArraySharedPointer.hpp
+++ b/src/chai/expt/ManagedArraySharedPointer.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/expt/ManagedArraySharedPointer.hpp
+++ b/src/chai/expt/ManagedArraySharedPointer.hpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/src/chai/managed_array.hpp
+++ b/src/chai/managed_array.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/managed_ptr.hpp
+++ b/src/chai/managed_ptr.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/chai/pluginLinker.hpp
+++ b/src/chai/pluginLinker.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/src/util/forall.hpp
+++ b/src/util/forall.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/tests/expt/CMakeLists.txt
+++ b/tests/expt/CMakeLists.txt
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 # contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause

--- a/tests/expt/CMakeLists.txt
+++ b/tests/expt/CMakeLists.txt
@@ -1,6 +1,6 @@
 ##############################################################################
 # Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/tests/expt/ContextGuardTests.cpp
+++ b/tests/expt/ContextGuardTests.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/tests/expt/ContextGuardTests.cpp
+++ b/tests/expt/ContextGuardTests.cpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/tests/expt/ContextManagerTests.cpp
+++ b/tests/expt/ContextManagerTests.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/tests/expt/ContextManagerTests.cpp
+++ b/tests/expt/ContextManagerTests.cpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/tests/expt/ContextRAJAPluginTests.cpp
+++ b/tests/expt/ContextRAJAPluginTests.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/tests/expt/ContextRAJAPluginTests.cpp
+++ b/tests/expt/ContextRAJAPluginTests.cpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/tests/expt/HostArrayPointerTests.cpp
+++ b/tests/expt/HostArrayPointerTests.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/tests/expt/HostArrayPointerTests.cpp
+++ b/tests/expt/HostArrayPointerTests.cpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/tests/expt/HostArraySharedPointerTests.cpp
+++ b/tests/expt/HostArraySharedPointerTests.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/tests/expt/HostArraySharedPointerTests.cpp
+++ b/tests/expt/HostArraySharedPointerTests.cpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/tests/expt/ManagedArrayPointerTests.cpp
+++ b/tests/expt/ManagedArrayPointerTests.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/tests/expt/ManagedArrayPointerTests.cpp
+++ b/tests/expt/ManagedArrayPointerTests.cpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/tests/expt/TestHelpers.hpp
+++ b/tests/expt/TestHelpers.hpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/tests/expt/TestHelpers.hpp
+++ b/tests/expt/TestHelpers.hpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-26, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/tests/install/CMakeLists.txt
+++ b/tests/install/CMakeLists.txt
@@ -1,9 +1,9 @@
-###############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC
-# and CHAI contributors. See the CHAI LICENSE and COPYRIGHT files for details.
+##############################################################################
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
-# SPDX-License-Identifier: (BSD-3-Clause)
-###############################################################################
+# SPDX-License-Identifier: BSD-3-Clause
+##############################################################################
 
 configure_file(
      using-with-cmake/host-config.cmake.in

--- a/tests/install/CMakeLists.txt
+++ b/tests/install/CMakeLists.txt
@@ -1,6 +1,6 @@
 ###############################################################################
 # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC
-# and CHAI project contributors. See the CHAI LICENSE file for details.
+# and CHAI contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################

--- a/tests/install/using-with-cmake/CMakeLists.txt
+++ b/tests/install/using-with-cmake/CMakeLists.txt
@@ -1,6 +1,6 @@
 ###############################################################################
 # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC
-# and CHAI project contributors. See the CHAI LICENSE file for details.
+# and CHAI contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################

--- a/tests/install/using-with-cmake/CMakeLists.txt
+++ b/tests/install/using-with-cmake/CMakeLists.txt
@@ -1,9 +1,9 @@
-###############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC
-# and CHAI contributors. See the CHAI LICENSE and COPYRIGHT files for details.
+##############################################################################
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
-# SPDX-License-Identifier: (BSD-3-Clause)
-###############################################################################
+# SPDX-License-Identifier: BSD-3-Clause
+##############################################################################
 
 if (ENABLE_HIP)
   cmake_minimum_required(VERSION 3.23)

--- a/tests/install/using-with-cmake/host-config.cmake.in
+++ b/tests/install/using-with-cmake/host-config.cmake.in
@@ -1,9 +1,9 @@
-###############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC
-# and CHAI contributors. See the CHAI LICENSE and COPYRIGHT files for details.
+##############################################################################
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
-# SPDX-License-Identifier: (BSD-3-Clause)
-###############################################################################
+# SPDX-License-Identifier: BSD-3-Clause
+##############################################################################
 
 # Config related to compiler
 set(CMAKE_C_COMPILER       "@CMAKE_C_COMPILER@"       CACHE PATH "")

--- a/tests/install/using-with-cmake/host-config.cmake.in
+++ b/tests/install/using-with-cmake/host-config.cmake.in
@@ -1,6 +1,6 @@
 ###############################################################################
 # Copyright (c) 2016-25, Lawrence Livermore National Security, LLC
-# and CHAI project contributors. See the CHAI LICENSE file for details.
+# and CHAI contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################

--- a/tests/install/using-with-cmake/using-with-cmake.cpp
+++ b/tests/install/using-with-cmake/using-with-cmake.cpp
@@ -1,9 +1,9 @@
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC
-// and CHAI contributors. See the CHAI LICENSE and COPYRIGHT files for details.
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
-// SPDX-License-Identifier: (BSD-3-Clause)
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// SPDX-License-Identifier: BSD-3-Clause
+//////////////////////////////////////////////////////////////////////////////
 
 #include "chai/ManagedArray.hpp"
 #include <cstddef>

--- a/tests/install/using-with-cmake/using-with-cmake.cpp
+++ b/tests/install/using-with-cmake/using-with-cmake.cpp
@@ -1,6 +1,6 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 // Copyright (c) 2016-25, Lawrence Livermore National Security, LLC
-// and CHAI project contributors. See the CHAI LICENSE file for details.
+// and CHAI contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/tests/integration/managed_array_tests.cpp
+++ b/tests/integration/managed_array_tests.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/tests/integration/managed_ptr_tests.cpp
+++ b/tests/integration/managed_ptr_tests.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/tests/integration/managed_shared_ptr_tests.cpp
+++ b/tests/integration/managed_shared_ptr_tests.cpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-24, Lawrence Livermore National Security, LLC and CHAI
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
 // contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause

--- a/tests/integration/managed_shared_ptr_tests.cpp
+++ b/tests/integration/managed_shared_ptr_tests.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2016-24, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/tests/integration/raja-chai-launch.cpp
+++ b/tests/integration/raja-chai-launch.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/tests/integration/raja-chai-nested.cpp
+++ b/tests/integration/raja-chai-nested.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/tests/integration/raja-chai-tests.cpp
+++ b/tests/integration/raja-chai-tests.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,6 +1,6 @@
 ##############################################################################
-# Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-# project contributors. See the CHAI LICENSE file for details.
+# Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+# contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 ##############################################################################

--- a/tests/unit/array_manager_unit_tests.cpp
+++ b/tests/unit/array_manager_unit_tests.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/managed_array_unit_tests.cpp
+++ b/tests/unit/managed_array_unit_tests.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/managed_ptr_unit_tests.cpp
+++ b/tests/unit/managed_ptr_unit_tests.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2016-25, Lawrence Livermore National Security, LLC and CHAI
-// project contributors. See the CHAI LICENSE file for details.
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
 //
 // SPDX-License-Identifier: BSD-3-Clause
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Previously, every file contained the copyright year, which meant every file was updated every year. This is unnecessary and makes it very difficult to compare versions. The copyright year is contained in the top level LICENSE file, which is referenced in all other files.

* Updated COPYRIGHT, LICENSE, and README.md files
* Removed copyright years from files with SPDX-License-Identifier
* Added copyright info where missing
* Corrected some instances of wrong license creeping in
* Updated copyright/license scripts

Fixes https://github.com/llnl/CHAI/issues/358
