### PR TITLE
Add experimental DualArrayManager

### DIFF
--- a/benchmarks/expt/CMakeLists.txt
+++ b/benchmarks/expt/CMakeLists.txt
@@ -23,6 +23,15 @@ endif ()
 
 if (CHAI_ENABLE_CUDA OR CHAI_ENABLE_HIP)
   blt_add_executable(
+    NAME DualArrayManagerBenchmarks
+    SOURCES DualArrayManagerBenchmarks.cpp
+    DEPENDS_ON ${chai_expt_benchmark_depends})
+
+  blt_add_benchmark(
+    NAME DualArrayManagerBenchmarks
+    COMMAND DualArrayManagerBenchmarks)
+
+  blt_add_executable(
     NAME UnifiedArrayManagerBenchmarks
     SOURCES UnifiedArrayManagerBenchmarks.cpp
     DEPENDS_ON ${chai_expt_benchmark_depends})

--- a/benchmarks/expt/DualArrayManagerBenchmarks.cpp
+++ b/benchmarks/expt/DualArrayManagerBenchmarks.cpp
@@ -24,7 +24,7 @@ namespace {
                                             Context call_context,
                                             bool call_touch)
   {
-    constexpr std::size_t size = 1;
+    const auto size = static_cast<std::size_t>(state.range(0));
 
     for (auto _ : state)
     {
@@ -50,6 +50,7 @@ namespace {
     }
 
     state.SetItemsProcessed(state.iterations());
+    state.SetBytesProcessed(state.iterations() * size * sizeof(int));
   }
 
   static void DualArrayManager_DefaultConstruct(benchmark::State& state)
@@ -91,6 +92,9 @@ namespace {
   }
 
   BENCHMARK(DualArrayManager_AfterHostRead_DataHostRead)
+    ->Arg(0)
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 20)
     ->Unit(benchmark::kNanosecond);
 
   static void DualArrayManager_AfterHostWrite_DataHostRead(benchmark::State& state)
@@ -103,6 +107,9 @@ namespace {
   }
 
   BENCHMARK(DualArrayManager_AfterHostWrite_DataHostRead)
+    ->Arg(0)
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 20)
     ->Unit(benchmark::kNanosecond);
 
   static void DualArrayManager_AfterHostRead_DataDeviceRead(benchmark::State& state)
@@ -115,6 +122,9 @@ namespace {
   }
 
   BENCHMARK(DualArrayManager_AfterHostRead_DataDeviceRead)
+    ->Arg(0)
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 20)
     ->Unit(benchmark::kNanosecond);
 
   static void DualArrayManager_AfterHostWrite_DataDeviceRead(benchmark::State& state)
@@ -127,6 +137,9 @@ namespace {
   }
 
   BENCHMARK(DualArrayManager_AfterHostWrite_DataDeviceRead)
+    ->Arg(0)
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 20)
     ->Unit(benchmark::kNanosecond);
 
   static void DualArrayManager_AfterDeviceRead_DataHostRead(benchmark::State& state)
@@ -139,6 +152,9 @@ namespace {
   }
 
   BENCHMARK(DualArrayManager_AfterDeviceRead_DataHostRead)
+    ->Arg(0)
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 20)
     ->Unit(benchmark::kNanosecond);
 
   static void DualArrayManager_AfterDeviceWrite_DataHostRead(benchmark::State& state)
@@ -151,6 +167,9 @@ namespace {
   }
 
   BENCHMARK(DualArrayManager_AfterDeviceWrite_DataHostRead)
+    ->Arg(0)
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 20)
     ->Unit(benchmark::kNanosecond);
 
   static void DualArrayManager_AfterDeviceRead_DataDeviceRead(benchmark::State& state)
@@ -163,6 +182,9 @@ namespace {
   }
 
   BENCHMARK(DualArrayManager_AfterDeviceRead_DataDeviceRead)
+    ->Arg(0)
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 20)
     ->Unit(benchmark::kNanosecond);
 
   static void DualArrayManager_AfterDeviceWrite_DataDeviceRead(benchmark::State& state)
@@ -175,6 +197,9 @@ namespace {
   }
 
   BENCHMARK(DualArrayManager_AfterDeviceWrite_DataDeviceRead)
+    ->Arg(0)
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 20)
     ->Unit(benchmark::kNanosecond);
 }  // namespace
 

