### PR TITLE
Cross project pipelines : A PR in Umpire can trigger CHAI CI for testing

### DIFF
--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -116,12 +116,12 @@ then
     if [[ -n ${raja_version} ]]
     then
         extra_variants="${extra_variants} +raja"
-        extra_deps="${extra_deps} ^raja@${raja_version}"
+        extra_deps="${extra_deps} ^raja@git.${raja_version}=develop"
     fi
 
     if [[ -n ${umpire_version} ]]
     then
-        extra_deps="${extra_deps} ^umpire@${umpire_version}"
+        extra_deps="${extra_deps} ^umpire@git.${umpire_version}=develop"
     fi
 
     [[ -n ${extra_variants} ]] && spec="${spec} ${extra_variants}"


### PR DESCRIPTION

Assume custom specs are specified with a commit sha.
Instruct spack to treat custom deps version as develop (otherwise spack would error because no other sha than develop is equivalent to develop).

Relates to https://github.com/llnl/Umpire/pull/882