### PR TITLE
Fix overload ambiguity errors

### DIFF
--- a/.gitlab/jobs/corona.yml
+++ b/.gitlab/jobs/corona.yml
@@ -17,6 +17,12 @@
 # project. We keep ${PROJECT_<MACHINE>_VARIANTS} and ${PROJECT_<MACHINE>_DEPS}
 # So that the comparison with the original job is easier.
 
+# Due to a compiler bug, ROCm 5.7.1 with C++20 is failing.
+rocmcc_5_7_1_hip:
+  extends: .job_on_corona
+  variables:
+    ON_CORONA: "OFF"
+
 ############
 # Extra jobs
 ############

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -15,6 +15,7 @@
 
 #include "umpire/Allocator.hpp"
 
+#include <concepts>
 #include <cstddef>
 
 namespace chai
@@ -135,8 +136,17 @@ public:
 
   /*!
    * \brief Construct a ManagedArray from a nullptr.
+   *
+   * \note The constraint prevents overload ambiguity between this constructor
+   *       and the size_t constructor when constructing with the literal 0.
+   *       Additionally, the constraint is a workaround for a nvcc bug where
+   *       overload resolution can incorrectly report an ambiguity between this
+   *       constructor and the size_t constructor, for example when constructing
+   *       from a const int within a function template.
+   *
+   * \todo Consider removing this constructor.
    */
-  CHAI_HOST_DEVICE ManagedArray(std::nullptr_t other);
+  CHAI_HOST_DEVICE ManagedArray(std::same_as<std::nullptr_t> auto) : ManagedArray() {}
 
   CHAI_HOST ManagedArray(PointerRecord* record, ExecutionSpace space);
 

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -137,11 +137,12 @@ public:
   /*!
    * \brief Construct a ManagedArray from a nullptr.
    *
-   * \note The constraint prevents overload ambiguity between this constructor
-   *       and the size_t constructor when constructing with the literal 0.
-   *       Additionally, the constraint is a workaround for a nvcc bug where
-   *       overload resolution can incorrectly report an ambiguity between this
-   *       constructor and the size_t constructor.
+   * \note The constraint prevents overload ambiguity between this
+   *       constructor and the size_t constructor when constructing
+   *       with the integer literal 0. Additionally, the constraint
+   *       is a workaround for a nvcc bug where overload resolution
+   *       can incorrectly report an ambiguity between this constructor
+   *       and the size_t constructor.
    *
    * \todo Consider removing this constructor.
    */

--- a/src/chai/ManagedArray.hpp
+++ b/src/chai/ManagedArray.hpp
@@ -141,8 +141,7 @@ public:
    *       and the size_t constructor when constructing with the literal 0.
    *       Additionally, the constraint is a workaround for a nvcc bug where
    *       overload resolution can incorrectly report an ambiguity between this
-   *       constructor and the size_t constructor, for example when constructing
-   *       from a const int within a function template.
+   *       constructor and the size_t constructor.
    *
    * \todo Consider removing this constructor.
    */

--- a/src/chai/ManagedArray.inl
+++ b/src/chai/ManagedArray.inl
@@ -76,13 +76,6 @@ ManagedArray<T>::ManagedArray(
 
 template<typename T>
 CHAI_INLINE
-CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(std::nullptr_t) :
-  ManagedArray()
-{
-}
-
-template<typename T>
-CHAI_INLINE
 CHAI_HOST ManagedArray<T>::ManagedArray(PointerRecord* record, ExecutionSpace space):
   m_active_pointer(static_cast<T*>(record->m_pointers[space])),
   m_active_base_pointer(static_cast<T*>(record->m_pointers[space])),

--- a/src/chai/ManagedArray_thin.inl
+++ b/src/chai/ManagedArray_thin.inl
@@ -69,21 +69,6 @@ CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(size_t elems, ExecutionSpace spac
 #endif
 }
 
-
-template <typename T>
-CHAI_INLINE CHAI_HOST_DEVICE ManagedArray<T>::ManagedArray(std::nullptr_t)
-    : m_active_pointer(nullptr),
-      m_active_base_pointer(nullptr),
-      m_resource_manager(nullptr),
-      m_size(0),
-      m_offset(0),
-      m_pointer_record(nullptr),
-      m_allocator_id(-1),
-      m_is_slice(false)
-{
-}
-
-
 template<typename T>
 CHAI_INLINE
 CHAI_HOST ManagedArray<T>::ManagedArray(PointerRecord* record, ExecutionSpace space):


### PR DESCRIPTION
`chai::ManagedArray` had two constructors that sometimes led to compilation errors due to ambiguous overload resolution.

```
CHAI_HOST_DEVICE ManagedArray(std::nullptr_t>) : ManagedArray() {}

CHAI_HOST_DEVICE explicit ManagedArray(
      size_t elems,
      ExecutionSpace space = get_default_space());
```

Compilation would fail when constructing a `ManagedArray` from the integer literal `0` because the compiler can't decide which overload to pick. Additionally, nvcc erroneously reports ambiguity when constructing from an int in certain cases.

Using a constraint resolves the ambiguity in both of those situations. The nullptr constructor will now only accept `nullptr` or a variable of type `std::nullptr_t`. The size_t constructor will get all the rest, including `0`.