--- a/benchmarks/expt/DualArrayManagerBenchmarks.cpp
+++ b/benchmarks/expt/DualArrayManagerBenchmarks.cpp
@@ -1,0 +1,181 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//////////////////////////////////////////////////////////////////////////////
+
+#include "benchmark/benchmark.h"
+
+#include <cstddef>
+
+#include "chai/expt/ContextGuard.hpp"
+#include "chai/expt/DualArrayManager.hpp"
+
+namespace {
+  using ::chai::expt::Context;
+  using ::chai::expt::ContextGuard;
+  using ::chai::expt::ContextManager;
+  using ::chai::expt::DualArrayManager;
+
+  static void DualArrayManager_DataSequence(benchmark::State& state,
+                                            Context initial_context,
+                                            bool initial_touch,
+                                            Context call_context,
+                                            bool call_touch)
+  {
+    constexpr std::size_t size = 1;
+
+    for (auto _ : state)
+    {
+      state.PauseTiming();
+
+      auto& contextManager = ContextManager::getInstance();
+      contextManager.reset();
+
+      DualArrayManager<int> manager{size};
+      {
+        ContextGuard guard{initial_context};
+        int* initial_data = manager.data(/*touch=*/initial_touch);
+        benchmark::DoNotOptimize(initial_data);
+      }
+
+      {
+        ContextGuard guard{call_context};
+        state.ResumeTiming();  // measure only the data() call
+        int* data = manager.data(/*touch=*/call_touch);
+        benchmark::DoNotOptimize(data);
+        state.PauseTiming();  // exclude guard destruction
+      }
+    }
+
+    state.SetItemsProcessed(state.iterations());
+  }
+
+  static void DualArrayManager_DefaultConstruct(benchmark::State& state)
+  {
+    for (auto _ : state)
+    {
+      DualArrayManager<int> manager{};
+      benchmark::DoNotOptimize(manager);
+    }
+  }
+
+  BENCHMARK(DualArrayManager_DefaultConstruct);
+
+  static void DualArrayManager_SizeConstruct(benchmark::State& state)
+  {
+    const auto size = static_cast<std::size_t>(state.range(0));
+
+    for (auto _ : state)
+    {
+      DualArrayManager<int> manager{size};
+      benchmark::DoNotOptimize(manager);
+    }
+
+    state.SetBytesProcessed(state.iterations() * size * sizeof(int));
+  }
+
+  BENCHMARK(DualArrayManager_SizeConstruct)
+    ->Arg(0)
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 20);
+
+  static void DualArrayManager_AfterHostRead_DataHostRead(benchmark::State& state)
+  {
+    DualArrayManager_DataSequence(state,
+                                  /*initial_context=*/Context::HOST,
+                                  /*initial_touch=*/false,
+                                  /*call_context=*/Context::HOST,
+                                  /*call_touch=*/false);
+  }
+
+  BENCHMARK(DualArrayManager_AfterHostRead_DataHostRead)
+    ->Unit(benchmark::kNanosecond);
+
+  static void DualArrayManager_AfterHostWrite_DataHostRead(benchmark::State& state)
+  {
+    DualArrayManager_DataSequence(state,
+                                  /*initial_context=*/Context::HOST,
+                                  /*initial_touch=*/true,
+                                  /*call_context=*/Context::HOST,
+                                  /*call_touch=*/false);
+  }
+
+  BENCHMARK(DualArrayManager_AfterHostWrite_DataHostRead)
+    ->Unit(benchmark::kNanosecond);
+
+  static void DualArrayManager_AfterHostRead_DataDeviceRead(benchmark::State& state)
+  {
+    DualArrayManager_DataSequence(state,
+                                  /*initial_context=*/Context::HOST,
+                                  /*initial_touch=*/false,
+                                  /*call_context=*/Context::DEVICE,
+                                  /*call_touch=*/false);
+  }
+
+  BENCHMARK(DualArrayManager_AfterHostRead_DataDeviceRead)
+    ->Unit(benchmark::kNanosecond);
+
+  static void DualArrayManager_AfterHostWrite_DataDeviceRead(benchmark::State& state)
+  {
+    DualArrayManager_DataSequence(state,
+                                  /*initial_context=*/Context::HOST,
+                                  /*initial_touch=*/true,
+                                  /*call_context=*/Context::DEVICE,
+                                  /*call_touch=*/false);
+  }
+
+  BENCHMARK(DualArrayManager_AfterHostWrite_DataDeviceRead)
+    ->Unit(benchmark::kNanosecond);
+
+  static void DualArrayManager_AfterDeviceRead_DataHostRead(benchmark::State& state)
+  {
+    DualArrayManager_DataSequence(state,
+                                  /*initial_context=*/Context::DEVICE,
+                                  /*initial_touch=*/false,
+                                  /*call_context=*/Context::HOST,
+                                  /*call_touch=*/false);
+  }
+
+  BENCHMARK(DualArrayManager_AfterDeviceRead_DataHostRead)
+    ->Unit(benchmark::kNanosecond);
+
+  static void DualArrayManager_AfterDeviceWrite_DataHostRead(benchmark::State& state)
+  {
+    DualArrayManager_DataSequence(state,
+                                  /*initial_context=*/Context::DEVICE,
+                                  /*initial_touch=*/true,
+                                  /*call_context=*/Context::HOST,
+                                  /*call_touch=*/false);
+  }
+
+  BENCHMARK(DualArrayManager_AfterDeviceWrite_DataHostRead)
+    ->Unit(benchmark::kNanosecond);
+
+  static void DualArrayManager_AfterDeviceRead_DataDeviceRead(benchmark::State& state)
+  {
+    DualArrayManager_DataSequence(state,
+                                  /*initial_context=*/Context::DEVICE,
+                                  /*initial_touch=*/false,
+                                  /*call_context=*/Context::DEVICE,
+                                  /*call_touch=*/false);
+  }
+
+  BENCHMARK(DualArrayManager_AfterDeviceRead_DataDeviceRead)
+    ->Unit(benchmark::kNanosecond);
+
+  static void DualArrayManager_AfterDeviceWrite_DataDeviceRead(benchmark::State& state)
+  {
+    DualArrayManager_DataSequence(state,
+                                  /*initial_context=*/Context::DEVICE,
+                                  /*initial_touch=*/true,
+                                  /*call_context=*/Context::DEVICE,
+                                  /*call_touch=*/false);
+  }
+
+  BENCHMARK(DualArrayManager_AfterDeviceWrite_DataDeviceRead)
+    ->Unit(benchmark::kNanosecond);
+}  // namespace
+
+BENCHMARK_MAIN();

--- a/benchmarks/expt/UnifiedArrayManagerBenchmarks.cpp
+++ b/benchmarks/expt/UnifiedArrayManagerBenchmarks.cpp
@@ -24,7 +24,7 @@ namespace {
                                                Context call_context,
                                                bool call_touch)
   {
-    constexpr std::size_t size = 1;
+    const auto size = static_cast<std::size_t>(state.range(0));
 
     for (auto _ : state)
     {
@@ -50,6 +50,7 @@ namespace {
     }
 
     state.SetItemsProcessed(state.iterations());
+    state.SetBytesProcessed(state.iterations() * size * sizeof(int));
   }
 
   static void UnifiedArrayManager_DefaultConstruct(benchmark::State& state)
@@ -91,6 +92,9 @@ namespace {
   }
 
   BENCHMARK(UnifiedArrayManager_AfterHostRead_DataHostRead)
+    ->Arg(0)
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 20)
     ->Unit(benchmark::kNanosecond);
 
   static void UnifiedArrayManager_AfterHostWrite_DataHostRead(benchmark::State& state)
@@ -103,6 +107,9 @@ namespace {
   }
 
   BENCHMARK(UnifiedArrayManager_AfterHostWrite_DataHostRead)
+    ->Arg(0)
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 20)
     ->Unit(benchmark::kNanosecond);
 
   static void UnifiedArrayManager_AfterHostRead_DataDeviceRead(benchmark::State& state)
@@ -115,6 +122,9 @@ namespace {
   }
 
   BENCHMARK(UnifiedArrayManager_AfterHostRead_DataDeviceRead)
