### PR TITLE
Prevent unwanted implicit conversions to ManagedArray

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,7 +12,12 @@ in this file.
 
 The format of this file is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-## [Version 2025.12.0] = Release date 2025-12-22
+## [Unreleased] - Release date yyyy-mm-dd
+
+### Changed
+- Made a ManagedArray constructor explicit to prevent unwanted implicit conversions. 
+
+## [Version 2025.12.0] - Release date 2025-12-22
 
 ### Fixed
 - Fixed compiler error related to using a lambda as a default function argument.

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -98,7 +98,9 @@ public:
    * \param elems Number of elements in the array.
    * \param space Execution space in which to allocate the array.
    */
-  CHAI_HOST_DEVICE ManagedArray(size_t elems, ExecutionSpace space = get_default_space());
+  CHAI_HOST_DEVICE explicit ManagedArray(
+      size_t elems,
+      ExecutionSpace space = get_default_space());
 
   ManagedArray(
       size_t elems,


### PR DESCRIPTION
Before, code like the following could compile but was very misleading:

```
chai::ManagedArray<int> a = 5;
```

Code will have to be changed to the following:

```
chai::ManagedArray<int> a = chai::ManagedArray<int>(5);
```

Or:

```
chai::ManagedArray<int> a(5);
```