### PR TITLE
Update RSC (rocm toolchain, mpich, cce), spack and spack-packages

### DIFF
--- a/.gitlab/jobs/matrix.yml
+++ b/.gitlab/jobs/matrix.yml
@@ -17,7 +17,6 @@
 # project. We keep ${PROJECT_<MACHINE>_VARIANTS} and ${PROJECT_<MACHINE>_DEPS}
 # So that the comparison with the original job is easier.
 
-# No overridden jobs so far.
 clang_18_1_8_gcc_13_cuda_12_6_0:
   extends: .job_on_matrix
   variables:

--- a/.gitlab/jobs/matrix.yml
+++ b/.gitlab/jobs/matrix.yml
@@ -23,6 +23,12 @@ clang_18_1_8_gcc_13_cuda_12_6_0:
     SPEC: " ~shared +raja tests=basic +cuda cuda_arch=90 %clang-18-gcc-13 ^cuda@12.6.0+allow-unsupported-compilers ^raja~examples~exercises"
   allow_failure: true
 
+# CHAI does not support cuda 13 yet
+clang_19_1_3_gcc_13_cuda_13_1_1:
+  extends: .job_on_matrix
+  variables:
+    ON_MATRIX: "OFF"
+
 ############
 # Extra jobs
 ############

--- a/.gitlab/jobs/matrix.yml
+++ b/.gitlab/jobs/matrix.yml
@@ -23,12 +23,6 @@ clang_18_1_8_gcc_13_cuda_12_6_0:
     SPEC: " ~shared +raja tests=basic +cuda cuda_arch=90 %clang-18-gcc-13 ^cuda@12.6.0+allow-unsupported-compilers ^raja~examples~exercises"
   allow_failure: true
 
-# CHAI does not support cuda 13 yet
-clang_19_1_3_gcc_13_cuda_13_1_1:
-  extends: .job_on_matrix
-  variables:
-    ON_MATRIX: "OFF"
-
 ############
 # Extra jobs
 ############

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "v1.1.0",
+"spack_branch": "v1.1.1",
 "spack_configs_path": "scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/radiuss-spack-configs/spack_repo/llnl_radiuss/packages",
 "spack_setup_clingo": false


### PR DESCRIPTION
- [X] Update to rocm 6.4.3 and mpich 8.1.33, then with mpich 9.0.1
- [X] Update to spack 1.1.1 (concretizer perf improvements)
- [X] Update to cce 21
- [X] Add one job with rocm 7.2 and mpich 9.1, keep rocm 6.4.3 for most specs (production state).