+    ->Arg(0)
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 20)
     ->Unit(benchmark::kNanosecond);
 
   static void UnifiedArrayManager_AfterHostWrite_DataDeviceRead(benchmark::State& state)
@@ -127,6 +137,9 @@ namespace {
   }
 
   BENCHMARK(UnifiedArrayManager_AfterHostWrite_DataDeviceRead)
+    ->Arg(0)
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 20)
     ->Unit(benchmark::kNanosecond);
 
   static void UnifiedArrayManager_AfterDeviceRead_DataHostRead(benchmark::State& state)
@@ -139,6 +152,9 @@ namespace {
   }
 
   BENCHMARK(UnifiedArrayManager_AfterDeviceRead_DataHostRead)
+    ->Arg(0)
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 20)
     ->Unit(benchmark::kNanosecond);
 
   static void UnifiedArrayManager_AfterDeviceWrite_DataHostRead(benchmark::State& state)
@@ -151,6 +167,9 @@ namespace {
   }
 
   BENCHMARK(UnifiedArrayManager_AfterDeviceWrite_DataHostRead)
+    ->Arg(0)
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 20)
     ->Unit(benchmark::kNanosecond);
 
   static void UnifiedArrayManager_AfterDeviceRead_DataDeviceRead(benchmark::State& state)
@@ -163,6 +182,9 @@ namespace {
   }
 
   BENCHMARK(UnifiedArrayManager_AfterDeviceRead_DataDeviceRead)
+    ->Arg(0)
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 20)
     ->Unit(benchmark::kNanosecond);
 
   static void UnifiedArrayManager_AfterDeviceWrite_DataDeviceRead(benchmark::State& state)
@@ -175,6 +197,9 @@ namespace {
   }
 
   BENCHMARK(UnifiedArrayManager_AfterDeviceWrite_DataDeviceRead)
+    ->Arg(0)
+    ->RangeMultiplier(8)
+    ->Range(1, 1 << 20)
     ->Unit(benchmark::kNanosecond);
 }  // namespace
 

--- a/docs/sphinx/expt/design.rst
+++ b/docs/sphinx/expt/design.rst
@@ -295,7 +295,7 @@ byte-wise copies between them, it is intended for trivially copyable element
 types.
 
 This manager is useful when an application wants explicit mirrored allocations
-in host and device memory rather than Umpire unified memory.
+in host and device memory rather than unified memory.
 
 .. code-block:: cpp
 

--- a/docs/sphinx/expt/design.rst
+++ b/docs/sphinx/expt/design.rst
@@ -269,3 +269,61 @@ of each element on the host (numeric types are initialized to zero).
     // Read through p...
   }
 
+----------------
+DualArrayManager
+----------------
+
+``DualArrayManager`` manages separate host and device allocations and keeps them
+coherent explicitly. Unlike ``UnifiedArrayManager``, it does not rely on a
+single unified-memory pointer that is valid in both contexts. Instead, it
+allocates storage lazily in the requested context and copies data between the
+two allocations when the authoritative copy lives in the other context.
+
+``DualArrayManager`` relies on :ref:`ContextManager <experimental_design>` in
+the same way as ``UnifiedArrayManager``:
+
+- ``data(touch=false)`` returns a pointer suitable for read access in the
+  current context and synchronizes with the most recent modifying context when
+  needed.
+- ``data(touch=true)`` indicates the caller will modify the array in the current
+  context; it performs any required synchronization first, then records the
+  current context as authoritative.
+
+``DualArrayManager`` also performs value initialization of each element when a
+new allocation is created. Since it uses raw host/device allocations and
+byte-wise copies between them, it is intended for trivially copyable element
+types.
+
+This manager is useful when an application wants explicit mirrored allocations
+in host and device memory rather than Umpire unified memory.
+
+.. code-block:: cpp
+
+  #include "chai/expt/Context.hpp"
+  #include "chai/expt/ContextGuard.hpp"
+  #include "chai/expt/DualArrayManager.hpp"
+
+  const std::size_t N = 1000000;
+  ::chai::expt::DualArrayManager<int> a{N};
+
+  {
+    ::chai::expt::ContextGuard guard{::chai::expt::Context::HOST};
+    int* p = a.data(true);
+    for (std::size_t i = 0; i < N; ++i) {
+      p[i] = static_cast<int>(i);
+    }
+  }
+
+  {
+    ::chai::expt::ContextGuard guard{::chai::expt::Context::DEVICE};
+    int* p = a.data(true);
+    // If the most recent modification was on HOST, this call copies to DEVICE first.
+    // Launch a CUDA/HIP kernel that writes through p...
+  }
+
+  {
+    ::chai::expt::ContextGuard guard{::chai::expt::Context::HOST};
+    // If the most recent modification was on DEVICE, this call synchronizes and copies first.
+    const int* p = a.data(false);
+    // Read through p...
+  }

--- a/src/chai/CMakeLists.txt
+++ b/src/chai/CMakeLists.txt
@@ -38,6 +38,7 @@ if(CHAI_ENABLE_EXPERIMENTAL)
     expt/Context.hpp
     expt/ContextGuard.hpp
     expt/ContextManager.hpp
+    expt/DualArrayManager.hpp
     expt/HostArrayManager.hpp
     expt/HostSharedPointer.hpp
     expt/ManagedArrayPointer.hpp

