### PR TITLE
Enable multi project: add manual trigger for CARE CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -237,4 +237,4 @@ trigger-care:
     UPDATE_CHAI: ${CI_COMMIT_SHA}
   trigger:
     project: radiuss/multi-project/care-trigger
-    branch: woptim/multi-project-ci
+    branch: develop

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -223,15 +223,18 @@ tuolumne-build-and-test:
       - artifact: 'tuolumne-jobs.yml'
         job: 'generate-job-lists'
 
-
-## If testing develop branch, trigger RAJA downstream tests with this version of CHAI.
-# trigger-raja:
-#   stage: multi-project
-#   rules:
-#     - if: '$CI_COMMIT_BRANCH == "develop" || $MULTI_PROJECT == "ON"'
-#   variables:
-#     UPDATE_CHAI: develop
-#   trigger:
-#     project: radiuss/raja
-#     branch: develop
-#     strategy: depend
+# MULTI-PROJECT PIPELINE
+trigger-care:
+  stage: multi-project
+  rules:
+    - if: $MULTI_PROJECT != "OFF"
+      when: manual
+    - when: never
+  allow_failure: true
+  inherit:
+    variables: false
+  variables:
+    UPDATE_CHAI: ${CI_COMMIT_SHA}
+  trigger:
+    project: radiuss/multi-project/care-trigger
+    branch: woptim/multi-project-ci


### PR DESCRIPTION
This PR adds a manual job to every GitLab CI pipeline in CHAI.
Running the job will test the associated commit in CARE CI.
Passing CARE CI is not required and even running the job is optional.

TODO:
- [x] Merge https://github.com/llnl/CARE/pull/371
- [x] Trigger CARE CI on develop branch