--- a/src/chai/expt/DualArrayManager.hpp
+++ b/src/chai/expt/DualArrayManager.hpp
@@ -1,0 +1,511 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef CHAI_DUAL_ARRAY_MANAGER_HPP
+#define CHAI_DUAL_ARRAY_MANAGER_HPP
+
+#include "chai/expt/Context.hpp"
+#include "chai/expt/ContextManager.hpp"
+#include "umpire/Allocator.hpp"
+#include "umpire/ResourceManager.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+
+namespace chai::expt
+{
+  /*!
+   * \brief This class manages mirrored host/device arrays with explicit
+   *        synchronization between the two copies.
+   *
+   * \tparam ElementType The type of elements contained in this array.
+   *
+   * \note DualArrayManager uses raw host/device allocations and byte-wise copies
+   *       between them. As a result, ElementType must be trivially copyable,
+   *       default constructible, and trivially destructible.
+   */
+  template <typename ElementType>
+  class DualArrayManager {
+    static_assert(std::is_trivially_copyable_v<ElementType>,
+                  "DualArrayManager requires trivially copyable element types.");
+    static_assert(std::is_default_constructible_v<ElementType>,
+                  "DualArrayManager requires default-constructible element types.");
+    static_assert(std::is_trivially_destructible_v<ElementType>,
+                  "DualArrayManager requires trivially destructible element types.");
+
+    public:
+      /*!
+       * \brief Default-constructs a DualArrayManager with zero elements
+       *        and default host/device allocators.
+       */
+      DualArrayManager() = default;
+
+      /*!
+       * \brief Constructs a DualArrayManager with zero elements using the
+       *        provided host and device allocators.
+       *
+       * \param host_allocator Allocator used for host memory allocations.
+       * \param device_allocator Allocator used for device memory allocations.
+       */
+      DualArrayManager(const umpire::Allocator& host_allocator,
+                       const umpire::Allocator& device_allocator)
+        : m_host_allocator{host_allocator},
+          m_device_allocator{device_allocator}
+      {
+      }
+
+      /*!
+       * \brief Constructs a DualArrayManager with \p size elements using
+       *        default host/device allocators.
+       *
+       * \param size Number of elements to allocate when the data is first touched.
+       */
+      explicit DualArrayManager(std::size_t size)
+        : m_size{size}
+      {
+      }
+
+      /*!
+       * \brief Constructs a DualArrayManager with \p size elements using the
+       *        provided host and device allocators.
+       *
+       * \param size Number of elements to allocate when the data is first touched.
+       * \param host_allocator Allocator used for host memory allocations.
+       * \param device_allocator Allocator used for device memory allocations.
+       */
+      DualArrayManager(std::size_t size,
+                       const umpire::Allocator& host_allocator,
+                       const umpire::Allocator& device_allocator)
+        : m_size{size},
+          m_host_allocator{host_allocator},
+          m_device_allocator{device_allocator}
+      {
+      }
+
+      /*!
+       * \brief Copy-constructs a DualArrayManager, duplicating any allocated
+       *        host/device buffers.
+       *
+       * \param other Manager to copy from.
+       */
+      DualArrayManager(const DualArrayManager& other)
+        : m_size{other.m_size},
+          m_modified{other.m_modified},
+          m_host_allocator{other.m_host_allocator},
+          m_device_allocator{other.m_device_allocator}
+      {
+        clone(other);
+      }
+
+      /*!
+       * \brief Copy-assigns a DualArrayManager, duplicating any allocated
+       *        host/device buffers.
+       *
+       * \param other Manager to copy from.
+       *
+       * \return Reference to this manager.
+       */
+      DualArrayManager& operator=(const DualArrayManager& other)
+      {
+        if (&other != this)
+        {
+          clear();
+
+          m_size = other.m_size;
+          m_modified = other.m_modified;
+          m_host_allocator = other.m_host_allocator;
+          m_device_allocator = other.m_device_allocator;
+
+          clone(other);
+        }
+
+        return *this;
+      }
+
+      /*!
+       * \brief Move-constructs a DualArrayManager, transferring ownership of
+       *        any allocated host/device buffers.
+       *
+       * \param other Manager to move from.
+       */
+      DualArrayManager(DualArrayManager&& other)
+        : m_host_data{other.m_host_data},
+          m_device_data{other.m_device_data},
+          m_size{other.m_size},
+          m_modified{other.m_modified},
+          m_host_allocator{other.m_host_allocator},
+          m_device_allocator{other.m_device_allocator}
+      {
+        other.m_host_data = nullptr;
+        other.m_device_data = nullptr;
+        other.m_size = 0;
+        other.m_modified = Context::NONE;
+      }
+
+      /*!
+       * \brief Move-assigns a DualArrayManager, transferring ownership of any
+       *        allocated host/device buffers.
+       *
+       * \param other Manager to move from.
+       *
+       * \return Reference to this manager.
+       */
+      DualArrayManager& operator=(DualArrayManager&& other)
+      {
+        if (&other != this)
+        {
+          clear();
+
+          m_host_data = other.m_host_data;
+          m_device_data = other.m_device_data;
+          m_size = other.m_size;
+          m_modified = other.m_modified;
+          m_host_allocator = other.m_host_allocator;
+          m_device_allocator = other.m_device_allocator;
+
+          other.m_host_data = nullptr;
+          other.m_device_data = nullptr;
+          other.m_size = 0;
+          other.m_modified = Context::NONE;
+        }
+
+        return *this;
+      }
+
+      /*!
+       * \brief Destructor.
+       *
+       * Deallocates any host/device buffers owned by this manager.
+       */
+      ~DualArrayManager()
+      {
+        clear();
+      }
+
+      /*!
+       * \brief Resizes the managed allocation to \p new_size elements.
+       *
+       * Existing contents are preserved up to \c min(old_size, new_size). If
+       * storage has already been allocated, the resize happens in the most
+       * authoritative space and the opposite copy is discarded.
+       *
+       * \param new_size New number of elements.
+       */
+      void resize(std::size_t new_size)
+      {
+        if (new_size == m_size)
+        {
+          return;
+        }
+
+        if (new_size == 0)
+        {
+          clear();
+          return;
+        }
+
+        if (m_host_data == nullptr && m_device_data == nullptr)
+        {
+          m_size = new_size;
+          m_modified = Context::NONE;
+          return;
+        }
+
+        const Context resize_context = choose_resize_context();
+        const std::size_t old_size_bytes = m_size * sizeof(ElementType);
+        const std::size_t new_size_bytes = new_size * sizeof(ElementType);
+
+        ElementType*& data = pointer(resize_context);
+        umpire::Allocator& allocator = getAllocator(resize_context);
+
+        ElementType* new_data = static_cast<ElementType*>(allocator.allocate(new_size_bytes));
+        valueInitialize(new_data, new_size);
+        ::umpire::ResourceManager::getInstance().copy(
+            new_data,
+            data,
+            std::min(old_size_bytes, new_size_bytes));
+
+        deallocate(data, allocator);
+        data = new_data;
+
+        if (resize_context == Context::HOST)
+        {
+          deallocate(m_device_data, m_device_allocator);
+        }
+        else
+        {
+          deallocate(m_host_data, m_host_allocator);
+        }
+
+        m_size = new_size;
+        m_modified = resize_context;
+      }
+
+      /*!
+       * \brief Returns the number of elements currently managed.
+       *
+       * \return Number of managed elements.
+       */
+      std::size_t size() const
+      {
+        return m_size;
+      }
+
+      /*!
+       * \brief Returns a pointer to the managed data in the current context.
+       *
+       * \param touch Whether the caller intends to modify the returned data.
+       *
+       * \return Pointer to the managed data, or nullptr if the current context
+       *         is Context::NONE or the array is empty.
+       */
+      ElementType* data(bool touch)
+      {
+        return data(ContextManager::getInstance().getContext(), touch);
+      }
+
+    private:
+      /*!
+       * \brief Pointer to data in the HOST context.
+       */
+      ElementType* m_host_data{nullptr};
+
+      /*!
+       * \brief Pointer to data in the DEVICE context.
+       */
+      ElementType* m_device_data{nullptr};
+
+      /*!
+       * \brief Number of elements currently managed.
+       */
+      std::size_t m_size{0};
+
+      /*!
+       * \brief Context that holds the most recently modified copy.
+       */
+      Context m_modified{Context::NONE};
+
+      /*!
+       * \brief Allocator used for host memory allocations.
+       */
+      umpire::Allocator m_host_allocator{::umpire::ResourceManager::getInstance().getAllocator("HOST")};
+
+      /*!
+       * \brief Allocator used for device memory allocations.
+       */
+      umpire::Allocator m_device_allocator{
+#if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
+        ::umpire::ResourceManager::getInstance().getAllocator("DEVICE")
+#else
+        ::umpire::ResourceManager::getInstance().getAllocator("HOST")
+#endif
+      };
+
+      /*!
+       * \brief Deep-copies any allocated buffers from \p other.
+       *
+       * \param other Manager to copy from.
+       */
+      void clone(const DualArrayManager& other)
+      {
+        const std::size_t size_bytes = other.m_size * sizeof(ElementType);
+
+        if (size_bytes == 0)
+        {
+          return;
+        }
+
+        ContextManager::getInstance().synchronize(other.m_modified);
+
+        if (other.m_host_data != nullptr)
+        {
+          m_host_data = static_cast<ElementType*>(m_host_allocator.allocate(size_bytes));
+          ::umpire::ResourceManager::getInstance().copy(m_host_data, other.m_host_data, size_bytes);
+        }
+
+        if (other.m_device_data != nullptr)
+        {
+          m_device_data = static_cast<ElementType*>(m_device_allocator.allocate(size_bytes));
+          ::umpire::ResourceManager::getInstance().copy(m_device_data, other.m_device_data, size_bytes);
+        }
+      }
+
+      /*!
+       * \brief Releases both host and device storage and resets the state.
+       */
+      void clear()
+      {
+        deallocate(m_host_data, m_host_allocator);
+        deallocate(m_device_data, m_device_allocator);
+        m_size = 0;
+        m_modified = Context::NONE;
+      }
+
+      /*!
+       * \brief Deallocates \p data when it is non-null.
+       *
+       * \param data Pointer to deallocate.
+       * \param allocator Allocator that owns \p data.
+       */
+      static void deallocate(ElementType*& data, umpire::Allocator& allocator)
+      {
+        if (data != nullptr)
+        {
+          allocator.deallocate(data);
+          data = nullptr;
+        }
+      }
+
+      /*!
+       * \brief Returns the allocator for \p context.
+       *
+       * \param context Desired context.
+       *
+       * \return Allocator for \p context.
+       */
+      umpire::Allocator& getAllocator(Context context)
+      {
+        return context == Context::DEVICE ? m_device_allocator : m_host_allocator;
+      }
+
+      /*!
+       * \brief Returns the storage pointer for \p context.
+       *
+       * \param context Desired context.
+       *
+       * \return Pointer reference for \p context.
+       */
+      ElementType*& pointer(Context context)
+      {
+        return context == Context::DEVICE ? m_device_data : m_host_data;
+      }
+
+      /*!
+       * \brief Returns the storage pointer for \p context.
+       *
+       * \param context Desired context.
+       *
+       * \return Pointer for \p context.
+       */
+      ElementType* pointer(Context context) const
+      {
+        return context == Context::DEVICE ? m_device_data : m_host_data;
+      }
+
+      /*!
+       * \brief Returns the opposite context for \p context.
+       *
+       * \param context Context whose opposite is requested.
+       *
+       * \return HOST for DEVICE, DEVICE for HOST.
+       */
+      static Context otherContext(Context context)
+      {
+        return context == Context::DEVICE ? Context::HOST : Context::DEVICE;
+      }
+
+      /*!
+       * \brief Chooses the context whose allocation should be preserved during
+       *        resize.
+       *
+       * \return Context to resize in.
+       */
+      Context choose_resize_context() const
+      {
+        if (m_modified != Context::NONE)
+        {
+          return m_modified;
+        }
+
+        if (m_host_data != nullptr && m_device_data == nullptr)
+        {
+          return Context::HOST;
+        }
+
+        if (m_device_data != nullptr && m_host_data == nullptr)
+        {
+          return Context::DEVICE;
+        }
+
+        return ContextManager::getInstance().getContext() == Context::DEVICE
+            ? Context::DEVICE
+            : Context::HOST;
+      }
+
+      /*!
+       * \brief Fills \p destination with value-initialized elements by staging
+       *        from a temporary host buffer.
+       *
+       * \param destination Allocation to initialize.
+       * \param count Number of elements to initialize.
+       */
+      static void valueInitialize(ElementType* destination, std::size_t count)
+      {
+        if (destination == nullptr || count == 0)
+        {
+          return;
+        }
+
+        std::unique_ptr<ElementType[]> initialized{new ElementType[count]()};
+        ::umpire::ResourceManager::getInstance().copy(
+            destination,
+            initialized.get(),
+            count * sizeof(ElementType));
+      }
+
+      /*!
+       * \brief Returns a pointer to the managed data in \p context, allocating
+       *        and synchronizing as needed.
+       *
+       * \param context Desired context.
+       * \param touch Whether the caller intends to modify the returned data.
+       *
+       * \return Pointer to data in \p context, or nullptr if \p context is
+       *         Context::NONE or the array is empty.
+       */
+      ElementType* data(Context context, bool touch = true)
+      {
+        if (context == Context::NONE || m_size == 0)
+        {
+          return nullptr;
+        }
+
+        ElementType*& destination = pointer(context);
+        ElementType* source = pointer(otherContext(context));
+        const bool destination_was_missing = destination == nullptr;
+        const std::size_t size_bytes = m_size * sizeof(ElementType);
+
+        if (destination_was_missing)
+        {
+          destination = static_cast<ElementType*>(getAllocator(context).allocate(size_bytes));
+          valueInitialize(destination, m_size);
+        }
+
+        if (source != nullptr &&
+            (destination_was_missing || m_modified == otherContext(context)))
+        {
+          ContextManager::getInstance().synchronize(m_modified);
+          ::umpire::ResourceManager::getInstance().copy(destination, source, size_bytes);
+        }
+
+        if (touch)
+        {
+          m_modified = context;
+        }
+        else
+        {
+          m_modified = Context::NONE;
+        }
+
+        return destination;
+      }
+  };  // class DualArrayManager
+}  // namespace chai::expt
+
+#endif  // CHAI_DUAL_ARRAY_MANAGER_HPP

--- a/tests/expt/CMakeLists.txt
+++ b/tests/expt/CMakeLists.txt
@@ -94,6 +94,17 @@ blt_add_test(
 
 if(ENABLE_CUDA OR ENABLE_HIP)
   blt_add_executable(
+    NAME DualArrayManagerTests
+    SOURCES DualArrayManagerTests.cpp
+    HEADERS ${chai_expt_test_headers}
+    INCLUDES ${PROJECT_BINARY_DIR}/include
+    DEPENDS_ON ${chai_expt_test_depends})
+
+  blt_add_test(
+    NAME DualArrayManagerTests
+    COMMAND DualArrayManagerTests)
+
+  blt_add_executable(
     NAME UnifiedArrayManagerTests
     SOURCES UnifiedArrayManagerTests.cpp
     HEADERS ${chai_expt_test_headers}

--- a/tests/expt/DualArrayManagerTests.cpp
+++ b/tests/expt/DualArrayManagerTests.cpp
@@ -1,0 +1,574 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) Lawrence Livermore National Security, LLC and other CHAI
+// contributors. See the CHAI LICENSE and COPYRIGHT files for details.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//////////////////////////////////////////////////////////////////////////////
+
+#include "chai/config.hpp"
+#include "chai/expt/Context.hpp"
+#include "chai/expt/ContextGuard.hpp"
+#include "chai/expt/ContextManager.hpp"
+#include "chai/expt/DualArrayManager.hpp"
+#include "camp/helpers.hpp"
+#include "gtest/gtest.h"
+
+#include <cstddef>
+
+#if defined(CHAI_ENABLE_CUDA)
+#include <cuda_runtime.h>
+#endif
+
+#if defined(CHAI_ENABLE_HIP)
+#include <hip/hip_runtime.h>
+#endif
+
+namespace {
+  using ::chai::expt::Context;
+  using ::chai::expt::ContextGuard;
+  using ::chai::expt::ContextManager;
+  using ::chai::expt::DualArrayManager;
+
+  template <typename T>
+  T* malloc_managed(std::size_t count)
+  {
+    T* ptr = nullptr;
+
+#if defined(CHAI_ENABLE_CUDA)
+    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaMallocManaged, (void**)&ptr, sizeof(T) * count);
+#elif defined(CHAI_ENABLE_HIP)
+    CAMP_HIP_API_INVOKE_AND_CHECK(hipMallocManaged, (void**)&ptr, sizeof(T) * count);
+#else
+    static_cast<void>(count);
+#endif
+
+    return ptr;
+  }
+
+  inline void free_managed(void* ptr)
+  {
+#if defined(CHAI_ENABLE_CUDA)
+    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaFree, ptr);
+#elif defined(CHAI_ENABLE_HIP)
+    CAMP_HIP_API_INVOKE_AND_CHECK(hipFree, ptr);
+#else
+    static_cast<void>(ptr);
+#endif
+  }
+
+#if defined(CHAI_ENABLE_CUDA) || defined(CHAI_ENABLE_HIP)
+  __global__ void increment_kernel(int* data, std::size_t size)
+  {
+    const std::size_t i = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i < size)
+    {
+      data[i] += 1;
+    }
+  }
+
+  __global__ void copy_kernel(const int* in, int* out, std::size_t size)
+  {
+    const std::size_t i = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (i < size)
+    {
+      out[i] = in[i];
+    }
+  }
+
+  inline void device_synchronize_raw()
+  {
+#if defined(CHAI_ENABLE_CUDA)
+    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaDeviceSynchronize);
+#elif defined(CHAI_ENABLE_HIP)
+    CAMP_HIP_API_INVOKE_AND_CHECK(hipDeviceSynchronize);
+#endif
+  }
+
+  inline void launch_increment(int* data, std::size_t size)
+  {
+    constexpr int BLOCK_SIZE = 256;
+    const int grid_size = static_cast<int>((size + BLOCK_SIZE - 1) / BLOCK_SIZE);
+
+#if defined(CHAI_ENABLE_CUDA)
+    increment_kernel<<<grid_size, BLOCK_SIZE>>>(data, size);
+    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaGetLastError);
+#elif defined(CHAI_ENABLE_HIP)
+    hipLaunchKernelGGL(increment_kernel,
+                       dim3(grid_size),
+                       dim3(BLOCK_SIZE),
+                       0,
+                       0,
+                       data,
+                       size);
+    CAMP_HIP_API_INVOKE_AND_CHECK(hipGetLastError);
+#endif
+  }
+
+  inline void launch_copy(const int* in, int* out, std::size_t size)
+  {
+    constexpr int BLOCK_SIZE = 256;
+    const int grid_size = static_cast<int>((size + BLOCK_SIZE - 1) / BLOCK_SIZE);
+
+#if defined(CHAI_ENABLE_CUDA)
+    copy_kernel<<<grid_size, BLOCK_SIZE>>>(in, out, size);
+    CAMP_CUDA_API_INVOKE_AND_CHECK(cudaGetLastError);
+#elif defined(CHAI_ENABLE_HIP)
+    hipLaunchKernelGGL(copy_kernel,
+                       dim3(grid_size),
+                       dim3(BLOCK_SIZE),
+                       0,
+                       0,
+                       in,
+                       out,
+                       size);
+    CAMP_HIP_API_INVOKE_AND_CHECK(hipGetLastError);
+#endif
+  }
+#endif
+
+  class DualArrayManagerTest : public ::testing::Test
+  {
+    protected:
+      void SetUp() override
+      {
+        ContextManager::getInstance().reset();
+      }
+
+      void TearDown() override
+      {
+        ContextManager::getInstance().reset();
+      }
+  };
+}  // namespace
+
+TEST_F(DualArrayManagerTest, DefaultConstructor)
+{
+  DualArrayManager<int> manager{};
+  EXPECT_EQ(manager.size(), 0);
+
+  {
+    ContextGuard guard{Context::HOST};
+    EXPECT_EQ(manager.data(false), nullptr);
+    EXPECT_EQ(manager.data(true), nullptr);
+  }
+}
+
+TEST_F(DualArrayManagerTest, AllocatorConstructor)
+{
+  constexpr std::size_t N = 32;
+  auto& rm = ::umpire::ResourceManager::getInstance();
+  umpire::Allocator host_allocator = rm.getAllocator("HOST");
+  umpire::Allocator device_allocator = rm.getAllocator("DEVICE");
+
+  DualArrayManager<int> manager{N, host_allocator, device_allocator};
+  EXPECT_EQ(manager.size(), N);
+
+  {
+    ContextGuard guard{Context::HOST};
+    int* data = manager.data(true);
+    ASSERT_NE(data, nullptr);
+    for (std::size_t i = 0; i < N; ++i)
+    {
+      EXPECT_EQ(data[i], 0);
+      data[i] = static_cast<int>(i * 2);
+    }
+  }
+
+  {
+    ContextGuard guard{Context::HOST};
+    int* data = manager.data(false);
+    ASSERT_NE(data, nullptr);
+    for (std::size_t i = 0; i < N; ++i)
+    {
+      EXPECT_EQ(data[i], static_cast<int>(i * 2));
+    }
+  }
+}
+
+TEST_F(DualArrayManagerTest, ResizeToZero)
+{
+  DualArrayManager<int> manager{10};
+  EXPECT_EQ(manager.size(), 10);
+
+  {
+    ContextGuard guard{Context::HOST};
+    EXPECT_NE(manager.data(false), nullptr);
+  }
+
+  manager.resize(0);
+  EXPECT_EQ(manager.size(), 0);
+
+  {
+    ContextGuard guard{Context::HOST};
+    EXPECT_EQ(manager.data(false), nullptr);
+    EXPECT_EQ(manager.data(true), nullptr);
+  }
+}
+
+TEST_F(DualArrayManagerTest, ResizeSmaller)
+{
+  constexpr std::size_t N0 = 16;
+  constexpr std::size_t N1 = 6;
+
+  DualArrayManager<int> manager{N0};
+
+  {
+    ContextGuard guard{Context::HOST};
+    int* data = manager.data(true);
+    ASSERT_NE(data, nullptr);
+    for (std::size_t i = 0; i < N0; ++i)
+    {
+      data[i] = static_cast<int>(i);
+    }
+  }
+
+  manager.resize(N1);
+  EXPECT_EQ(manager.size(), N1);
+
+  {
+    ContextGuard guard{Context::HOST};
+    int* data = manager.data(false);
+    ASSERT_NE(data, nullptr);
+    for (std::size_t i = 0; i < N1; ++i)
+    {
+      EXPECT_EQ(data[i], static_cast<int>(i));
+    }
+  }
+}
+
+TEST_F(DualArrayManagerTest, ResizeLarger)
+{
+  constexpr std::size_t N0 = 8;
+  constexpr std::size_t N1 = 16;
+
+  DualArrayManager<int> manager{N0};
+
+  {
+    ContextGuard guard{Context::HOST};
+    int* data = manager.data(true);
+    ASSERT_NE(data, nullptr);
+    for (std::size_t i = 0; i < N0; ++i)
+    {
+      data[i] = static_cast<int>(i + 10);
+    }
+  }
+
+  manager.resize(N1);
+  EXPECT_EQ(manager.size(), N1);
+
+  {
+    ContextGuard guard{Context::HOST};
+    int* data = manager.data(false);
+    ASSERT_NE(data, nullptr);
+
+    for (std::size_t i = 0; i < N0; ++i)
+    {
+      EXPECT_EQ(data[i], static_cast<int>(i + 10));
+    }
+
+    for (std::size_t i = N0; i < N1; ++i)
+    {
+      EXPECT_EQ(data[i], 0);
+    }
+  }
+}
+
+TEST_F(DualArrayManagerTest, HostReadThenHostRead)
+{
+  // Set up
+  constexpr std::size_t N = 128;
+  DualArrayManager<int> manager{N};
+
+  // Host read
+  {
+    ContextGuard guard{Context::HOST};
+    const int* data = manager.data(false);
+    ASSERT_NE(data, nullptr);
+
+    for (std::size_t i = 0; i < N; ++i)
+    {
+      EXPECT_EQ(data[i], 0);
+    }
+  }
+
+  // Host read
+  {
+    ContextGuard guard{Context::HOST};
+    const int* data = manager.data(false);
+    ASSERT_NE(data, nullptr);
+
+    for (std::size_t i = 0; i < N; ++i)
+    {
+      EXPECT_EQ(data[i], 0);
+    }
+  }
+}
+
+TEST_F(DualArrayManagerTest, HostWriteThenHostRead)
+{
+  // Set up
+  constexpr std::size_t N = 128;
+  DualArrayManager<int> manager{N};
+
+  // Host write
+  {
+    ContextGuard guard{Context::HOST};
+    int* data = manager.data(true);
+    ASSERT_NE(data, nullptr);
+
+    for (std::size_t i = 0; i < N; ++i)
+    {
+      data[i] = static_cast<int>(i);
+    }
+  }
+
+  // Host read
+  {
+    ContextGuard guard{Context::HOST};
+    const int* data = manager.data(false);
+    ASSERT_NE(data, nullptr);
+
+    for (std::size_t i = 0; i < N; ++i)
+    {
+      EXPECT_EQ(data[i], static_cast<int>(i));
+    }
+  }
+}
+
+TEST_F(DualArrayManagerTest, HostReadThenDeviceRead)
+{
+  // Set up
+  constexpr std::size_t N = 256;
+  DualArrayManager<int> manager{N};
+
+  // Host read
+  {
+    ContextGuard guard{Context::HOST};
+    const int* data = manager.data(false);
+    ASSERT_NE(data, nullptr);
+
+    for (std::size_t i = 0; i < N; ++i)
+    {
+      EXPECT_EQ(data[i], 0);
+    }
+  }
+
+  // Set up
+  int* out = malloc_managed<int>(N);
+  ASSERT_NE(out, nullptr);
+
+  // Device read
+  {
+    ContextGuard guard{Context::DEVICE};
+    const int* data = manager.data(false);
+    ASSERT_NE(data, nullptr);
+    launch_copy(data, out, N);
+  }
+
+  // Synchronize
+  device_synchronize_raw();
+
+  // Check result
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    EXPECT_EQ(out[i], 0);
+  }
+
+  // Clean up
+  free_managed(out);
+}
+
+TEST_F(DualArrayManagerTest, HostWriteThenDeviceRead)
+{
+  // Set up
+  constexpr std::size_t N = 256;
+  DualArrayManager<int> manager{N};
+
+  // Host write
+  {
+    ContextGuard guard{Context::HOST};
+    int* data = manager.data(true);
+    ASSERT_NE(data, nullptr);
+
+    for (std::size_t i = 0; i < N; ++i)
+    {
+      data[i] = static_cast<int>(i);
+    }
+  }
+
+  // Set up
+  int* out = malloc_managed<int>(N);
+  ASSERT_NE(out, nullptr);
+
+  // Device read
+  {
+    ContextGuard guard{Context::DEVICE};
+    const int* data = manager.data(false);
+    ASSERT_NE(data, nullptr);
+    launch_copy(data, out, N);
+  }
+
+  // Synchronize
+  device_synchronize_raw();
+
+  // Check result
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    EXPECT_EQ(out[i], static_cast<int>(i));
+  }
+
+  // Clean up
+  free_managed(out);
+}
+
+TEST_F(DualArrayManagerTest, DeviceReadThenHostRead)
+{
+  // Set up
+  constexpr std::size_t N = 256;
+  DualArrayManager<int> manager{N};
+
+  int* out = malloc_managed<int>(N);
+  ASSERT_NE(out, nullptr);
+
+  // Device read
+  {
+    ContextGuard guard{Context::DEVICE};
+    const int* data = manager.data(false);
+    ASSERT_NE(data, nullptr);
+    launch_copy(data, out, N);
+  }
+
+  // Host read
+  {
+    ContextGuard guard{Context::HOST};
+    const int* data = manager.data(false);
+    ASSERT_NE(data, nullptr);
+
+    for (std::size_t i = 0; i < N; ++i)
+    {
+      EXPECT_EQ(data[i], 0);
+    }
+  }
+
+  // Synchronize
+  // Note: The host read should have caused a synchronize, but the following
+  //       checks should independent of whether than part works.
+  device_synchronize_raw();
+
+  // Checks
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    EXPECT_EQ(out[i], 0);
+  }
+
+  // Clean up
+  free_managed(out);
+}
+
+TEST_F(DualArrayManagerTest, DeviceWriteThenHostRead)
+{
+  // Set up
+  constexpr std::size_t N = 256;
+  DualArrayManager<int> manager{N};
+
+  // Device write
+  {
+    ContextGuard guard{Context::DEVICE};
+    int* data = manager.data(true);
+    ASSERT_NE(data, nullptr);
+    launch_increment(data, N);
+  }
+
+  // Host read
+  {
+    ContextGuard guard{Context::HOST};
+    const int* data = manager.data(false);
+    ASSERT_NE(data, nullptr);
+
+    for (std::size_t i = 0; i < N; ++i)
+    {
+      EXPECT_EQ(data[i], 1);
+    }
+  }
+}
+
+TEST_F(DualArrayManagerTest, DeviceReadThenDeviceRead)
+{
+  // Set up
+  constexpr std::size_t N = 256;
+  DualArrayManager<int> manager{N};
+
+  int* out0 = malloc_managed<int>(N);
+  int* out1 = malloc_managed<int>(N);
+  ASSERT_NE(out0, nullptr);
+  ASSERT_NE(out1, nullptr);
+
+  // Device read
+  {
+    ContextGuard guard{Context::DEVICE};
+    const int* data = manager.data(false);
+    ASSERT_NE(data, nullptr);
+    launch_copy(data, out0, N);
+  }
+
+  // Device read
+  {
+    ContextGuard guard{Context::DEVICE};
+    const int* data = manager.data(false);
+    ASSERT_NE(data, nullptr);
+    launch_copy(data, out1, N);
+  }
+
+  // Synchronize
+  device_synchronize_raw();
+
+  // Checks
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    EXPECT_EQ(out0[i], 0);
+    EXPECT_EQ(out1[i], 0);
+  }
+
+  // Clean up
+  free_managed(out0);
+  free_managed(out1);
+}
+
+TEST_F(DualArrayManagerTest, DeviceWriteThenDeviceRead)
+{
+  // Set up
+  constexpr std::size_t N = 256;
+  DualArrayManager<int> manager{N};
+
+  // Device write
+  {
+    ContextGuard guard{Context::DEVICE};
+    int* data = manager.data(true);
+    ASSERT_NE(data, nullptr);
+    launch_increment(data, N);
+  }
+
+  // Set up
+  int* out = malloc_managed<int>(N);
+  ASSERT_NE(out, nullptr);
+
+  // Device read
+  {
+    ContextGuard guard{Context::DEVICE};
+    const int* data = manager.data(false);
+    ASSERT_NE(data, nullptr);
+    launch_copy(data, out, N);
+  }
+
+  // Synchronize
+  device_synchronize_raw();
+
+  // Checks
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    EXPECT_EQ(out[i], 1);
+  }
+
+  // Clean up
+  free_managed(out);
+}


### PR DESCRIPTION
``DualArrayManager`` manages separate host and device allocations and keeps them
coherent explicitly. Unlike ``UnifiedArrayManager``, it does not rely on a
single unified-memory pointer that is valid in both contexts. Instead, it
allocates storage lazily in the requested context and copies data between the
two allocations when the authoritative copy lives in the other context.